### PR TITLE
Mention debug prints of Linux XHCI driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,18 @@ checks can become annoying. In this case, use:
 ```console
 $ git commit --no-verify
 ```
+
+### Kernel Debug Messages for XHCI
+The XHCI driver in the Linux kernel prints helpful messages with `xhci_dbg`.
+If your kernel supports `CONFIG_DYNAMIC_DEBUG` (the NixOS netboot kernel does),
+you can enable the messages for XHCI with:
+
+```
+$ echo "file drivers/usb/host/xhci* +p" | sudo tee /sys/kernel/debug/dynamic_debug/control
+```
+
+Then, you can filter the kernel log for the relevant messages:
+
+```
+$ sudo dmesg | grep xhci
+```


### PR DESCRIPTION
Add section to the README, mentioning the command that enables the `xhci_dbg` prints of the Linux kernel XHCI driver.
I tested with the default NixOS netboot binaries and parameters (`cloud-hypervisor --memory size=4G,shared=on --serial tty --user-device socket=/tmp/usbvfiod-socket --console off --kernel result/bzImage --initramfs result/initrd --cmdline "init=/nix/store/9yfbfkbhd6bmfzbhy4fcs42wafv5yv45-nixos-system-nixos-kexec-25.11pre708350.gfedcba/init initrd=initrd nohibernate loglevel=4 console=ttyS0"`).