### PR TITLE
Add Smoke Test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        inherit (pkgs) lib;
+        inherit (nixpkgs) lib;
 
         craneLib = crane.mkLib pkgs;
         src = craneLib.cleanCargoSource ./.;
@@ -58,6 +58,10 @@
         # artifacts from above.
         usbvfiod = craneLib.buildPackage (commonArgs // {
           inherit cargoArtifacts;
+
+          meta = {
+            mainProgram = "usbvfiod";
+          };
         });
       in
       {
@@ -122,7 +126,10 @@
             partitionType = "count";
             cargoNextestPartitionsExtraArgs = "--no-tests=pass";
           });
-        };
+        } // (import ./nix/tests.nix {
+          inherit lib pkgs;
+          usbvfiod = self.packages.${system}.default;
+        });
 
         packages = {
           default = usbvfiod;

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -1,0 +1,96 @@
+# This file contains integration tests for usbvfiod.
+{ lib, pkgs, usbvfiod }:
+let
+  # For the VM that we start in Cloud Hypervisor, we re-use the netboot image.
+  netbootNixos = lib.nixosSystem {
+    inherit (pkgs) system;
+
+    modules = [
+      "${pkgs.path}/nixos/modules/installer/netboot/netboot-minimal.nix"
+
+      # Cloud Hypervisor Guest Convenience
+      ({ config, ... }: {
+
+        boot.kernelParams = [
+          # Use the serial console for kernel output.
+          #
+          # The virtio-console is an option as well, but is not
+          # compiled into the NixOS kernel and would be inconvenient.
+          "console=ttyS0"
+        ];
+
+        # Enable debug verbosity.
+        boot.consoleLogLevel = 7;
+
+        # Silence the useless stateVersion warning. We have no state to keep.
+        system.stateVersion = config.system.nixos.release;
+      })
+    ];
+  };
+
+  netboot =
+    let
+      inherit (netbootNixos) config;
+
+      kernelTarget = pkgs.stdenv.hostPlatform.linux-kernel.target;
+    in
+    {
+      initrd = "${config.system.build.netbootRamdisk}/initrd";
+      kernel = "${config.system.build.kernel}/${kernelTarget}";
+      cmdline = "init=${config.system.build.toplevel}/init "
+        + builtins.toString config.boot.kernelParams;
+    };
+
+  # Putting the socket in a world-readable location is obviously not a
+  # good choice for a production setup, but for this test it works
+  # well.
+  usbvfiodSocket = "/tmp/usbvfio";
+  cloudHypervisorLog = "/tmp/chv.log";
+in
+{
+  integration-smoke = pkgs.nixosTest {
+    name = "usbvfiod Smoke Test";
+
+    nodes.machine = { pkgs, ... }: {
+      systemd.services.usbvfiod = {
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          ExecStart = ''
+            ${lib.getExe usbvfiod} -v --socket-path ${usbvfiodSocket}
+          '';
+        };
+      };
+
+      systemd.services.cloud-hypervisor = {
+        wantedBy = [ "multi-user.target" ];
+        requires = [ "usbvfiod.service" ];
+        after = [ "usbvfiod.service" ];
+
+        serviceConfig = {
+          ExecStart = ''
+            ${lib.getExe pkgs.cloud-hypervisor} --memory size=2G,shared=on --console off --serial file=${cloudHypervisorLog} \
+              --kernel ${netboot.kernel} \
+              --cmdline ${lib.escapeShellArg netboot.cmdline} \
+              --initramfs ${netboot.initrd} \
+              --user-device socket=${usbvfiodSocket}
+          '';
+        };
+      };
+
+      virtualisation = {
+        cores = 2;
+        memorySize = 4096;
+      };
+    };
+
+    testScript = ''
+      start_all()
+
+      machine.wait_for_unit("cloud-hypervisor.service")
+
+      # Check whether the USB controller pops up.
+      machine.wait_until_succeeds("grep -Fq 'pci 0000:00:02.0: [1b36:000d]' ${cloudHypervisorLog}")
+    '';
+  };
+}


### PR DESCRIPTION
Add a simple smoke test that checks whether the USB controller pops up in the VMs PCI config space.

 As the xhci driver currently hangs for quite a long time, we only
check whether the kernel sees it during boot up. This makes the test succeed in a couple of seconds. If we wait for VM userspace to come up, this currently takes more than a minute.

We can refactor the test later when the xhci driver attaches cleanly.

@xanderio The Github CI currently needs 80 seconds to run the NixOS integration test. Should I set up a Hercules CI runner?