### PR TITLE
Add supported protocols extended capability

### DIFF
--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -237,6 +237,7 @@ pub mod xhci {
         pub const USBCMD: u64 = super::OP_BASE;
         pub const USBSTS: u64 = super::OP_BASE + 0x4;
         pub const PAGESIZE: u64 = super::OP_BASE + 0x8;
+        pub const DNCTL: u64 = super::OP_BASE + 0x14;
         pub const CRCR: u64 = super::OP_BASE + 0x18;
         pub const CRCR_HI: u64 = super::OP_BASE + 0x1c;
         pub const DCBAAP: u64 = super::OP_BASE + 0x30;

--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -229,6 +229,10 @@ pub mod xhci {
         pub const RTSOFF: u64 = 0x18;
         pub const HCCPARAMS2: u64 = 0x1c;
 
+        /// Extended Capabilities
+        pub const SUPPORTED_PROTOCOLS: u64 = 0x20;
+        pub const SUPPORTED_PROTOCOLS_CONFIG: u64 = 0x28;
+
         /// Operational Register Offsets
         pub const USBCMD: u64 = super::OP_BASE;
         pub const USBSTS: u64 = super::OP_BASE + 0x4;
@@ -265,6 +269,16 @@ pub mod xhci {
         pub const HCIVERSION: u64 = 0x100;
         pub const HCSPARAMS1: u64 =
             (super::MAX_PORTS << 24) | (super::MAX_INTRS << 8) | super::MAX_SLOTS;
+        pub const HCCPARAMS1: u64 = super::offset::SUPPORTED_PROTOCOLS << 14;
+
+        pub mod supported_protocols {
+            const ID: u64 = 2;
+            const MAJOR: u64 = 0x03;
+            const MINOR: u64 = 0x20;
+            const NEXT: u64 = 0;
+            pub const CAP_INFO: u64 = ID | (MAJOR << 24) | (MINOR << 16) | (NEXT << 8);
+            pub const CONFIG: u64 = 1 | (super::super::MAX_PORTS << 8);
+        }
     }
 
     /// Constants for the operational registers.

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -217,10 +217,14 @@ impl PciDevice for Mutex<XhciController> {
             offset::HCSPARAMS1 => capability::HCSPARAMS1,
             offset::HCSPARAMS2 => 0, /* ERST Max size is a single segment */
             offset::HCSPARAMS3 => 0,
-            offset::HCCPARAMS1 => 0,
+            offset::HCCPARAMS1 => capability::HCCPARAMS1,
             offset::DBOFF => 0x2000,
             offset::RTSOFF => RUN_BASE,
             offset::HCCPARAMS2 => 0,
+
+            // xHC Extended Capability ("Supported Protocols Capability")
+            offset::SUPPORTED_PROTOCOLS => capability::supported_protocols::CAP_INFO,
+            offset::SUPPORTED_PROTOCOLS_CONFIG => capability::supported_protocols::CONFIG,
 
             // xHC Operational Registers
             offset::USBCMD => 0,

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -187,6 +187,7 @@ impl PciDevice for Mutex<XhciController> {
                 val if val & 0x1 == 0 => (), /* stop */
                 _ => todo!(),
             },
+            offset::DNCTL => assert_eq!(value, 2, "debug notifications not supported"),
             offset::CRCR => self.lock().unwrap().update_command_ring(value),
             offset::CRCR_HI => assert_eq!(value, 0, "no support for configuration above 4G"),
             offset::DCBAAP => self.lock().unwrap().configure_device_contexts(value),
@@ -229,6 +230,7 @@ impl PciDevice for Mutex<XhciController> {
             // xHC Operational Registers
             offset::USBCMD => 0,
             offset::USBSTS => self.lock().unwrap().status(),
+            offset::DNCTL => 2,
             offset::CRCR => self.lock().unwrap().command_ring_status(),
             offset::CRCR_HI => 0,
             offset::PAGESIZE => 0x1, /* 4k Pages */


### PR DESCRIPTION
The Linux kernel `xhci_hcd` driver does not trust the `PORTSC` register values for the number of available ports. It reads from the "Supported Protocols" Extended Capability instead. Provide one such capability that claims a single USB 3.2 compatible port.

Note the Linux driver creates two "fake" root hubs, one for USB2 and one for USB3.  One of those will stay empty when we can only assign a single port, and print a message to the system logs ("root hub has no ports").

The driver still fails to attach, now because of the missing MSI or MSI-X support. But the `usbvfiod` does not crash (in a `todo!()`) from the access anymore.

```
$ sudo dmesg | grep xhci
[    1.397109] xhci_hcd 0000:00:03.0: xHCI Host Controller
[    1.397348] xhci_hcd 0000:00:03.0: new USB bus registered, assigned bus number 1
[    1.399178] xhci_hcd 0000:00:03.0: USB2 root hub has no ports
[    1.399468] xhci_hcd 0000:00:03.0: Host supports USB 3.2 Enhanced SuperSpeed
[    1.400843] xhci_hcd 0000:00:03.0: hcc params 0x00080000 hci version 0x0 quirks 0x0000000000000000
[    1.402102] xhci_hcd 0000:00:03.0: No msi-x/msi found and no IRQ in BIOS
[    1.402394] xhci_hcd 0000:00:03.0: startup error -22
[    1.402623] xhci_hcd 0000:00:03.0: USB bus 1 deregistered
[    1.402969] xhci_hcd 0000:00:03.0: init 0000:00:03.0 fail, -22
[    1.403281] xhci_hcd 0000:00:03.0: probe with driver xhci_hcd failed with error -22
```
