### PR TITLE
Fix git-hooks Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,12 @@ can use:
 ```console
 $ taplo format file.toml
 ```
+
+### Temporarily Ignoring Pre-Commit Checks
+
+When committing incomplete or work-in-progress changes, the pre-commit
+checks can become annoying. In this case, use:
+
+```console
+$ git commit --no-verify
+```

--- a/flake.lock
+++ b/flake.lock
@@ -92,7 +92,9 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1742649964,
@@ -131,22 +133,6 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730768919,
-        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
         "lastModified": 1743938762,
         "narHash": "sha256-UgFYn8sGv9B8PoFpUfCa43CjMZBl1x/ShQhRDHBFQdI=",
         "owner": "NixOS",
@@ -168,7 +154,7 @@
         "fenix": "fenix",
         "flake-utils": "flake-utils",
         "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "systems": "systems"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
     };
 
     git-hooks.url = "github:cachix/git-hooks.nix";
-    git-hooks.inputs.systems.follows = "systems";
+    git-hooks.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = { self, nixpkgs, crane, fenix, flake-utils, advisory-db, git-hooks, ... }:


### PR DESCRIPTION
#6 had a small copy'n'paste error in the Flake inputs. While I was here, I also added the handy `git commit --no-verify` to the README.