### PR TITLE
Add a virtual usb device to test

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -69,6 +69,11 @@ let
   # well.
   usbvfiodSocket = "/tmp/usbvfio";
   cloudHypervisorLog = "/tmp/chv.log";
+
+  # Provide a raw file as usb stick test image.
+  usbDiskImage = pkgs.writeText "usb-stick-image.raw" ''
+    This is an uninitialized drive.
+  '';
 in
 {
   integration-smoke = pkgs.nixosTest {
@@ -105,6 +110,13 @@ in
       virtualisation = {
         cores = 2;
         memorySize = 4096;
+        qemu.options = [
+          # A virtual USB XHCI controller in the host ...
+          "-device qemu-xhci,id=host-xhci,addr=10"
+          # ... with an attached usb stick.
+          "-drive if=none,id=usbstick,format=raw,snapshot=on,file=${usbDiskImage}"
+          "-device usb-storage,bus=host-xhci.0,drive=usbstick"
+        ];
       };
     };
 
@@ -121,6 +133,9 @@ in
 
       # Read the diagnostic information after login.
       machine.wait_until_succeeds("grep -Eq '\s+1\s+PCI-MSIX.*xhci_hcd' ${cloudHypervisorLog}")
+
+      # Check whether the virtual usb stick is available in the host.
+      machine.succeed('grep -Fq "uninitialized drive" /dev/sda')
     '';
   };
 }


### PR DESCRIPTION
Configure the NixOS smoke integration test with a virtual XHCI controller and virtual USB storage device.
We will pass this storage device to the guest through the `usbvfiod` service eventually. For now, it is not used by the guest.

I added a check that we can read the device contents in the host at least (so it works, before we pass it to the guest).

While here, this also adds the `dyndbg` messages for the guest xhci driver.