### PR TITLE
doc: improve dynamic debug for guest xhci

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ $ git commit --no-verify
 ```
 
 ### Kernel Debug Messages for XHCI
+
 The XHCI driver in the Linux kernel prints helpful messages with `xhci_dbg`.
 If your kernel supports `CONFIG_DYNAMIC_DEBUG` (the NixOS netboot kernel does),
 you can enable the messages for XHCI with:
@@ -132,5 +133,12 @@ $ echo "file drivers/usb/host/xhci* +p" | sudo tee /sys/kernel/debug/dynamic_deb
 Then, you can filter the kernel log for the relevant messages:
 
 ```
-$ sudo dmesg | grep xhci
+$ sudo dmesg | grep -E xhci\|usb
 ```
+
+> [!TIP]
+> You can also enable the dynamic debug messages on boot by adding
+> `xhci_hcd.dyndbg==pmfl xhci_pci.dyndbg==pmfl` to the command line.
+>
+> Alternatively, provide `dyndbg==pfml` as option to `modprobe` on
+> invocation or through a `modprobe` config.


### PR DESCRIPTION
After our debug session, I finally figured out how to conveniently enable the dynamic debug messages on boot. It was [in the documentation](https://www.kernel.org/doc/html/v6.12/admin-guide/dynamic-debug-howto.html#debug-messages-at-module-initialization-time) all along :grin: 

I also improved the `grep` expression to capture a bunch of the regular `usb` messages as well.