### PR TITLE
xhci_backend: add memory barrier before interrupt

### DIFF
--- a/src/xhci_backend.rs
+++ b/src/xhci_backend.rs
@@ -41,6 +41,10 @@ struct InterruptEventFd {
 
 impl InterruptLine for InterruptEventFd {
     fn interrupt(&self) {
+        // Ensure all guest memory modifications can be observed by another process.
+        // The sequentially consistent fence emits a hardware memory barrier operation.
+        std::sync::atomic::fence(std::sync::atomic::Ordering::SeqCst);
+
         // Write any 8 byte value to the EventFd.
         // TODO: we just expect this to always work currently.
         let _amount = self


### PR DESCRIPTION
Ensure all guest memory modifications are realized before raising the interrupt to the guest.

This is most likely not needed, as the read/write system calls on the `EventFd` are supposed to act as a sufficient barrier. Guest kernel drivers will expect "DMA IO semantics" from the device, and will employ sufficient barriers (`dma_rmb()` / `dma_wmb()`). Let's add the explicit synchronization and see if it has measurable impact later on.


FYI: this inserts an `mfence` instruction in the `x86_64` release build.
