### PR TITLE
DMA Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ name = "usbvfiod"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "clap",
  "libc",
  "memmap2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +640,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "libc",
+ "memmap2",
  "proptest",
  "tracing",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = { version = "1.0.97", default-features = false, features = ["std"] }
+arc-swap = "1.7.1"
 clap = { version = "4.5.35", features = [
   "cargo",
   "color",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.5.35", features = [
   "std",
   "usage",
 ], default-features = false }
+memmap2 = "0.9.5"
 tracing = { version = "0.1.41", default-features = false, features = [
   "log",
   "std",
@@ -41,3 +42,4 @@ vfio_user = { git = "https://github.com/rust-vmm/vfio-user.git", rev = "208dbb0d
 
 [dev-dependencies]
 proptest = "1.6.0"
+libc = "0.2.172"

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -6,7 +6,7 @@
 use std::sync::Mutex;
 
 use crate::device::{
-    bus::{Request, SingleThreadedBusDevice},
+    bus::{BusDeviceRef, Request, SingleThreadedBusDevice},
     pci::{
         config_space::{ConfigSpace, ConfigSpaceBuilder},
         traits::{PciDevice, RequestKind},
@@ -16,22 +16,25 @@ use crate::device::{
 /// The emulation of a XHCI controller.
 #[derive(Debug, Clone)]
 pub struct XhciController {
-    config_space: ConfigSpace,
-}
+    /// A reference to the VM memory to perform DMA on.
+    #[allow(unused)]
+    dma_bus: BusDeviceRef,
 
-impl Default for XhciController {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// The PCI Configuration Space of the controller.
+    config_space: ConfigSpace,
 }
 
 impl XhciController {
     /// Create a new XHCI controller with default settings.
+    ///
+    /// `dma_bus` is the device on which we will perform DMA
+    /// operations. This is typically VM guest memory.
     #[must_use]
-    pub fn new() -> Self {
+    pub fn new(dma_bus: BusDeviceRef) -> Self {
         use crate::device::pci::constants::config_space::*;
 
         Self {
+            dma_bus,
             config_space: ConfigSpaceBuilder::new(vendor::REDHAT, device::REDHAT_XHCI)
                 .class(class::SERIAL, subclass::SERIAL_USB, progif::USB_XHCI)
                 // TODO Should be a 64-bit BAR.

--- a/src/dynamic_bus.rs
+++ b/src/dynamic_bus.rs
@@ -1,0 +1,100 @@
+use std::sync::{Arc, Mutex};
+
+use arc_swap::ArcSwap;
+use usbvfiod::device::bus::{AddBusDeviceError, Bus, BusDevice, BusDeviceRef, Request};
+
+#[derive(Debug)]
+struct DeviceEntry {
+    start_addr: u64,
+    device: BusDeviceRef,
+}
+
+#[derive(Default, Debug)]
+pub struct DynamicBus {
+    segments: Mutex<Vec<DeviceEntry>>,
+    bus: Arc<ArcSwap<Bus>>,
+}
+
+impl DynamicBus {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn add(&self, start_addr: u64, device: BusDeviceRef) -> Result<(), AddBusDeviceError> {
+        let mut new_bus = Bus::new("DMA bus", u64::MAX);
+        let mut segments = self.segments.lock().unwrap();
+
+        segments.push(DeviceEntry { start_addr, device });
+
+        for segment in segments.iter() {
+            new_bus.add(segment.start_addr, segment.device.clone())?;
+        }
+
+        // It's okay to use store here, because we only have a single
+        // writer (serialized by the mutex).
+        self.bus.store(Arc::new(new_bus));
+
+        Ok(())
+    }
+}
+
+impl BusDevice for DynamicBus {
+    fn size(&self) -> u64 {
+        self.bus.load().size()
+    }
+
+    fn read(&self, req: Request) -> u64 {
+        self.bus.load().read(req)
+    }
+
+    fn write(&self, req: Request, value: u64) {
+        self.bus.load().write(req, value)
+    }
+
+    fn read_bulk(&self, offset: u64, data: &mut [u8]) {
+        self.bus.load().read_bulk(offset, data)
+    }
+
+    fn write_bulk(&self, offset: u64, data: &[u8]) {
+        self.bus.load().write_bulk(offset, data)
+    }
+
+    fn compare_exchange_request(&self, req: Request, current: u64, new: u64) -> Result<u64, u64> {
+        self.bus.load().compare_exchange_request(req, current, new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use usbvfiod::device::bus::RequestSize;
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct TestDevice {}
+
+    impl BusDevice for TestDevice {
+        fn size(&self) -> u64 {
+            0x1000
+        }
+
+        fn read(&self, _req: Request) -> u64 {
+            42
+        }
+
+        fn write(&self, _req: Request, _value: u64) {
+            // Ignore
+        }
+    }
+
+    #[test]
+    fn can_add_devices() {
+        let bus = DynamicBus::default();
+        let device1 = Arc::new(TestDevice::default());
+
+        assert_eq!(bus.read(Request::new(0x1000, RequestSize::Size1)), 0xFF);
+
+        bus.add(0x1000, device1).unwrap();
+        assert_eq!(bus.read(Request::new(0x1000, RequestSize::Size1)), 42);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod dynamic_bus;
 mod memory_segment;
 mod xhci_backend;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod memory_segment;
 mod xhci_backend;
 
 use anyhow::{Context, Result};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod cli;
 mod xhci_backend;
 
-pub(crate) use anyhow::{Context, Result};
+use anyhow::{Context, Result};
 use clap::Parser;
 use cli::Cli;
 use tracing::{info, Level};

--- a/src/memory_segment.rs
+++ b/src/memory_segment.rs
@@ -63,8 +63,9 @@ pub struct MemorySegment {
 impl MemorySegment {
     /// Creates a memory segment from a file.
     ///
-    /// The file is only used for mapping and will not be read or
-    /// written to.
+    /// The `File` object is only used for memory-mapping and will not
+    /// be read or written to. We only access the underlying file via
+    /// the memory mapping.
     pub fn new_from_fd(
         fd: &File,
         file_offset: u64,

--- a/src/memory_segment.rs
+++ b/src/memory_segment.rs
@@ -1,0 +1,256 @@
+//! Provide a [`BusDevice`] abstraction over a piece of a mmap'able
+//! file.
+
+use std::{
+    fs::File,
+    sync::{
+        atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, Ordering},
+        Arc,
+    },
+};
+
+use memmap2::{Mmap, MmapMut, MmapOptions};
+use usbvfiod::device::bus::{BusDevice, Request, RequestSize};
+use vfio_user::DmaMapFlags;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessRights {
+    ReadOnly,
+    ReadWrite,
+}
+
+impl TryFrom<DmaMapFlags> for AccessRights {
+    type Error = ();
+
+    fn try_from(value: DmaMapFlags) -> Result<Self, Self::Error> {
+        match value {
+            DmaMapFlags::READ_ONLY => Ok(AccessRights::ReadOnly),
+            DmaMapFlags::READ_WRITE => Ok(AccessRights::ReadWrite),
+            unsupported => todo!("unsupported DmaMapFlags {unsupported:?}"),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Mapping {
+    ReadOnly(Mmap),
+    ReadWrite(MmapMut),
+}
+
+impl Mapping {
+    fn as_ptr(&self) -> *const u8 {
+        match self {
+            Mapping::ReadOnly(map) => map.as_ptr(),
+            Mapping::ReadWrite(map) => map.as_ptr(),
+        }
+    }
+
+    fn is_writable(&self) -> bool {
+        match self {
+            Mapping::ReadWrite(_) => true,
+            Mapping::ReadOnly(_) => false,
+        }
+    }
+}
+
+/// A contiguous piece of mmap'ed memory.
+#[derive(Debug, Clone)]
+pub struct MemorySegment {
+    size: u64,
+    mapping: Arc<Mapping>,
+}
+
+impl MemorySegment {
+    /// Creates a memory segment from a file.
+    ///
+    /// The file is only used for mapping and will not be read or
+    /// written to.
+    pub fn new_from_fd(
+        fd: &File,
+        file_offset: u64,
+        size: u64,
+        access_rights: AccessRights,
+    ) -> Result<Self, std::io::Error> {
+        Ok(MemorySegment {
+            size,
+            mapping: Arc::new({
+                let mut mmap = MmapOptions::new();
+
+                mmap.len(size.try_into().unwrap());
+                mmap.offset(file_offset);
+
+                match access_rights {
+                    // SAFETY: We only access mmap'ed memory via atomics, so the warnings
+                    // around UB in the Mmap and MmapMut documentation do not apply.
+                    AccessRights::ReadOnly => unsafe { Mapping::ReadOnly(mmap.map(fd)?) },
+
+                    // SAFETY: See above.
+                    AccessRights::ReadWrite => unsafe { Mapping::ReadWrite(mmap.map_mut(fd)?) },
+                }
+            }),
+        })
+    }
+}
+
+impl BusDevice for MemorySegment {
+    fn size(&self) -> u64 {
+        self.size
+    }
+
+    fn read(&self, req: Request) -> u64 {
+        assert!(req.addr.checked_add(req.size.into()).unwrap() <= self.size);
+
+        // SAFETY: We check whether the request fits into the memory region above.
+        let ptr = unsafe { self.mapping.as_ptr().add(req.addr.try_into().unwrap()) };
+
+        match req.size {
+            RequestSize::Size1 => {
+                // SAFETY:
+                //
+                // We make sure all accesses to the memory happen via
+                // atomics, because the pointer never escapes from
+                // MemorySegment. We also ensure above that the
+                // pointer points to valid memory.
+                let atomic = unsafe { &*(ptr as *const AtomicU8) };
+
+                atomic.load(Ordering::Relaxed).into()
+            }
+            RequestSize::Size2 => {
+                // SAFETY: See above.
+                let atomic = unsafe { &*(ptr as *const AtomicU16) };
+
+                atomic.load(Ordering::Relaxed).into()
+            }
+            RequestSize::Size4 => {
+                // SAFETY: See above.
+                let atomic = unsafe { &*(ptr as *const AtomicU32) };
+
+                atomic.load(Ordering::Relaxed).into()
+            }
+            RequestSize::Size8 => {
+                // SAFETY: See above.
+                let atomic = unsafe { &*(ptr as *const AtomicU64) };
+
+                atomic.load(Ordering::Relaxed)
+            }
+        }
+    }
+
+    fn write(&self, req: Request, value: u64) {
+        assert!(req.addr.checked_add(req.size.into()).unwrap() <= self.size);
+
+        if !self.mapping.is_writable() {
+            return;
+        }
+
+        // SAFETY: We check whether the request fits into the memory region above.
+        let ptr = unsafe { self.mapping.as_ptr().add(req.addr.try_into().unwrap()) };
+
+        match req.size {
+            RequestSize::Size1 => {
+                // SAFETY:
+                //
+                // We make sure all accesses to the memory happen via
+                // atomics, because the pointer never escapes from
+                // MemorySegment. We also ensure above that the
+                // pointer points to valid memory.
+                let atomic = unsafe { &*(ptr as *const AtomicU8) };
+
+                atomic.store(value as u8, Ordering::Relaxed);
+            }
+            RequestSize::Size2 => {
+                // SAFETY: See above.
+                let atomic = unsafe { &*(ptr as *const AtomicU16) };
+
+                atomic.store(value as u16, Ordering::Relaxed);
+            }
+            RequestSize::Size4 => {
+                // SAFETY: See above.
+                let atomic = unsafe { &*(ptr as *const AtomicU32) };
+
+                atomic.store(value as u32, Ordering::Relaxed);
+            }
+            RequestSize::Size8 => {
+                // SAFETY: See above.
+                let atomic = unsafe { &*(ptr as *const AtomicU64) };
+
+                atomic.store(value, Ordering::Relaxed)
+            }
+        }
+    }
+
+    // TODO Implement read_bulk/write_bulk for efficiency.
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        ffi::CString,
+        io::{Read, Seek},
+        os::fd::FromRawFd,
+    };
+
+    use super::*;
+
+    fn create_memfd(size: u64) -> Result<File, std::io::Error> {
+        let fd = unsafe { libc::memfd_create(CString::new("unittest").unwrap().as_ptr(), 0) };
+
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        // SAFETY: fd is a valid file descriptor, because we created it above.
+        let file = unsafe { File::from_raw_fd(fd) };
+        file.set_len(size)?;
+
+        Ok(file)
+    }
+
+    #[test]
+    fn can_read_write() -> Result<(), std::io::Error> {
+        let memfd = create_memfd(0x1000)?;
+        let mseg = MemorySegment::new_from_fd(&memfd, 0, 0x1000, AccessRights::ReadWrite)?;
+
+        assert_eq!(mseg.read(Request::new(0, RequestSize::Size8)), 0);
+
+        mseg.write(Request::new(0, RequestSize::Size8), 0xcafed00dfeedface);
+        assert_eq!(
+            mseg.read(Request::new(0, RequestSize::Size8)),
+            0xcafed00dfeedface
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn cant_write_to_read_only() -> Result<(), std::io::Error> {
+        let memfd = create_memfd(0x1000)?;
+        let mseg = MemorySegment::new_from_fd(&memfd, 0, 0x1000, AccessRights::ReadOnly)?;
+
+        mseg.write(Request::new(0, RequestSize::Size8), 0xcafed00dfeedface);
+        assert_eq!(mseg.read(Request::new(0, RequestSize::Size8)), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn file_offset_is_respected() -> Result<(), std::io::Error> {
+        let mut memfd = create_memfd(0x2000)?;
+        let mseg = MemorySegment::new_from_fd(&memfd, 0x1000, 0x1000, AccessRights::ReadWrite)?;
+
+        let data = 0xcafed00dfeedface_u64.to_le_bytes();
+
+        mseg.write(
+            Request::new(0x10, RequestSize::Size8),
+            u64::from_le_bytes(data),
+        );
+
+        let mut check_data = [0; 8];
+        memfd.seek(std::io::SeekFrom::Start(0x1010))?;
+        memfd.read_exact(&mut check_data)?;
+
+        assert_eq!(data, check_data);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR works towards the infrastructure for the virtual XHCI controller to be able to access guest memory. For this we introduce:

- `MemorySegment`: a wrapper around a mmap-ed memory
- `DynamicBus`: a wrapper around `Bus` that allows modifying the bus

We assemble `MemorySegments` into a bus and then hand this to the XHCI controller as target for DMA.

I would cleanup the structure of the crate a bit next. We have the Particle device emulation code in the `usbvfiod` library and the other components just as modules in the binary. This is a bit awkward now. But I didn't want to shuffle this around in this PR as well. :)

## TODO

- [x] Finish implementation of `MemorySegment` (and add tests)
- [x] Add `SAFETY` comments for any unsafe code.
- [x] Create a `Bus` of all memory regions we get from `dma_map` (using `MemorySegment`)
- [x] Wire everything up to be used from the XHCI backend