### PR TITLE
Make the xhci driver attach

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -93,7 +93,8 @@ in
       machine.wait_for_unit("cloud-hypervisor.service")
 
       # Check whether the USB controller pops up.
-      machine.wait_until_succeeds("grep -Fq 'pci 0000:00:02.0: [1b36:000d]' ${cloudHypervisorLog}")
+      machine.wait_until_succeeds("grep -Fq 'usb usb1: Product: xHCI Host Controller' ${cloudHypervisorLog}")
+      machine.wait_until_succeeds("grep -Fq 'hub 1-0:1.0: 1 port detected' ${cloudHypervisorLog}")
     '';
   };
 }

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -87,13 +87,15 @@ in
       };
     };
 
+    # The nested CI runs are really slow.
+    globalTimeout = 3600;
     testScript = ''
       start_all()
 
       machine.wait_for_unit("cloud-hypervisor.service")
 
       # Check whether the USB controller pops up.
-      machine.wait_until_succeeds("grep -Fq 'usb usb1: Product: xHCI Host Controller' ${cloudHypervisorLog}")
+      machine.wait_until_succeeds("grep -Fq 'usb usb1: Product: xHCI Host Controller' ${cloudHypervisorLog}", timeout=3000)
       machine.wait_until_succeeds("grep -Fq 'hub 1-0:1.0: 1 port detected' ${cloudHypervisorLog}")
     '';
   };

--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -291,4 +291,10 @@ pub mod xhci {
             pub const CA: u64 = 0x4;
         }
     }
+
+    /// Constants for the runtime registers.
+    pub mod runtime {
+        /// The default minimum interrupt interval of ~1ms (4000 * 250ns).
+        pub const IMOD_DEFAULT: u64 = 4000;
+    }
 }

--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -206,7 +206,7 @@ pub mod config_space {
 pub mod xhci {
 
     /// Value for the operational base as returned for reading CAPLENGTH.
-    pub const OP_BASE: u64 = 0x68;
+    pub const OP_BASE: u64 = 0x40;
     /// Runtime register base offset.
     pub const RUN_BASE: u64 = 0x3000;
     /// Maximum number of supported ports.

--- a/src/xhci_backend.rs
+++ b/src/xhci_backend.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Result;
-use tracing::{info, trace};
+use tracing::{debug, info, trace};
 
 use vfio_bindings::bindings::vfio::{
     vfio_region_info, VFIO_PCI_CONFIG_REGION_INDEX, VFIO_PCI_NUM_IRQS, VFIO_PCI_NUM_REGIONS,
@@ -64,7 +64,7 @@ impl XhciBackend {
         for index in 0..VFIO_PCI_NUM_IRQS {
             let irq = IrqInfo {
                 index,
-                count: 0,
+                count: !index,
                 flags: 0,
             };
 
@@ -204,12 +204,17 @@ impl ServerBackend for XhciBackend {
 
     fn set_irqs(
         &mut self,
-        _index: u32,
-        _flags: u32,
-        _start: u32,
-        _count: u32,
-        _fds: Vec<File>,
+        index: u32,
+        flags: u32,
+        start: u32,
+        count: u32,
+        fds: Vec<File>,
     ) -> Result<(), std::io::Error> {
-        todo!()
+        debug!(
+            "set IRQs: {index} flags: {flags:#x} start: {start:#x} count: {count:#x} #fds: {}",
+            fds.len()
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Handle runtime interrupt registers to the point where the guest `xhci` driver attaches and exposes two virtual buses.

```
$ lsusb -t
/:  Bus 001.Port 001: Dev 001, Class=root_hub, Driver=xhci_hcd/1p, 20000M/x2
/:  Bus 002.Port 001: Dev 001, Class=root_hub, Driver=xhci_hcd/1p, 20000M/x2
```

The MSI-X capability is not exposed to the guest because the VMM fails to configure it. The `broken pipe` errors it sees are not fatal, though.

The vfio backend dies in a `todo!()`:

```
2025-05-19T16:44:07.143245Z TRACE usbvfiod::xhci_backend: read  region 0 offset 0x3020+4
2025-05-19T16:44:07.143265Z TRACE usbvfiod::xhci_backend: write region 0 offset 0x3020+4 val [2, 0, 0, 0]
2025-05-19T16:44:07.143282Z TRACE usbvfiod::xhci_backend: read  region 0 offset 0x40+4
2025-05-19T16:44:07.143302Z TRACE usbvfiod::xhci_backend: write region 0 offset 0x40+4 val [1, 0, 0, 0]
2025-05-19T16:44:07.143309Z DEBUG usbvfiod::device::pci::xhci: controller started with cmd 0x1
2025-05-19T16:44:07.143327Z TRACE usbvfiod::xhci_backend: read  region 0 offset 0x44+4
2025-05-19T16:44:07.143365Z TRACE usbvfiod::xhci_backend: read  region 0 offset 0x10+4
2025-05-19T16:44:07.145418Z TRACE usbvfiod::xhci_backend: read  region 0 offset 0x440+4

thread 'main' panicked at src/device/pci/xhci.rs:266:18:
not yet implemented
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

And we see a warning with stack trace in guest `dmesg` during port detection. There are some more details in the commit messages.

I also updated the integration test goal post.