### PR TITLE
Add abstractions for the event ring

### DIFF
--- a/src/device/pci/mod.rs
+++ b/src/device/pci/mod.rs
@@ -7,4 +7,5 @@ pub mod config_space;
 pub mod constants;
 pub mod msix_table;
 pub mod traits;
+pub mod trb;
 pub mod xhci;

--- a/src/device/pci/mod.rs
+++ b/src/device/pci/mod.rs
@@ -6,6 +6,7 @@
 pub mod config_space;
 pub mod constants;
 pub mod msix_table;
+pub mod rings;
 pub mod traits;
 pub mod trb;
 pub mod xhci;

--- a/src/device/pci/rings.rs
+++ b/src/device/pci/rings.rs
@@ -1,0 +1,138 @@
+//! Abstractions of the rings (Event Ring, Command Ring, Transfer Ring) of a
+//! USB3 Host (XHCI) controller.
+//!
+//! The specification is available
+//! [here](https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/extensible-host-controler-interface-usb-xhci.pdf).
+
+use tracing::debug;
+
+use crate::device::bus::{BusDeviceRef, Request, RequestSize};
+
+use super::trb::EventTrb;
+
+/// The Event Ring: A unidirectional means of communication, allowing the XHCI
+/// controller to send events to the driver.
+///
+/// This implementation is a simplified version of the full mechanism specified
+/// in the XHCI specification. We assume that the Event Ring Segment Table only
+/// holds a single segment.
+#[derive(Debug, Default, Clone)]
+pub struct EventRing {
+    /// The address of the Event Ring Segment Table.
+    /// This field directly corresponds with the ERSTBA register(s) in the
+    /// XHCI's MMIO region.
+    base_address: u64,
+    /// The dequeue pointer as the driver reports it.
+    /// This field directly corresponds with the ERDP register(s) in the
+    /// XHCI's MMIO region.
+    /// When the ring is not empty, the pointer indicates the address of the
+    /// last processed TRB.
+    /// When the ring is empty, the pointer is equal to the enqueue pointer
+    /// (EREP).
+    dequeue_pointer: u64,
+    /// no public access, indicated via cycle bit
+    /// The enqueue pointer; the spec refers to it as the EREP.
+    /// It is an internal variable of the XHCI controller.
+    /// The driver implicitly knows it reached the enqueue pointer (and thus
+    /// can conclude the ring is empty), when it detects a cycle-bit mismatch
+    /// at ERDP.
+    enqueue_pointer: u64,
+    /// The number of TRBs that fits into the current segment.
+    /// The count is initialized from the size field of an Event Ring Segment
+    /// Table Entry. Once the count reaches 0, we have to advance to the next
+    /// segment—because we only support one, we move back to the start of the
+    /// same segment.
+    trb_count: u32,
+    /// The producer cycle state.
+    /// The driver tracks cycle state as well and can deduce the enqueue
+    /// pointer by detecting cycle-state mismatches.
+    /// Initially, the state has to be true (corresponds to TRB cycle bits
+    /// equal to 1), so new TRBs can be written over the zero-initialized
+    /// memory. Later, the cycle_state has to flip after every full pass of the
+    /// event ring (i.e., in our case, when we move from the back of the
+    /// segment to the front of the single segment).
+    cycle_state: bool,
+}
+
+impl EventRing {
+    /// Configure the Event Ring.
+    /// Amongst setting the base address of the Event Ring Segment Table,
+    ///
+    /// # Parameters
+    ///
+    /// - `erstba`: base address of the Event Ring Segment Table
+    /// - `dma_bus`: the bus to use for DMA accesses
+    pub fn configure(&mut self, erstba: u64, dma_bus: BusDeviceRef) {
+        assert_eq!(erstba & 0x3f, 0, "unaligned event ring base address");
+
+        self.base_address = erstba;
+        self.enqueue_pointer = dma_bus.read(Request::new(erstba, RequestSize::Size8));
+        self.trb_count = dma_bus.read(Request::new(erstba + 8, RequestSize::Size4)) as u32;
+        self.cycle_state = true;
+
+        debug!("event ring segment table is at {:#x}", erstba);
+        debug!(
+            "initializing event ring enqueue pointer with base address of the first (and only) segment: {:#x}",
+            self.enqueue_pointer
+        );
+        debug!(
+            "retrieving TRB count of the first (and only) event ring segment from the segment table: {}",
+            self.trb_count
+        );
+    }
+
+    /// Handle writes to the Event Ring Dequeue Pointer (ERDP).
+    ///
+    /// # Parameters
+    ///
+    /// - `erdp`: value that the driven has written to the ERDP register.
+    pub fn update_dequeue_pointer(&mut self, erdp: u64) {
+        self.dequeue_pointer = erdp;
+        debug!("driver set event ring dequeue pointer to {:#x}", erdp);
+    }
+
+    /// Handle reads to the Event Ring Segment Table Base Address (ERSTBA).
+    pub fn read_base_address(&self) -> u64 {
+        self.base_address
+    }
+
+    /// Handle reads to the Event Ring Dequeue Pointer (ERDP).
+    pub fn read_dequeue_pointer(&self) -> u64 {
+        self.dequeue_pointer
+    }
+
+    /// Enqueue an Event TRB to the ring.
+    ///
+    /// # Current Limitations
+    /// The method is not capable of wrapping around to the start of the single
+    /// segment. We fail once the first segment is full
+    ///
+    /// # Parameters
+    ///
+    /// - `trb`: the TRB to enqueue.
+    /// - `dma_bus`: the bus to use for DMA accesses
+    pub fn enqueue(&mut self, trb: &EventTrb, dma_bus: BusDeviceRef) {
+        if self.check_event_ring_full() {
+            todo!();
+        }
+
+        dma_bus.write_bulk(self.enqueue_pointer, &trb.to_bytes(self.cycle_state));
+
+        let enqueue_address = self.enqueue_pointer;
+
+        self.enqueue_pointer += 16;
+        self.trb_count -= 1;
+
+        debug!(
+            "enqueued TRB in first segment of event ring at address {:#x}. Space for {} more TRBs left (TRB: {:?})",
+            enqueue_address, self.trb_count, trb
+        );
+    }
+
+    // The method is currently not capable of dealing with wrapping around to
+    // the start of the single segment and just reports full once the segment
+    // is filled up.
+    fn check_event_ring_full(&self) -> bool {
+        self.trb_count == 0
+    }
+}

