### PR TITLE
treewide: make clippy quite pedantic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ name = "usbvfiod"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/cyberus-technology/usbvfiod"
+keywords = ["usb", "vfio"]
+categories = ["emulators", "hardware-support"]
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,14 +57,10 @@ pub enum ServerSocket<'a> {
 }
 
 impl Cli {
-    pub fn server_socket(&self) -> ServerSocket {
-        if let Some(fd) = self.fd {
-            ServerSocket::Fd(fd)
-        } else if let Some(socket_path) = &self.socket_path {
-            ServerSocket::Path(socket_path)
-        } else {
-            // The clap configuration above prevents that we run into this case.
-            unreachable!()
-        }
+    pub fn server_socket(&self) -> ServerSocket<'_> {
+        self.socket_path.as_ref().map_or_else(
+            || unreachable!(),
+            |socket_path| ServerSocket::Path(socket_path),
+        )
     }
 }

--- a/src/device/msi_message.rs
+++ b/src/device/msi_message.rs
@@ -24,7 +24,7 @@ pub struct MsiMessage {
 impl MsiMessage {
     /// Create a new [`MsiMessage`] struct.
     #[must_use]
-    pub fn new(address: u64, data: u16) -> Self {
+    pub const fn new(address: u64, data: u16) -> Self {
         Self { address, data }
     }
 }

--- a/src/device/pci/config_space.rs
+++ b/src/device/pci/config_space.rs
@@ -30,7 +30,7 @@ pub struct BarInfo {
 }
 
 impl BarInfo {
-    fn new(size: u32, kind: RequestKind) -> Self {
+    const fn new(size: u32, kind: RequestKind) -> Self {
         Self { size, kind }
     }
 }
@@ -126,7 +126,7 @@ impl ConfigSpaceBuilder {
     /// When not specified, the revision defaults to 0.
     #[must_use]
     #[allow(unused)]
-    pub fn revision(mut self, revision: u8) -> Self {
+    pub const fn revision(mut self, revision: u8) -> Self {
         self.revision = revision;
 
         self
@@ -151,7 +151,7 @@ impl ConfigSpaceBuilder {
     /// This is necessary for guests to probe additional functions on this device.
     #[must_use]
     #[allow(unused)]
-    pub fn multifunction(mut self) -> Self {
+    pub const fn multifunction(mut self) -> Self {
         self.multifunction = true;
         self
     }
@@ -161,7 +161,7 @@ impl ConfigSpaceBuilder {
     /// When not specified, the interrupt pin defaults to 0 (None).
     #[must_use]
     #[allow(unused)]
-    pub fn interrupt_pin(mut self, irq_pin: u8) -> Self {
+    pub const fn interrupt_pin(mut self, irq_pin: u8) -> Self {
         self.interrupt_pin = irq_pin;
 
         self
@@ -172,7 +172,7 @@ impl ConfigSpaceBuilder {
     /// When not specified, the interrupt line defaults to `0xff` (not connected).
     #[must_use]
     #[allow(unused)]
-    pub fn interrupt_line(mut self, irq_line: u8) -> Self {
+    pub const fn interrupt_line(mut self, irq_line: u8) -> Self {
         self.interrupt_line = irq_line;
 
         self

--- a/src/device/pci/rings.rs
+++ b/src/device/pci/rings.rs
@@ -106,12 +106,12 @@ impl EventRing {
     }
 
     /// Handle reads to the Event Ring Segment Table Base Address (ERSTBA).
-    pub fn read_base_address(&self) -> u64 {
+    pub const fn read_base_address(&self) -> u64 {
         self.base_address
     }
 
     /// Handle reads to the Event Ring Dequeue Pointer (ERDP).
-    pub fn read_dequeue_pointer(&self) -> u64 {
+    pub const fn read_dequeue_pointer(&self) -> u64 {
         self.dequeue_pointer
     }
 
@@ -147,7 +147,7 @@ impl EventRing {
     // The method is currently not capable of dealing with wrapping around to
     // the start of the single segment and just reports full once the segment
     // is filled up.
-    fn check_event_ring_full(&self) -> bool {
+    const fn check_event_ring_full(&self) -> bool {
         self.trb_count == 0
     }
 }

--- a/src/device/pci/trb.rs
+++ b/src/device/pci/trb.rs
@@ -31,8 +31,8 @@ impl EventTrb {
     pub fn to_bytes(&self, cycle_bit: bool) -> [u8; 16] {
         // layout the event-type-specific data
         let mut trb_data = match self {
-            EventTrb::CommandCompletionEvent(data) => data.to_bytes(),
-            EventTrb::PortStatusChangeEvent(data) => data.to_bytes(),
+            Self::CommandCompletionEvent(data) => data.to_bytes(),
+            Self::PortStatusChangeEvent(data) => data.to_bytes(),
         };
         // set cycle bit
         trb_data[12] = (trb_data[12] & !0x1) | cycle_bit as u8;
@@ -75,7 +75,7 @@ impl EventTrb {
         command_completion_parameter: u32,
         completion_code: CompletionCode,
         slot_id: u8,
-    ) -> EventTrb {
+    ) -> Self {
         assert_eq!(
             0,
             command_trb_pointer & 0x0f,
@@ -86,7 +86,7 @@ impl EventTrb {
             command_completion_parameter & 0xff000000,
             "command_completion_parameter has to be a 24-bit value."
         );
-        EventTrb::CommandCompletionEvent(CommandCompletionEventTrbData {
+        Self::CommandCompletionEvent(CommandCompletionEventTrbData {
             command_trb_pointer,
             command_completion_parameter,
             completion_code,
@@ -127,13 +127,13 @@ impl EventTrb {
     ///
     /// - `port_id`: The number of the root hub port that generated this
     ///   event.
-    pub fn new_port_status_change_event_trb(port_id: u8) -> EventTrb {
-        EventTrb::PortStatusChangeEvent(PortStatusChangeEventTrbData { port_id })
+    pub const fn new_port_status_change_event_trb(port_id: u8) -> Self {
+        Self::PortStatusChangeEvent(PortStatusChangeEventTrbData { port_id })
     }
 }
 
 impl PortStatusChangeEventTrbData {
-    fn to_bytes(&self) -> [u8; 16] {
+    const fn to_bytes(&self) -> [u8; 16] {
         let mut bytes = [0; 16];
 
         bytes[3] = self.port_id;

--- a/src/device/register_set.rs
+++ b/src/device/register_set.rs
@@ -41,7 +41,7 @@ impl<const SIZE: usize> RegisterSetBuilder<SIZE> {
     /// Initialize a builder for a fully read-only MMIO region where
     /// all bits are set.
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             data: [0xFF; SIZE],
             rw_mask: [0; SIZE],
@@ -248,8 +248,7 @@ impl<const SIZE: usize> RegisterSetBuilder<SIZE> {
                 let overlap = rw_mask & w1c_mask;
                 assert_eq!(
                     overlap, 0,
-                    "Writable and W1C bits overlap in register set at offset {:#x}: {:#x}",
-                    offset, overlap
+                    "Writable and W1C bits overlap in register set at offset {offset:#x}: {overlap:#x}",
                 );
             });
 

--- a/src/dynamic_bus.rs
+++ b/src/dynamic_bus.rs
@@ -29,12 +29,14 @@ impl DynamicBus {
         for segment in segments.iter() {
             new_bus.add(segment.start_addr, segment.device.clone())?;
         }
-        // release lock early
-        drop(segments);
 
         // It's okay to use store here, because we only have a single
         // writer (serialized by the mutex).
         self.bus.store(Arc::new(new_bus));
+
+        // Silence clippy: we want updates to `self.bus` also to be synchronized
+        // by the Mutex.
+        drop(segments);
 
         Ok(())
     }

--- a/src/dynamic_bus.rs
+++ b/src/dynamic_bus.rs
@@ -29,6 +29,8 @@ impl DynamicBus {
         for segment in segments.iter() {
             new_bus.add(segment.start_addr, segment.device.clone())?;
         }
+        // release lock early
+        drop(segments);
 
         // It's okay to use store here, because we only have a single
         // writer (serialized by the mutex).

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,16 @@
+#![deny(
+    clippy::all,
+    clippy::cargo,
+    clippy::nursery,
+    clippy::must_use_candidate
+)]
+// now allow a few rules which are denied by the above's statement
+#![allow(clippy::multiple_crate_versions)]
+#![deny(missing_debug_implementations)]
+#![deny(rustdoc::all)]
+
+//! usbvfiod
+
 mod cli;
 mod device;
 mod dynamic_bus;

--- a/src/memory_segment.rs
+++ b/src/memory_segment.rs
@@ -40,9 +40,9 @@ impl TryFrom<DmaMapFlags> for AccessRights {
         }
 
         if readable && !writable {
-            Ok(AccessRights::ReadOnly)
+            Ok(Self::ReadOnly)
         } else if readable && writable {
-            Ok(AccessRights::ReadWrite)
+            Ok(Self::ReadWrite)
         } else {
             // Not readable?
             Err(DmaMapFlagsError::InvalidFlags { value })
@@ -57,17 +57,18 @@ enum Mapping {
 }
 
 impl Mapping {
+    #[allow(clippy::missing_const_for_fn)] // false positive
     fn as_ptr(&self) -> *const u8 {
         match self {
-            Mapping::ReadOnly(map) => map.as_ptr(),
-            Mapping::ReadWrite(map) => map.as_ptr(),
+            Self::ReadOnly(map) => map.as_ptr(),
+            Self::ReadWrite(map) => map.as_ptr(),
         }
     }
 
-    fn is_writable(&self) -> bool {
+    const fn is_writable(&self) -> bool {
         match self {
-            Mapping::ReadWrite(_) => true,
-            Mapping::ReadOnly(_) => false,
+            Self::ReadWrite(_) => true,
+            Self::ReadOnly(_) => false,
         }
     }
 }
@@ -91,7 +92,7 @@ impl MemorySegment {
         size: u64,
         access_rights: AccessRights,
     ) -> Result<Self, std::io::Error> {
-        Ok(MemorySegment {
+        Ok(Self {
             size,
             mapping: Arc::new({
                 let mut mmap = MmapOptions::new();


### PR DESCRIPTION
**First of all: Please consider this as optional.** I did this in a 10min break mostly with the help of automation. I think it is cool and worth it.

---

This adds a treewide improvement of the code quality by activating many sensible clippy lints. >90% of the changes were done automatically by using: `clippy --fix --all-targets --all-features`

It is a quick win and make the code quality more sustainable and robust.