### PR TITLE
Fix race condition in smoke-test

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -55,6 +55,7 @@ in
     name = "usbvfiod Smoke Test";
 
     nodes.machine = { pkgs, ... }: {
+      boot.kernelModules = [ "kvm" ];
       systemd.services.usbvfiod = {
         wantedBy = [ "multi-user.target" ];
 


### PR DESCRIPTION
On my system, the smoke-test consistently (five attempts) failed, because the systemd cloud-hypervisor.service failed ("Failed to open hypervisor interface"). Manually restarting the service in an interactive test run worked, so we assume there is a race condition between the loading of KVM and the execution of the cloud-hypervisor.service.
This PR ensures that KVM is loaded during the second stage of the boot process and is thus reliably available for the start of cloud-hypervisor.service.

For reference, the log of the failed cloud-hypervisor.service:
![image](https://github.com/user-attachments/assets/fe9ffbe6-0b00-4acb-bfc2-ca532cbc105b)
The image also shows that kvm was available during interactive use but apparently not when the cloud-hypervisor.service launched.