--- a/src/device/pci/trb.rs
+++ b/src/device/pci/trb.rs
@@ -1,0 +1,183 @@
+//! Abstraction of the Transfer Request Block of a USB3 Host (XHCI) controller.
+//!
+//! The specification is available
+//! [here](https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/extensible-host-controler-interface-usb-xhci.pdf).
+
+/// Represents a TRB that the XHCI controller can place on the event ring.
+#[derive(Debug)]
+pub enum EventTrb {
+    //TransferEvent,
+    CommandCompletionEvent(CommandCompletionEventTrbData),
+    PortStatusChangeEvent(PortStatusChangeEventData),
+    //BandwidthRequestEvent,
+    //DoorbellEvent,
+    //HostControllerEvent,
+    //DeviceNotificationEvent,
+    //MfIndexWrapEvent,
+}
+
+impl EventTrb {
+    /// Generates the byte representation of the TRB.
+    /// The cycle bit's value does not depend on the TRB but on the ring that
+    /// the TRB will be placed on.
+    ///
+    /// # Parameters
+    ///
+    /// - `cycle_bit`: value to set the cycle bit to. Has to match the ring
+    ///   where the caller will write the TRB on.
+    pub fn to_bytes(&self, cycle_bit: bool) -> [u8; 16] {
+        // layout the event-type-specific data
+        let mut trb_data = match self {
+            EventTrb::CommandCompletionEvent(data) => data.to_bytes(),
+            EventTrb::PortStatusChangeEvent(data) => data.to_bytes(),
+        };
+        // set cycle bit
+        trb_data[12] = (trb_data[12] & !0x1) | cycle_bit as u8;
+
+        trb_data
+    }
+}
+
+/// Stores the relevant data for a Command Completion Event.
+/// Do not use this struct directly, use EventTrb::new_command_completion_event_trb
+/// instead.
+#[derive(Debug)]
+pub struct CommandCompletionEventTrbData {
+    command_trb_pointer: u64,
+    command_completion_parameter: u32,
+    completion_code: CompletionCode,
+    slot_id: u8,
+}
+
+impl EventTrb {
+    /// Create a new Command Completion Event TRB.
+    /// The XHCI spec describes this structure in Section 6.4.2.2.
+    ///
+    /// # Parameters
+    ///
+    /// - `command_trb_pointer`: 64-bit address of the Command TRB that
+    ///   generated this event. The address has to be 16-byte-aligned, so the
+    ///   lowest four bit have to be 0.
+    /// - `command_completion_parameter`: Depends on the associated command.
+    ///   This is a 24-bit value, so the highest eight bit are ignored.
+    /// - `completion_code`: Encodes the completion status of the associated
+    ///   command.
+    /// - `slot_id`: The slot associated with command that generated this
+    ///   event.
+    #[allow(unused)]
+    pub fn new_command_completion_event_trb(
+        command_trb_pointer: u64,
+        command_completion_parameter: u32,
+        completion_code: CompletionCode,
+        slot_id: u8,
+    ) -> EventTrb {
+        assert_ne!(
+            0,
+            command_trb_pointer & 0x0f,
+            "command_trb_pointer has to be 16-byte-aligned."
+        );
+        assert_ne!(
+            0,
+            command_completion_parameter & 0xff000000,
+            "command_completion_parameter has to be a 24-bit value."
+        );
+        EventTrb::CommandCompletionEvent(CommandCompletionEventTrbData {
+            command_trb_pointer,
+            command_completion_parameter,
+            completion_code,
+            slot_id,
+        })
+    }
+}
+
+impl CommandCompletionEventTrbData {
+    fn to_bytes(&self) -> [u8; 16] {
+        let command_completion_event_id = 33;
+        let mut trb = [0; 16];
+
+        trb[0..8].copy_from_slice(&self.command_trb_pointer.to_le_bytes());
+        trb[8..11].copy_from_slice(&self.command_completion_parameter.to_le_bytes());
+        trb[11] = self.completion_code as u8;
+        trb[13] = command_completion_event_id << 2;
+        trb[15] = self.slot_id;
+
+        trb
+    }
+}
+
+/// Stores the relevant data for a Port Status Change Event.
+/// Do not use this struct directly, use EventTrb::new_port_status_change_event_trb
+/// instead.
+#[derive(Debug)]
+pub struct PortStatusChangeEventData {
+    port_id: u8,
+}
+
+impl EventTrb {
+    /// Create a new Port Status Change Event TRB.
+    /// The XHCI spec describes this structure in Section 6.4.2.3.
+    ///
+    /// # Parameters
+    ///
+    /// - `port_id`: The number of the root hub port that generated this
+    ///   event.
+    pub fn new_port_status_change_event_trb(port_id: u8) -> EventTrb {
+        EventTrb::PortStatusChangeEvent(PortStatusChangeEventData { port_id })
+    }
+}
+
+impl PortStatusChangeEventData {
+    fn to_bytes(&self) -> [u8; 16] {
+        let port_status_change_event_id = 34;
+        let mut bytes = [0; 16];
+
+        bytes[3] = self.port_id;
+        bytes[11] = CompletionCode::Success as u8;
+        bytes[13] = port_status_change_event_id << 2;
+
+        bytes
+    }
+}
+
+/// Encodes the completion code that some event TRBs contain.
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone)]
+pub enum CompletionCode {
+    Invalid = 0,
+    Success,
+    DataBufferError,
+    BabbleDetectedError,
+    UsbTransactionError,
+    TrbError,
+    StallError,
+    ResourceError,
+    BandwidthError,
+    NoSlotsAvailableError,
+    InvalidStreamTypeError,
+    SlotNotEnabledError,
+    EndpointNotEnabledError,
+    ShortPacket,
+    RingUnderrun,
+    RingOverrun,
+    VfEventRingFullError,
+    ParameterError,
+    BandwidthOverrunError,
+    ContextStateError,
+    NoPingResponseError,
+    EventRingFullError,
+    IncompatibleDeviceError,
+    MissedServiceError,
+    CommandRingStopped,
+    CommandAborted,
+    Stopped,
+    StoppedLengthInvalid,
+    StoppedShortedPacket,
+    MaxExitLatencyTooLargeError,
+    Reserved,
+    IsochBufferOverrun,
+    EventLostError,
+    UndefinedError,
+    InvalidStreamIdError,
+    SecondaryBandwidthError,
+    SplitTransactionError,
+}

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -20,14 +20,7 @@ use crate::device::{
     },
 };
 
