### PR TITLE
Derive standard traits in all custom types and create note in developer guidelines

### DIFF
--- a/docs/developers/guidelines.md
+++ b/docs/developers/guidelines.md
@@ -40,3 +40,4 @@ For consistency and readability, follow this trait order when deriving multiple 
 
 ```rust
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+```

--- a/docs/developers/guidelines.md
+++ b/docs/developers/guidelines.md
@@ -14,3 +14,29 @@ itself in the foot. In such cases, we want to behave like a physical
 XHCI controller and wrap around.
 
 Explicitly treating the calculations as wrapping aligns the behavior between debug and release builds.
+
+## Trait Derivations
+
+Deriving standard traits improves debuggability, testability, and code clarity. While not strictly mandatory, developers are encouraged to apply them where safe and semantically appropriate.
+
+- **Always derive `Debug`**  
+  Include `#[derive(Debug)]` for all structs and enums to enable diagnostic output and logging.
+
+- **Derive `Clone` or `Copy`**  
+  Use `Copy` only for small types with trivial duplication semantics (e.g., numeric types). Use `Clone` for safe but potentially more complex duplication.  
+  _Avoid both_ if the type encapsulates ownership-sensitive resources (e.g., file handles, raw pointers, custom lifetimes).
+
+- **Derive `PartialEq`, `Eq`**  
+  Enable equality checks, especially useful in test assertions and control logic. Only add when comparisons are semantically meaningful.
+
+- **Derive `Default`**  
+  Provide `Default` when a clear and unambiguous zero-configuration or initial state exists.
+
+Derives may be added proactively for likely future needs (e.g., test support or logging), provided they don’t introduce ambiguity or misuse.
+
+### Recommended Derive Order
+
+For consistency and readability, follow this trait order when deriving multiple traits:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,7 @@ pub struct Cli {
 }
 
 /// The location of the server socket for the vfio-user client connection.
+#[derive(Debug, Clone, Copy)]
 pub enum ServerSocket<'a> {
     /// The socket is already open.
     #[allow(dead_code)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,7 +47,7 @@ pub struct Cli {
 }
 
 /// The location of the server socket for the vfio-user client connection.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub enum ServerSocket<'a> {
     /// The socket is already open.
     #[allow(dead_code)]

