### PR TITLE
Rework CommandTrb, TransferTrb, UsbRequest

### DIFF
--- a/src/device/pci/rings.rs
+++ b/src/device/pci/rings.rs
@@ -9,7 +9,7 @@ use tracing::{debug, trace, warn};
 
 use super::{
     device_slots::EndpointContext,
-    trb::{CommandTrb, CommandTrbVariant, EventTrb, RawTrbBuffer, TransferTrb, TrbParseError},
+    trb::{CommandTrb, CommandTrbVariant, EventTrb, RawTrbBuffer, TransferTrb, TransferTrbVariant},
     usbrequest::UsbRequest,
 };
 
@@ -386,36 +386,39 @@ impl TransferRing {
 
     /// Try to retrieve a new TRB from a transfer ring.
     ///
-    /// This function only returns `TransferTrb`s that represent commands that
-    /// are not Link TRBs. Instead, Link TRBs are handled correctly, which is
-    /// the reason why the function might read two TRBs to return a single one.
-    pub fn next_transfer_trb(&self) -> Option<(u64, Result<TransferTrb, TrbParseError>)> {
+    /// This function only returns `TransferTrb`s that are not Link TRBs.
+    /// Instead, Link TRBs are handled correctly, which is the reason why the
+    /// function might read two TRBs to return a single one.
+    pub fn next_transfer_trb(&self) -> Option<TransferTrb> {
         let (mut dequeue_pointer, mut cycle_state) =
             self.endpoint_context.get_dequeue_pointer_and_cycle_state();
         // retrieve TRB at dequeue pointer and return None if there is no fresh
         // TRB
-        let first_trb_result = self.next_trb()?;
-        // special handling for Link TRBs
-        let trb_result = if let Ok(TransferTrb::Link(link_data)) = first_trb_result {
-            // encountered Link TRB
-            // update transfer ring status
-            dequeue_pointer = link_data.ring_segment_pointer;
-            if link_data.toggle_cycle {
-                cycle_state = !cycle_state;
+        let first_trb_buffer = self.next_trb_buffer()?;
+        let first_trb = TransferTrbVariant::parse(first_trb_buffer);
+
+        let final_trb = match first_trb {
+            TransferTrbVariant::Link(link_data) => {
+                // encountered Link TRB
+                // update transfer ring status
+                dequeue_pointer = link_data.ring_segment_pointer;
+                if link_data.toggle_cycle {
+                    cycle_state = !cycle_state;
+                }
+                self.endpoint_context
+                    .set_dequeue_pointer_and_cycle_state(dequeue_pointer, cycle_state);
+                // lookup first TRB in the new memory segment
+                let second_trb_buffer = self.next_trb_buffer()?;
+                let second_trb = TransferTrbVariant::parse(second_trb_buffer);
+                if matches!(second_trb, TransferTrbVariant::Link(_)) {
+                    panic!("Link TRB should not follow directly after another Link TRB");
+                }
+                second_trb
             }
-            self.endpoint_context
-                .set_dequeue_pointer_and_cycle_state(dequeue_pointer, cycle_state);
-            // lookup first TRB in the new memory segment
-            let second_trb_result = self.next_trb()?;
-            if let Ok(TransferTrb::Link(_)) = second_trb_result {
-                panic!("Link TRB should not follow directly after another Link TRB");
-            }
-            second_trb_result
-        } else {
-            first_trb_result
+            _ => first_trb,
         };
 
-        let trb_address = dequeue_pointer;
+        let address = dequeue_pointer;
 
         // advance to next TRB
         dequeue_pointer += TRB_SIZE as u64;
@@ -423,7 +426,10 @@ impl TransferRing {
             .set_dequeue_pointer_and_cycle_state(dequeue_pointer, cycle_state);
 
         // return parsed result
-        Some((trb_address, trb_result))
+        Some(TransferTrb {
+            address,
+            variant: final_trb,
+        })
     }
 
     /// Try to retrieve a new TRB from a transfer ring.
@@ -431,7 +437,7 @@ impl TransferRing {
     /// If there is a fresh TRB at the dequeue pointer, the function tries to
     /// parse the transfer TRB and returns the result. If there is a fresh Link
     /// TRB, this function will return it!
-    fn next_trb(&self) -> Option<Result<TransferTrb, TrbParseError>> {
+    fn next_trb_buffer(&self) -> Option<RawTrbBuffer> {
         let (dequeue_pointer, cycle_state) =
             self.endpoint_context.get_dequeue_pointer_and_cycle_state();
         // retrieve TRB at current dequeue_pointer
@@ -450,10 +456,8 @@ impl TransferRing {
             return None;
         }
 
-        // TRB is fresh; try to parse
-        let trb_result = TransferTrb::try_from(trb_buffer);
-
-        Some(trb_result)
+        // TRB is fresh; return it
+        Some(trb_buffer)
     }
 
     /// Retrieve the next USB control request from a transfer ring.
@@ -469,21 +473,14 @@ impl TransferRing {
     /// partial requests is a valid scenario (and we would have to wait for
     /// the driver to write the missing TRBs).
     pub fn next_request(&self) -> Option<Result<(u64, UsbRequest), RequestParseError>> {
-        let first_trb = self.next_transfer_trb();
-        let setup_trb_data = match first_trb {
-            None => {
-                // no TRB available -> no request available
-                return None;
-            }
-            Some((_, Err(err))) => {
-                // got a erroneous TRB, pass error on
-                return Some(Err(RequestParseError::TrbParseError(err)));
-            }
-            Some((_, Ok(TransferTrb::SetupStage(data)))) => {
+        let first_trb = self.next_transfer_trb()?;
+
+        let setup_trb_data = match first_trb.variant {
+            TransferTrbVariant::SetupStage(data) => {
                 // happy case, we got a Setup Stage TRB
                 data
             }
-            Some((_, Ok(trb))) => {
+            trb => {
                 // got some TRB, but not a Setup Stage
                 return Some(Err(RequestParseError::UnexpectedTrbType(
                     vec![trb_types::SETUP_STAGE],
@@ -498,29 +495,34 @@ impl TransferRing {
                 // there should follow either Data or Status Stage
                 return Some(Err(RequestParseError::MissingTrb));
             }
-            Some((_, Err(err))) => {
-                // got a erroneous TRB, pass error on
-                return Some(Err(RequestParseError::TrbParseError(err)));
-            }
-            Some((_, Ok(TransferTrb::DataStage(data)))) => {
+            Some(TransferTrb {
+                address: _,
+                variant: TransferTrbVariant::DataStage(data),
+            }) => {
                 // happy case, we got a Data Stage TRB
                 if data.chain {
-                    panic!("encountered DataStage with chain bit set");
+                    todo!("encountered DataStage with chain bit set");
                 }
                 Ok(data)
             }
-            Some((trb_address, Ok(TransferTrb::StatusStage))) => {
+            Some(TransferTrb {
+                address,
+                variant: TransferTrbVariant::StatusStage,
+            }) => {
                 // happy case, we skipped Data Stage TRB and already got Status
                 // Stage.
                 // we indicate the address of the status stage (required for
                 // Transfer Event)
-                Err(trb_address)
+                Err(address)
             }
-            Some((_, Ok(trb))) => {
+            Some(TransferTrb {
+                address: _,
+                variant,
+            }) => {
                 // got some TRB, but neither a Data Stage nor a Status Stage
                 return Some(Err(RequestParseError::UnexpectedTrbType(
                     vec![trb_types::DATA_STAGE, trb_types::STATUS_STAGE],
-                    trb,
+                    variant,
                 )));
             }
         };
@@ -536,19 +538,21 @@ impl TransferRing {
                         // there should follow a Status Stage
                         return Some(Err(RequestParseError::MissingTrb));
                     }
-                    Some((_, Err(err))) => {
-                        // got a erroneous TRB, pass error on
-                        return Some(Err(RequestParseError::TrbParseError(err)));
-                    }
-                    Some((trb_address, Ok(TransferTrb::StatusStage))) => {
+                    Some(TransferTrb {
+                        address,
+                        variant: TransferTrbVariant::StatusStage,
+                    }) => {
                         // happy case, we got a Data Stage TRB
-                        trb_address
+                        address
                     }
-                    Some((_, Ok(trb))) => {
+                    Some(TransferTrb {
+                        address: _,
+                        variant,
+                    }) => {
                         // got some TRB, but not a Status Stage
                         return Some(Err(RequestParseError::UnexpectedTrbType(
                             vec![trb_types::STATUS_STAGE],
-                            trb,
+                            variant,
                         )));
                     }
                 };
@@ -586,10 +590,8 @@ impl TransferRing {
 
 #[derive(Error, Debug)]
 pub enum RequestParseError {
-    #[error("Encountered invalid TRB")]
-    TrbParseError(TrbParseError),
     #[error("Encountered unexpected TRB type. Expected type(s) {0:?}, got TRB {1:?}")]
-    UnexpectedTrbType(Vec<u8>, TransferTrb),
+    UnexpectedTrbType(Vec<u8>, TransferTrbVariant),
     #[error("Expected another TRB, but there was none.")]
     MissingTrb,
 }

--- a/src/device/pci/usbrequest.rs
+++ b/src/device/pci/usbrequest.rs
@@ -1,59 +1,23 @@
+/// Represent a USB control request.
+///
+/// For documentation of the fields other than `address`, see Section "9.3 USB
+/// Device Requests" in the USB 2.0 specification.
+///
+/// A request without data is packaged in two TRBs (a Setup Stage and a
+/// Status Stage). `data` should then be `None`.
+///
+/// A request with data is packaged in three TRBs (a Setup Stage, a Data
+/// Stage and a Status Stage). `data` should then contain the pointer
+/// from the Data Stage).
+///
 #[derive(Debug)]
 pub struct UsbRequest {
+    /// The guest address of the Status Stage of this request.
+    pub address: u64,
     pub request_type: u8,
     pub request: u8,
     pub value: u16,
     pub index: u16,
     pub length: u16,
     pub data: Option<u64>,
-}
-
-impl UsbRequest {
-    /// Create a new instance without data.
-    ///
-    /// A request without data is packaged in two TRBs (a Setup Stage and a
-    /// Status Stage).
-    ///
-    /// # Parameters
-    ///
-    /// For the parameters, see Section "9.3 USB Device Requests" in the USB
-    /// 2.0 specification.
-    pub const fn new(request_type: u8, request: u8, value: u16, index: u16, length: u16) -> Self {
-        Self {
-            request_type,
-            request,
-            value,
-            index,
-            length,
-            data: None,
-        }
-    }
-
-    /// Create a new instance data.
-    ///
-    /// A request with data is packaged in three TRBs (a Setup Stage, a Data
-    /// Stage and a Status Stage). With data means that the request carries a
-    /// pointer to a data buffer in guest memory.
-    ///
-    /// # Parameters
-    ///
-    /// For the parameters, see Section "9.3 USB Device Requests" in the USB
-    /// 2.0 specification.
-    pub const fn new_with_data(
-        request_type: u8,
-        request: u8,
-        value: u16,
-        index: u16,
-        length: u16,
-        data: u64,
-    ) -> Self {
-        Self {
-            request_type,
-            request,
-            value,
-            index,
-            length,
-            data: Some(data),
-        }
-    }
 }

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -266,7 +266,7 @@ impl XhciController {
             .get_device_context(1)
             .get_control_transfer_ring();
 
-        let (address, request) = match transfer_ring.next_request() {
+        let request = match transfer_ring.next_request() {
             None => {
                 // XXX currently, we expect that a doorbell ring always
                 // notifies us about a new control request. We want to
@@ -297,8 +297,14 @@ impl XhciController {
         // TODO forward request to device
 
         // send transfer event
-        let trb =
-            EventTrb::new_transfer_event_trb(address, 0, CompletionCode::Success, false, 1, 1);
+        let trb = EventTrb::new_transfer_event_trb(
+            request.address,
+            0,
+            CompletionCode::Success,
+            false,
+            1,
+            1,
+        );
         self.event_ring.enqueue(&trb);
         self.interrupt_line.interrupt();
         debug!("sent Transfer Event and signaled interrupt");

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -16,7 +16,7 @@ use crate::device::{
             RUN_BASE,
         },
         traits::PciDevice,
-        trb::{CompletionCode, EventTrb},
+        trb::{CommandTrbVariant, CompletionCode, EventTrb},
     },
 };
 
@@ -165,8 +165,8 @@ impl XhciController {
         debug!("Ding Dong!");
         // check command available
         let next = self.command_ring.next_command_trb();
-        if let Some((address, Ok(cmd_trb))) = next {
-            self.handle_command(address, cmd_trb);
+        if let Some(cmd) = next {
+            self.handle_command(cmd);
         } else {
             debug!(
                 "Doorbell was rang, but no (valid) command found on the command ring ({:?})",
@@ -175,42 +175,57 @@ impl XhciController {
         }
     }
 
-    fn handle_command(&mut self, address: u64, cmd: CommandTrb) {
-        debug!("handling command {:?} at {:#x}", cmd, address);
-        let completion_event = match cmd {
-            CommandTrb::EnableSlot => {
+    fn handle_command(&mut self, cmd: CommandTrb) {
+        debug!("handling command {:?} at {:#x}", cmd, cmd.address);
+        let completion_event = match cmd.variant {
+            CommandTrbVariant::EnableSlot => {
                 let (completion_code, slot_id) = self.handle_enable_slot();
-                EventTrb::new_command_completion_event_trb(address, 0, completion_code, slot_id)
+                EventTrb::new_command_completion_event_trb(cmd.address, 0, completion_code, slot_id)
             }
-            CommandTrb::DisableSlot => {
+            CommandTrbVariant::DisableSlot => {
                 // TODO this command probably requires more handling.
                 // Currently, we just acknowledge to not crash usbvfiod in the
                 // integration test.
-                EventTrb::new_command_completion_event_trb(address, 0, CompletionCode::Success, 1)
+                EventTrb::new_command_completion_event_trb(
+                    cmd.address,
+                    0,
+                    CompletionCode::Success,
+                    1,
+                )
             }
-            CommandTrb::AddressDevice(data) => {
+            CommandTrbVariant::AddressDevice(data) => {
                 self.handle_address_device(&data);
                 EventTrb::new_command_completion_event_trb(
-                    address,
+                    cmd.address,
                     0,
                     CompletionCode::Success,
                     data.slot_id,
                 )
             }
-            CommandTrb::ConfigureEndpoint => todo!(),
-            CommandTrb::EvaluateContext => todo!(),
-            CommandTrb::ResetEndpoint => todo!(),
-            CommandTrb::StopEndpoint => {
+            CommandTrbVariant::ConfigureEndpoint => todo!(),
+            CommandTrbVariant::EvaluateContext => todo!(),
+            CommandTrbVariant::ResetEndpoint => todo!(),
+            CommandTrbVariant::StopEndpoint => {
                 // TODO this command probably requires more handling.
                 // Currently, we just acknowledge to not crash usbvfiod in the
                 // integration test.
-                EventTrb::new_command_completion_event_trb(address, 0, CompletionCode::Success, 1)
+                EventTrb::new_command_completion_event_trb(
+                    cmd.address,
+                    0,
+                    CompletionCode::Success,
+                    1,
+                )
             }
-            CommandTrb::SetTrDequeuePointer => todo!(),
-            CommandTrb::ResetDevice => todo!(),
-            CommandTrb::ForceHeader => todo!(),
-            CommandTrb::NoOp => todo!(),
-            CommandTrb::Link(_) => unreachable!(),
+            CommandTrbVariant::SetTrDequeuePointer => todo!(),
+            CommandTrbVariant::ResetDevice => todo!(),
+            CommandTrbVariant::ForceHeader => todo!(),
+            CommandTrbVariant::NoOp => todo!(),
+            CommandTrbVariant::Link(_) => unreachable!(),
+            CommandTrbVariant::Unrecognized(trb_buffer, error) => todo!(
+                "encountered unrecognized command (error: {}, trb: {:?})",
+                error,
+                trb_buffer
+            ),
         };
         self.event_ring.enqueue(&completion_event);
         self.interrupt_line.interrupt();


### PR DESCRIPTION
The functions `CommandRing::next_command_trb` and `TransferRing::next_transfer_trb` return complex types (e.g., `Option<(u64, Result<CommandTrb, TrbParseError)>`). There are reasons for all the included types:

- `Option` gives the possibility to encode that there is no new TRB on the ring.
- `u64` is the address of the TRB, which is needed (for Command TRBs and Status Stage Transfer TRBs) to indicate the driver that the command or transfer has been completed.
- `Result` has to represent the case that the function could not properly parse the fresh TRB.

This PR simplifies the types and thus also the related code by
- including the address into the `CommandTrb` and `TransferTrb` types (both types were enums so far. To include an additional field for all enum variants, `.*Trb` was renamed to `.*TrbVariant` and we introduce new structs `.*Trb` that include the variant and the address).
- introducing a variant `Unrecognized`, which encodes the parsing error internally.

Of course, this PR also adapts the code in xhci.rs and rings.rs that uses these types. 

Further, the guest address of `UsbRequest` was also moved from being tagged on with a tuple to inside the `UsbRequest`.