### PR TITLE
Add unit test for retrieving requests from the transfer ring

### DIFF
--- a/src/device/pci/device_slots.rs
+++ b/src/device/pci/device_slots.rs
@@ -243,7 +243,7 @@ impl EndpointContext {
     ///
     /// - address: the address of the endpoint context in guest memory.
     /// - dma_bus: reference to the guest memory.
-    const fn new(address: u64, dma_bus: BusDeviceRef) -> Self {
+    pub const fn new(address: u64, dma_bus: BusDeviceRef) -> Self {
         Self { address, dma_bus }
     }
 

--- a/src/device/pci/rings.rs
+++ b/src/device/pci/rings.rs
@@ -589,7 +589,7 @@ impl TransferRing {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum RequestParseError {
     #[error("Encountered unexpected TRB type. Expected type(s) {0:?}, got TRB {1:?}")]
     UnexpectedTrbType(Vec<u8>, TransferTrbVariant),

--- a/src/device/pci/rings.rs
+++ b/src/device/pci/rings.rs
@@ -766,4 +766,126 @@ mod tests {
             panic!("Expected to parse a NoOpCommand, instead got: {:?}", trb);
         }
     }
+
+    // test summary:
+    //
+    // This test checks the parsing of USB control requests from two and
+    // three TRBs as well as correct handling of wrap around/Link TRBs.
+    //
+    // steps:
+    //
+    // - transfer ring with 5 TRBs
+    // - prepare
+    //   [Setup Stage] [Data Stage] [Status Stage] [non-fresh TRB] [non-fresh TRB]
+    // - request should be parsed from the three TRBs
+    // - prepare
+    //   [Status Stage] [non-fresh TRB] [non-fresh TRB] [Setup Stage] [Link]
+    // - request should be parsed from the two TRBs
+    #[test]
+    fn transfer_ring_retrieve_control_requests() {
+        let setup = [
+            0x11, 0x22, 0x44, 0x33, 0x66, 0x55, 0x88, 0x77, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08,
+            0x00, 0x00,
+        ];
+        let data = [
+            0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c,
+            0x00, 0x00,
+        ];
+        let status = [
+            0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x10, 0x0, 0x0,
+        ];
+        let link = [
+            0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2, 0x18, 0x0, 0x0,
+        ];
+
+        // construct memory segment for a ring that can contain 5 TRBs and an endpoint context
+        let ram = Arc::new(TestingRamDevice::new(&[0; TRB_SIZE * 5 + 32]));
+        let offset_ep_context = TRB_SIZE as u64 * 5;
+        // setup dequeue pointer and cycle state in the endpoint context
+        // (dequeue pointer is 0, thus only setting cycle bit)
+        ram.write_bulk(offset_ep_context + 8, &[0x1]);
+        let ep = EndpointContext::new(offset_ep_context, ram.clone());
+        let transfer_ring = TransferRing::new(ep, ram.clone());
+
+        // the ring is still empty
+        let request = transfer_ring.next_request();
+        assert!(
+            request.is_none(),
+            "When no fresh request is on the transfer ring, next_request should return None, instead got: {:?}",
+            request
+        );
+
+        // place first request
+        // place setup
+        ram.write_bulk(0, &setup);
+        // set cycle bit
+        ram.write_bulk(12, &[0x1]);
+
+        // place data
+        ram.write_bulk(TRB_SIZE as u64, &data);
+        ram.write_bulk(TRB_SIZE as u64 + 12, &[0x1]);
+
+        // place status
+        ram.write_bulk(TRB_SIZE as u64 * 2, &status);
+        ram.write_bulk(TRB_SIZE as u64 * 2 + 12, &[0x1]);
+
+        // ring abstraction should parse correctly
+        let expected = Some(Ok(UsbRequest {
+            address: TRB_SIZE as u64 * 2,
+            request_type: 0x11,
+            request: 0x22,
+            value: 0x3344,
+            index: 0x5566,
+            length: 0x7788,
+            data: Some(0x1122334455667788),
+        }));
+        let actual = transfer_ring.next_request();
+        assert_eq!(expected, actual);
+
+        // no new command placed, should return no new command
+        let request = transfer_ring.next_request();
+        assert!(
+            request.is_none(),
+            "When no fresh request is on the transfer ring, next_request should return None, instead got: {:?}",
+            request
+        );
+
+        // place second request (include link TRB because the ring needs to
+        // wrap around)
+        // place setup
+        ram.write_bulk(TRB_SIZE as u64 * 3, &setup);
+        ram.write_bulk(TRB_SIZE as u64 * 3 + 12, &[0x1]);
+
+        // place link
+        ram.write_bulk(TRB_SIZE as u64 * 4, &link);
+        ram.write_bulk(TRB_SIZE as u64 * 4 + 12, &[0x1]);
+        // set cycle bit without affecting the toggle_cycle bit
+        ram.write_bulk(TRB_SIZE as u64 * 4 + 12, &[0x1 | link[12]]);
+
+        // place status
+        ram.write_bulk(0, &status);
+        // wrap around---cycle bit now needs to be 0
+        ram.write_bulk(0, &[0x0]);
+
+        // ring abstraction should parse correctly
+        let expected = Some(Ok(UsbRequest {
+            address: 0,
+            request_type: 0x11,
+            request: 0x22,
+            value: 0x3344,
+            index: 0x5566,
+            length: 0x7788,
+            data: None,
+        }));
+        let actual = transfer_ring.next_request();
+        assert_eq!(expected, actual);
+
+        // no new command placed, should return no new command
+        let request = transfer_ring.next_request();
+        assert!(
+            request.is_none(),
+            "When no fresh request is on the transfer ring, next_request should return None, instead got: {:?}",
+            request
+        );
+    }
 }

--- a/src/device/pci/trb.rs
+++ b/src/device/pci/trb.rs
@@ -420,7 +420,7 @@ impl CommandTrbVariant {
 }
 
 /// Custom error type to represent errors in TRB parsing.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkTrbData {
     /// The address of the next ring segment.
     pub ring_segment_pointer: u64,
@@ -523,7 +523,7 @@ pub struct TransferTrb {
 }
 
 /// Represents a TRB that the driver can place on a transfer ring.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TransferTrbVariant {
     Normal,
     SetupStage(SetupStageTrbData),
@@ -566,7 +566,7 @@ impl TransferTrbVariant {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SetupStageTrbData {
     pub request_type: u8,
     pub request: u8,
@@ -609,7 +609,7 @@ impl TrbData for SetupStageTrbData {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct DataStageTrbData {
     pub data_pointer: u64,
     pub chain: bool,
@@ -645,7 +645,7 @@ impl TrbData for DataStageTrbData {
     }
 }
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum TrbParseError {
     #[error("TRB type {0} refers to \"{1}\", which is optional and not supported.")]
     UnsupportedOptionalCommand(u8, String),

--- a/src/device/pci/usbrequest.rs
+++ b/src/device/pci/usbrequest.rs
@@ -10,7 +10,7 @@
 /// Stage and a Status Stage). `data` should then contain the pointer
 /// from the Data Stage).
 ///
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct UsbRequest {
     /// The guest address of the Status Stage of this request.
     pub address: u64,


### PR DESCRIPTION
The tests checks whether `TransferRing::next_request` can

- correctly parse a request out of three TRBs (setup stage + data stage + status stage)
- correctly parse a request out of two TRBs (setup stage + status stage)
- correctly handles ring wrap-arounds/Link TRBs

The test indirectly also tests the underlying `TransferRing::next_transfer_trb` function.

A few changes outside the test were necessary:

- added `derive(PartialEq, Eq)` to a number of types to make the return value of `TransferRing::next_request` usable with `assert_eq!`
- `EndpointContext::new` needs to be public so that the test can construct an endpoint context without going the whole `DeviceContext` setup process.
- Added non-bulk reads and writes to the testing RAM device, because the endpoint context retrieves and sets the the dequeue pointer of the transfer ring using non-bulk reads and writes.