--- a/src/device/bus.rs
+++ b/src/device/bus.rs
@@ -450,7 +450,7 @@ impl Default for Bus {
 /// Information for a single bulk request to a specific device.
 ///
 /// See [`Bus::iter_bulk_request`].
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 struct BulkRequestChunk<'a> {
     /// The device to perform the bulk request on.
     device: &'a dyn BusDevice,
@@ -465,6 +465,7 @@ struct BulkRequestChunk<'a> {
 /// An iterator to split bulk requests.
 ///
 /// See [`Bus::iter_bulk_request`].
+#[derive(Debug)]
 struct BulkRequestIterator<'a> {
     bus: &'a Bus,
 

--- a/src/device/bus.rs
+++ b/src/device/bus.rs
@@ -931,7 +931,7 @@ mod tests {
 
     /// A device that asserts all read and write requests are
     /// for a configured address. It returns constant 0 on read.
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     struct AddressCheckDevice {
         expected_address: u64,
         size: u64,

--- a/src/device/bus.rs
+++ b/src/device/bus.rs
@@ -772,7 +772,7 @@ mod tests {
 
     /// A device that returns a constant value for all read requests
     /// and expects all writes to have that value as well.
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     struct ConstDevice {
         value: u64,
         size: u64,

--- a/src/device/pci/device_slots.rs
+++ b/src/device/pci/device_slots.rs
@@ -285,7 +285,7 @@ mod tests {
 
     use super::*;
 
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct DummyMemory {}
 
     impl BusDevice for DummyMemory {

--- a/src/device/pci/device_slots.rs
+++ b/src/device/pci/device_slots.rs
@@ -304,7 +304,7 @@ mod tests {
     fn device_slot_reservation() {
         // we test with only one device slot, because that case is currently
         // what we run with
-        let mut device_slot_manager = DeviceSlotManager::new(1, Arc::new(DummyMemory {}));
+        let mut device_slot_manager = DeviceSlotManager::new(1, Arc::new(DummyMemory::default()));
 
         // reserve the only slot
         assert_eq!(Some(1), device_slot_manager.reserve_slot());

--- a/src/device/pci/msix_table.rs
+++ b/src/device/pci/msix_table.rs
@@ -35,7 +35,7 @@ pub const CONTROL_MASKED: u32 = 1 << 0;
 /// Due to [limitations](https://github.com/rust-lang/rust/issues/44580) in Rust's generic
 /// programming, this type has to be instantiated with the **size in bytes** instead of the number
 /// of desired vectors.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MsixTable<const SIZE_BYTES: usize> {
     registers: RegisterSet<{ SIZE_BYTES }>,
 }

--- a/src/device/pci/rings.rs
+++ b/src/device/pci/rings.rs
@@ -30,7 +30,7 @@ use crate::device::{
 /// This implementation is a simplified version of the full mechanism specified
 /// in the XHCI specification. We assume that the Event Ring Segment Table only
 /// holds a single segment.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct EventRing {
     /// Access to guest memory.
     ///
@@ -191,7 +191,7 @@ impl EventRing {
 
 /// The Command Ring: A unidirectional means of communication, allowing the
 /// driver to send commands to the XHCI controller.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CommandRing {
     /// Access to guest memory.
     ///

--- a/src/device/pci/rings.rs
+++ b/src/device/pci/rings.rs
@@ -680,16 +680,11 @@ mod tests {
         ram.write_bulk(12, &[0x1]);
 
         // ring abstraction should parse correctly
-        let trb = command_ring.next_command_trb();
-        if let Some(CommandTrb {
-            address,
+        let expected = Some(CommandTrb {
+            address: 0,
             variant: CommandTrbVariant::NoOp,
-        }) = trb
-        {
-            assert_eq!(0, address, "incorrect address of the next TRB returned");
-        } else {
-            panic!("Expected to parse a NoOpCommand, instead got: {:?}", trb);
-        }
+        });
+        assert_eq!(command_ring.next_command_trb(), expected);
 
         // no new command placed, should return no new command
         let trb = command_ring.next_command_trb();
@@ -706,28 +701,18 @@ mod tests {
         ram.write_bulk(32 + 12, &[0x1]);
 
         // parse first noop
-        let trb = command_ring.next_command_trb();
-        if let Some(CommandTrb {
-            address,
+        let expected = Some(CommandTrb {
+            address: 16,
             variant: CommandTrbVariant::NoOp,
-        }) = trb
-        {
-            assert_eq!(16, address, "incorrect address of the next TRB returned");
-        } else {
-            panic!("Expected to parse a NoOpCommand, instead got: {:?}", trb);
-        }
+        });
+        assert_eq!(command_ring.next_command_trb(), expected);
 
         // parse second noop
-        let trb = command_ring.next_command_trb();
-        if let Some(CommandTrb {
-            address,
+        let expected = Some(CommandTrb {
+            address: 32,
             variant: CommandTrbVariant::NoOp,
-        }) = trb
-        {
-            assert_eq!(32, address, "incorrect address of the next TRB returned");
-        } else {
-            panic!("Expected to parse a NoOpCommand, instead got: {:?}", trb);
-        }
+        });
+        assert_eq!(command_ring.next_command_trb(), expected);
 
         // no new command placed, should return no new command
         let trb = command_ring.next_command_trb();
@@ -757,16 +742,11 @@ mod tests {
         ram.write_bulk(12, &[0x0]);
 
         // parse refreshed noop
-        let trb = command_ring.next_command_trb();
-        if let Some(CommandTrb {
-            address,
+        let expected = Some(CommandTrb {
+            address: 0,
             variant: CommandTrbVariant::NoOp,
-        }) = trb
-        {
-            assert_eq!(0, address, "incorrect address of the next TRB returned");
-        } else {
-            panic!("Expected to parse a NoOpCommand, instead got: {:?}", trb);
-        }
+        });
+        assert_eq!(command_ring.next_command_trb(), expected);
     }
 
     // test summary:

--- a/src/device/pci/trb.rs
+++ b/src/device/pci/trb.rs
@@ -464,7 +464,7 @@ impl TrbData for LinkTrbData {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AddressDeviceCommandTrbData {
     /// The address of the input context.
     pub input_context_pointer: u64,

--- a/src/memory_segment.rs
+++ b/src/memory_segment.rs
@@ -74,7 +74,7 @@ impl Mapping {
 }
 
 /// A contiguous piece of mmap'ed memory.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MemorySegment {
     size: u64,
     mapping: Arc<Mapping>,


### PR DESCRIPTION
### Reason for this PR
Streamline the codebase by keeping only the trait derives that are truly needed—reducing boilerplate, preventing unintended copies of stateful structs, and clarifying our guidelines for future contributors.
### Changes in this PR

- Removed redundant derives

    Eliminated several unused Clone annotations from state‑bearing structs (e.g., memory segments, rings, registers) to avoid accidental copying.

-  Added essential derives

    Supplied `Debug`, `PartialEq`, `Eq`, or `Copy `+` Clone` only where testing, logging, or lightweight value semantics genuinely require them.

- Documentation update

    Expanded `guidelines.md` with a concise “Trait Derivations” section that clarifies when each common derive should or shouldn’t be used.
### Test
All changes compile and unit tests pass locally (`cargo check`, `cargo test`).