-use super::config_space::BarInfo;
-
-/// A Basic Event Ring.
-#[derive(Debug, Default, Clone)]
-pub struct EventRing {
-    base_address: u64,
-    dequeue_pointer: u64,
-}
+use super::{config_space::BarInfo, rings::EventRing};
 
 /// The emulation of a XHCI controller.
 #[derive(Debug, Clone)]
@@ -147,21 +140,6 @@ impl XhciController {
         self.device_contexts.push(device_context_base_array_ptr);
     }
 
-    /// Configure the Event Ring Segment Table from the base address.
-    pub fn configure_event_ring_segment_table(&mut self, erstba: u64) {
-        assert_eq!(erstba & 0x3f, 0, "unaligned event ring base address");
-
-        self.event_ring.base_address = erstba;
-
-        debug!("event ring segment table at {:#x}", erstba);
-    }
-
-    /// Handle writes to the Event Ring Dequeue Pointer (ERDP).
-    pub fn update_event_ring(&mut self, value: u64) {
-        debug!("event ring dequeue pointer advanced to {:#x}", value);
-        self.event_ring.dequeue_pointer = value;
-    }
-
     /// Start/Stop controller operation
     ///
     /// This is called for writes of the `USBCMD` register.
@@ -241,12 +219,18 @@ impl PciDevice for Mutex<XhciController> {
             offset::IMAN => self.lock().unwrap().interrupt_management = value,
             offset::IMOD => self.lock().unwrap().interrupt_moderation_interval = value,
             offset::ERSTSZ => assert_eq!(value, 1, "only a single segment supported"),
-            offset::ERSTBA => self
+            offset::ERSTBA => {
+                let mut xhci = self.lock().unwrap();
+                let dma_bus = xhci.dma_bus.clone();
+                xhci.event_ring
+                    .configure_event_ring_segment_table(value, dma_bus)
+            }
+            offset::ERSTBA_HI => assert_eq!(value, 0, "no support for configuration above 4G"),
+            offset::ERDP => self
                 .lock()
                 .unwrap()
-                .configure_event_ring_segment_table(value),
-            offset::ERSTBA_HI => assert_eq!(value, 0, "no support for configuration above 4G"),
-            offset::ERDP => self.lock().unwrap().update_event_ring(value),
+                .event_ring
+                .update_dequeue_pointer(value),
             offset::ERDP_HI => assert_eq!(value, 0, "no support for configuration above 4G"),
             _ => todo!(),
         }
