### PR TITLE
Use wrapping_add to calculate DMA addresses

### DIFF
--- a/docs/developers/guidelines.md
+++ b/docs/developers/guidelines.md
@@ -13,9 +13,4 @@ operation, only when the USB driver in the guest wants to shoot
 itself in the foot. In such cases, we want to behave like a physical
 XHCI controller and wrap around.
 
-If we used normal calculations, the behavior in overflow situations
-would differ between builds:
-
-- debug builds crash when an overflow occurs due to inserted overflow
-checks
-- release build perform wrap-around on overflow
+Explicitly treating the calculations as wrapping aligns the behavior between debug and release builds.

--- a/docs/developers/guidelines.md
+++ b/docs/developers/guidelines.md
@@ -1,0 +1,21 @@
+# Code Guidelines
+
+This document lists code design and style choices that developers
+should adhere to when modifying or extending the source code.
+
+## DMA Address Calculations 
+
+When calculating DMA addresses to access guest memory, you should use
+wrap-around calculations such as `u64::wrapping_add`.
+
+Overflows in addresses calculations should not occur during normal
+operation, only when the USB driver in the guest wants to shoot
+itself in the foot. In such cases, we want to behave like a physical
+XHCI controller and wrap around.
+
+If we used normal calculations, the behavior in overflow situations
+would differ between builds:
+
+- debug builds crash when an overflow occurs due to inserted overflow
+checks
+- release build perform wrap-around on overflow

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,3 +10,4 @@ professional support.
 ## For Developers
 
 - [Architecture Overview](./developers/architecture.md)
+- [Code Guidelines](./developers/guidelines.md)


### PR DESCRIPTION
Previously, when using normal additions to calculate DMA addresses, behavior differed between builds:

- debug builds crash when an overflow occurs due to inserted overflow
checks
- release build perform wrap-around on overflow

This PR introduces `u64::wrapping_add` for wrap-around behavior, just as a real controller most likely has, and adds a note for future contributions in the developer guidelines. 

Note: wrapping of addresses should not occur during normal operation, only when the USB driver in the guest wants to shoot itself in the foot.