### PR TITLE
Parse Stop Endpoint Command

### DIFF
--- a/src/device/pci/trb.rs
+++ b/src/device/pci/trb.rs
@@ -696,7 +696,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_enable_slot_command_trb() {
+    fn parse_enable_slot_command_trb() {
         let trb_bytes = [
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x24,
             0x00, 0x00,
@@ -706,7 +706,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_link_trb_as_command() {
+    fn parse_link_trb_as_command() {
         let trb_bytes = [
             0x80, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00, 0x00, 0x00, 0x00, 0x02, 0x18,
             0x00, 0x00,
@@ -719,7 +719,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_address_device_command_trb() {
+    fn parse_address_device_command_trb() {
         let trb_bytes = [
             0x80, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00, 0x00, 0x00, 0x00, 0x02, 0x2e,
             0x00, 0x13,
@@ -733,7 +733,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_stop_endpoint_command_trb() {
+    fn parse_stop_endpoint_command_trb() {
         let trb_bytes = [
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3c,
             0x02, 0x10,
@@ -746,7 +746,7 @@ mod tests {
     }
 
     #[test]
-    fn test_command_completion_event_trb() {
+    fn command_completion_event_trb() {
         let trb = EventTrb::new_command_completion_event_trb(
             0x1122334455667780,
             0xaabbcc,
@@ -763,7 +763,7 @@ mod tests {
     }
 
     #[test]
-    fn test_port_status_change_event_trb() {
+    fn port_status_change_event_trb() {
         let trb = EventTrb::new_port_status_change_event_trb(2);
         assert_eq!(
             [

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -226,15 +226,16 @@ impl XhciController {
             }
             CommandTrbVariant::EvaluateContext => todo!(),
             CommandTrbVariant::ResetEndpoint => todo!(),
-            CommandTrbVariant::StopEndpoint => {
+            CommandTrbVariant::StopEndpoint(data) => {
                 // TODO this command probably requires more handling.
                 // Currently, we just acknowledge to not crash usbvfiod in the
                 // integration test.
+                let _ = data.endpoint_id;
                 EventTrb::new_command_completion_event_trb(
                     cmd.address,
                     0,
                     CompletionCode::Success,
-                    1,
+                    data.slot_id,
                 )
             }
             CommandTrbVariant::SetTrDequeuePointer => todo!(),


### PR DESCRIPTION
Fully parse the Stop Endpoint Command.

I currently (during my endpoint configuration experiments) would like the information about the `endpoint_id` encoded in a Stop Endpoint Command. Because the functionality can stand on its own and will be needed later, I put it into this smaller PR.

Additionally, the PR aligns the names of the tests in `trb.rs` with the test names in the rest of the project.