@@ -288,9 +272,9 @@ impl PciDevice for Mutex<XhciController> {
             offset::IMAN => self.lock().unwrap().interrupt_management,
             offset::IMOD => self.lock().unwrap().interrupt_moderation_interval,
             offset::ERSTSZ => 1,
-            offset::ERSTBA => self.lock().unwrap().event_ring.base_address,
+            offset::ERSTBA => self.lock().unwrap().event_ring.read_base_address(),
             offset::ERSTBA_HI => 0,
-            offset::ERDP => self.lock().unwrap().event_ring.dequeue_pointer,
+            offset::ERDP => self.lock().unwrap().event_ring.read_dequeue_pointer(),
             offset::ERDP_HI => 0,
 
             // Everything else is Reserved Zero

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -17,6 +17,7 @@ use crate::device::{
             runtime, MAX_INTRS, MAX_SLOTS, OP_BASE, RUN_BASE,
         },
         traits::PciDevice,
+        trb::EventTrb,
     },
 };
 
@@ -148,6 +149,12 @@ impl XhciController {
         if self.running {
             debug!("controller started with cmd {usbcmd:#x}");
 
+            // XXX: This is just a test to see if we can enqueue events.
+            // This will be removed once we send events in the right place
+            // (e.g., command completion events on doorbell writes)
+            let trb = EventTrb::new_port_status_change_event_trb(0);
+            self.event_ring.enqueue(&trb, self.dma_bus.clone());
+
             // XXX: This is just a test to see if we can generate interrupts.
             // This will be removed once we generate interrupts in the right
             // place, (e.g. generate a Port Connect Status Event) and test it.
@@ -222,8 +229,7 @@ impl PciDevice for Mutex<XhciController> {
             offset::ERSTBA => {
                 let mut xhci = self.lock().unwrap();
                 let dma_bus = xhci.dma_bus.clone();
-                xhci.event_ring
-                    .configure_event_ring_segment_table(value, dma_bus)
+                xhci.event_ring.configure(value, dma_bus)
             }
             offset::ERSTBA_HI => assert_eq!(value, 0, "no support for configuration above 4G"),
             offset::ERDP => self


### PR DESCRIPTION
This PR adds abstractions for event ring handling itself as well as the Transfer Request Blocks (TRBs) that the XHCI controller can place on the event ring.

# TRBs

The controller requires the possibility to construct representations of the events it wants to signal to the driver (ideally checked by the type system as much as possible, further check with assertions to detect implausible values), and a way to retrieve the 16-byte representation it has to write on the event ring.

Individual structs encode the event-specific information (currently `CommandCompletionEventTrbData` and `PortStatusChangeEventTrbData` are implemented); the enum `EventTrb` aggregates the different events. Each event requires the implementation of a matching, publicly available constructor. Further, each event struct needs to implement `to_bytes`, which the public `EventTrb::to_bytes` can call.

The cycle bit is not part of the TRB representation and only set by `EventTrb::to_bytes`. The caller has to make sure the specified cycle bit value is appropriate with the current state of the event ring, where the TRB will be placed.

# Event Ring
The new Event Ring implementation offers methods for initial configuration and for runtime use (read/write values of MMIO registers, enqueue event TRBs).

We remove the old minimal internal implementation of the event ring in the XHCI controller and replace it with the new abstraction. Additionally, an event gets enqueued for testing right after the controller starts and before a test interrupt is fired.

## Limitations
The ring cannot yet wrap around. The Linux driver supplies us with a single segment for 256 TRBs. The `enqueue` method works well 256 times, after that we crash.
Despite our choice to support only a single segment for the event ring, the wrap-around logic is not trivial.
In my opinion, the current implementation should allow us to get far enough to fully configure USB devices, which we should focus on before refining the event ring implementation.
