### PR TITLE
Handle more initial MMIO register access

### DIFF
--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -209,6 +209,12 @@ pub mod xhci {
     pub const OP_BASE: u64 = 0x68;
     /// Runtime register base offset.
     pub const RUN_BASE: u64 = 0x3000;
+    /// Maximum number of supported ports.
+    pub const MAX_PORTS: u64 = 1;
+    /// Maximum number of supported interrupter register sets.
+    pub const MAX_INTRS: u64 = 1;
+    /// Maximum number of supported device slots.
+    pub const MAX_SLOTS: u64 = 1;
 
     /// Offsets of various fields from the start of the XHCI MMIO region.
     pub mod offset {
@@ -227,19 +233,47 @@ pub mod xhci {
         pub const USBCMD: u64 = super::OP_BASE;
         pub const USBSTS: u64 = super::OP_BASE + 0x4;
         pub const PAGESIZE: u64 = super::OP_BASE + 0x8;
+        pub const CRCR: u64 = super::OP_BASE + 0x18;
+        pub const CRCR_HI: u64 = super::OP_BASE + 0x1c;
+        pub const DCBAAP: u64 = super::OP_BASE + 0x30;
+        pub const DCBAAP_HI: u64 = super::OP_BASE + 0x34;
         pub const CONFIG: u64 = super::OP_BASE + 0x38;
 
+        /// Per Port Operational Register Offsets
+        pub const PORTSC: u64 = super::OP_BASE + 0x400; /* +(0x10 * (portnr-1)) */
+        pub const PORTPMSC: u64 = super::OP_BASE + 0x404;
+        pub const PORTLI: u64 = super::OP_BASE + 408;
+
         /// Runtime Register Offsets
-        pub const IMAN: u64 = super::RUN_BASE;
-        pub const IMOD: u64 = super::RUN_BASE + 0x4;
-        pub const ERSTSZ: u64 = super::RUN_BASE + 0x8;
-        pub const ERSTBA: u64 = super::RUN_BASE + 0x10;
-        pub const ERDB: u64 = super::RUN_BASE + 0x18;
+        pub const MFINDEX: u64 = super::RUN_BASE;
+
+        /// Per Interruptor Runtime Register Offsets
+        pub const IR0: u64 = super::RUN_BASE + 0x20;
+
+        pub const IMAN: u64 = IR0;
+        pub const IMOD: u64 = IR0 + 0x4;
+        pub const ERSTSZ: u64 = IR0 + 0x8;
+        pub const ERSTBA: u64 = IR0 + 0x10;
+        pub const ERSTBA_HI: u64 = IR0 + 0x14;
+        pub const ERDP: u64 = IR0 + 0x18;
+        pub const ERDP_HI: u64 = IR0 + 0x1c;
     }
 
     /// Constants for the capability register.
-    pub mod capability {}
+    pub mod capability {
+        /// We only emulate version 1.0.0 of the XHCI spec for simplicity.
+        pub const HCIVERSION: u64 = 0x100;
+        pub const HCSPARAMS1: u64 =
+            (super::MAX_PORTS << 24) | (super::MAX_INTRS << 8) | super::MAX_SLOTS;
+    }
 
     /// Constants for the operational registers.
-    pub mod operational {}
+    pub mod operational {
+        pub mod crcr {
+            pub const DEQUEUE_POINTER_MASK: u64 = !0x3fu64;
+            pub const RCS: u64 = 0x1;
+            pub const CS: u64 = 0x2;
+            pub const CA: u64 = 0x4;
+        }
+    }
 }

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -9,7 +9,7 @@ use crate::device::{
     bus::{BusDeviceRef, Request, SingleThreadedBusDevice},
     pci::{
         config_space::{ConfigSpace, ConfigSpaceBuilder},
-        constants::xhci::{offset, OP_BASE, RUN_BASE},
+        constants::xhci::{capability, offset, OP_BASE, RUN_BASE},
         traits::PciDevice,
     },
 };
@@ -75,10 +75,8 @@ impl PciDevice for Mutex<XhciController> {
         match req.addr {
             // xHC Capability Registers
             offset::CAPLENGTH => OP_BASE,
-            offset::HCIVERSION => 0x100, /* BCD encoded 1.0.0 */
-            offset::HCSPARAMS1 => {
-                (1 << 24/* max ports */) | (1 << 8/* max intrs */) | (1/* max slots */)
-            }
+            offset::HCIVERSION => capability::HCIVERSION,
+            offset::HCSPARAMS1 => capability::HCSPARAMS1,
             offset::HCSPARAMS2 => 0,
             offset::HCSPARAMS3 => 0,
             offset::HCCPARAMS1 => 0,


### PR DESCRIPTION
This PR starts tracking and returning some internal state during MMIO register access. The xhci driver probe still fails.

The visible guest driver probe sequence changes a little from:

```
$ sudo dmesg | grep xhci
[    1.371933] xhci_hcd 0000:00:03.0: xHCI Host Controller
[    1.372179] xhci_hcd 0000:00:03.0: new USB bus registered, assigned bus number 1
[    1.373995] xhci_hcd 0000:00:03.0: No Extended Capability registers, unable to set up roothub
[    1.511130] xhci_hcd 0000:00:03.0: Host halt failed, -110
[    1.511380] xhci_hcd 0000:00:03.0: Host controller not halted, aborting reset.
[    1.511733] xhci_hcd 0000:00:03.0: can't setup: -12
[    1.511938] xhci_hcd 0000:00:03.0: USB bus 1 deregistered
[    1.512180] xhci_hcd 0000:00:03.0: init 0000:00:03.0 fail, -12
[    1.512431] xhci_hcd 0000:00:03.0: probe with driver xhci_hcd failed with error -12
```

to:
```
$ sudo dmesg | grep xhci 
[    1.383109] xhci_hcd 0000:00:03.0: xHCI Host Controller
[    1.383344] xhci_hcd 0000:00:03.0: new USB bus registered, assigned bus number 1
[    1.384923] xhci_hcd 0000:00:03.0: No Extended Capability registers, unable to set up roothub
[    1.385705] xhci_hcd 0000:00:03.0: can't setup: -12
[    1.385987] xhci_hcd 0000:00:03.0: USB bus 1 deregistered
[    1.386258] xhci_hcd 0000:00:03.0: init 0000:00:03.0 fail, -12
[    1.388043] xhci_hcd 0000:00:03.0: probe with driver xhci_hcd failed with error -12
```
(the host controller "halt"/reset looks correct now).

The xhci driver finishes by writing a 0 to the primary event ring segment table size, which should result in "undefined behavior" (cannot stop the primary event ring). At this point, we need to provide more capabilities to describe the XHCI controller setup.