### PR TITLE
Start handling MMIO Region access

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -22,6 +22,9 @@ let
         # Enable debug verbosity.
         boot.consoleLogLevel = 7;
 
+        # Convenience packages for interactive use
+        environment.systemPackages = [ pkgs.pciutils pkgs.usbutils ];
+
         # Silence the useless stateVersion warning. We have no state to keep.
         system.stateVersion = config.system.nixos.release;
       })

--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -201,3 +201,45 @@ pub mod config_space {
         }
     }
 }
+
+/// Constants related to the XHCI MMIO space.
+pub mod xhci {
+
+    /// Value for the operational base as returned for reading CAPLENGTH.
+    pub const OP_BASE: u64 = 0x68;
+    /// Runtime register base offset.
+    pub const RUN_BASE: u64 = 0x3000;
+
+    /// Offsets of various fields from the start of the XHCI MMIO region.
+    pub mod offset {
+        /// Capability Register Offsets
+        pub const CAPLENGTH: u64 = 0x0;
+        pub const HCIVERSION: u64 = 0x2;
+        pub const HCSPARAMS1: u64 = 0x4;
+        pub const HCSPARAMS2: u64 = 0x8;
+        pub const HCSPARAMS3: u64 = 0xc;
+        pub const HCCPARAMS1: u64 = 0x10;
+        pub const DBOFF: u64 = 0x14;
+        pub const RTSOFF: u64 = 0x18;
+        pub const HCCPARAMS2: u64 = 0x1c;
+
+        /// Operational Register Offsets
+        pub const USBCMD: u64 = super::OP_BASE;
+        pub const USBSTS: u64 = super::OP_BASE + 0x4;
+        pub const PAGESIZE: u64 = super::OP_BASE + 0x8;
+        pub const CONFIG: u64 = super::OP_BASE + 0x38;
+
+        /// Runtime Register Offsets
+        pub const IMAN: u64 = super::RUN_BASE;
+        pub const IMOD: u64 = super::RUN_BASE + 0x4;
+        pub const ERSTSZ: u64 = super::RUN_BASE + 0x8;
+        pub const ERSTBA: u64 = super::RUN_BASE + 0x10;
+        pub const ERDB: u64 = super::RUN_BASE + 0x18;
+    }
+
+    /// Constants for the capability register.
+    pub mod capability {}
+
+    /// Constants for the operational registers.
+    pub mod operational {}
+}

--- a/src/device/pci/traits.rs
+++ b/src/device/pci/traits.rs
@@ -54,34 +54,21 @@ pub trait PciDevice: Debug {
 
     /// Write a value to an I/O region.
     ///
-    /// The device may or may not claim the request. If the request is claimed, this function
-    /// returns `Some(())` otherwise `None`.
-    ///
-    /// A device that only claims requests via standard BARs can use
-    /// [`try_match_bar`](super::config_space::ConfigSpace::try_match_bar) to implement this function.
-    ///
     /// # Parameters
     ///
-    /// - `kind`: Specifies the type of request.
+    /// - `region`: Identifies the targeted I/O region (BAR).
     /// - `req`: The offset and size of the request. Offsets are relative to the beginning of each
     ///          I/O region.
     /// - `value`: The value to be written.
-    #[must_use]
-    fn try_io_write(&self, kind: RequestKind, req: Request, value: u64) -> Option<()>;
+    fn write_io(&self, region: u32, req: Request, value: u64);
 
     /// Read a value from an I/O region.
     ///
-    /// The device may or may not claim the request. If the request is claimed, this function
-    /// returns `Some(value)` otherwise `None`.
-    ///
-    /// A device that only claims requests via standard BARs can use
-    /// [`try_match_bar`](super::config_space::ConfigSpace::try_match_bar) to implement this function.
-    ///
     /// # Parameters
     ///
-    /// - `kind`: Specifies the type of request.
+    /// - `region`: Identifies the targeted I/O region (BAR).
     /// - `req`: The offset and size of the request. Offsets are relative to the beginning of each
     ///          I/O region.
     #[must_use]
-    fn try_io_read(&self, kind: RequestKind, req: Request) -> Option<u64>;
+    fn read_io(&self, region: u32, req: Request) -> u64;
 }

--- a/src/xhci_backend.rs
+++ b/src/xhci_backend.rs
@@ -87,12 +87,16 @@ impl ServerBackend for XhciBackend {
         let value: u64 = match region {
             VFIO_PCI_CONFIG_REGION_INDEX => self.device.read_cfg(Request::new(
                 offset,
-                RequestSize::try_from(data.len() as u64).unwrap(),
+                RequestSize::try_from(data.len() as u64).expect("should use valid request size"),
             )),
 
             0 => self.device.read_io(
                 0,
-                Request::new(offset, RequestSize::try_from(data.len() as u64).unwrap()),
+                Request::new(
+                    offset,
+                    RequestSize::try_from(data.len() as u64)
+                        .expect("should use valid request size"),
+                ),
             ),
 
             _ => !0u64,
@@ -117,7 +121,11 @@ impl ServerBackend for XhciBackend {
 
         match region {
             VFIO_PCI_CONFIG_REGION_INDEX => self.device.write_cfg(
-                Request::new(offset, RequestSize::try_from(data.len() as u64).unwrap()),
+                Request::new(
+                    offset,
+                    RequestSize::try_from(data.len() as u64)
+                        .expect("should use valid request size"),
+                ),
                 match data.len() {
                     1 => data[0].into(),
                     2 => {
@@ -135,7 +143,11 @@ impl ServerBackend for XhciBackend {
 
             0 => self.device.write_io(
                 0,
-                Request::new(offset, RequestSize::try_from(data.len() as u64).unwrap()),
+                Request::new(
+                    offset,
+                    RequestSize::try_from(data.len() as u64)
+                        .expect("should use valid request size"),
+                ),
                 match data.len() {
                     1 => data[0].into(),
                     2 => {


### PR DESCRIPTION
This is work on the way to make the XHCI driver attach successfully.

* Change the PCI device trait to better work with the VFIO region access
* Add constants for XHCI register offsets
* Return defaults for basic register access

This currently bails out when the XHCI driver configures the single device slot (in `CONFIG`).