### PR TITLE
tests: normalize assert_eq! order to (actual, expected)

### DIFF
--- a/src/device/pci/device_slots.rs
+++ b/src/device/pci/device_slots.rs
@@ -307,9 +307,9 @@ mod tests {
         let mut device_slot_manager = DeviceSlotManager::new(1, Arc::new(DummyMemory::default()));
 
         // reserve the only slot
-        assert_eq!(Some(1), device_slot_manager.reserve_slot());
+        assert_eq!(device_slot_manager.reserve_slot(), Some(1));
 
         // reserving another slot should fail
-        assert_eq!(None, device_slot_manager.reserve_slot());
+        assert_eq!(device_slot_manager.reserve_slot(), None);
     }
 }

--- a/src/device/pci/registers.rs
+++ b/src/device/pci/registers.rs
@@ -48,33 +48,33 @@ mod tests {
     #[test]
     fn portsc_read_write() {
         let mut reg = PortscRegister::new(0x00260203);
-        assert_eq!(0x00260203, reg.read());
+        assert_eq!(reg.read(), 0x00260203);
 
         reg.write(0x0);
         assert_eq!(
-            0x00260203,
             reg.read(),
+            0x00260203,
             "writing 0 should affect neither the read-only nor the RW1C bits."
         );
 
         reg.write(0x00200000);
         assert_eq!(
-            0x00060203,
             reg.read(),
+            0x00060203,
             "writing 1 to bit 21 should clear the bit."
         );
 
         reg.write(0x00040000);
         assert_eq!(
-            0x00020203,
             reg.read(),
+            0x00020203,
             "writing 1 to bit 18 should clear the bit."
         );
 
         reg.write(0x00020000);
         assert_eq!(
-            0x00000203,
             reg.read(),
+            0x00000203,
             "writing 1 to bit 17 should clear the bit."
         );
     }

--- a/src/device/pci/rings.rs
+++ b/src/device/pci/rings.rs
@@ -821,8 +821,7 @@ mod tests {
             length: 0x7788,
             data: Some(0x1122334455667788),
         }));
-        let actual = transfer_ring.next_request();
-        assert_eq!(expected, actual);
+        assert_eq!(transfer_ring.next_request(), expected);
 
         // no new command placed, should return no new command
         let request = transfer_ring.next_request();
@@ -859,8 +858,7 @@ mod tests {
             length: 0x7788,
             data: None,
         }));
-        let actual = transfer_ring.next_request();
-        assert_eq!(expected, actual);
+        assert_eq!(transfer_ring.next_request(), expected);
 
         // no new command placed, should return no new command
         let request = transfer_ring.next_request();

--- a/src/memory_segment.rs
+++ b/src/memory_segment.rs
@@ -270,7 +270,7 @@ mod tests {
         memfd.seek(std::io::SeekFrom::Start(0x1010))?;
         memfd.read_exact(&mut check_data)?;
 
-        assert_eq!(data, check_data);
+        assert_eq!(check_data, data);
 
         Ok(())
     }


### PR DESCRIPTION
Some existing test cases did not follow the `assert_eq!(actual, expected)` argument order.
This PR standardizes all occurrences to the correct order for consistency and to make test failure messages clearer and easier to interpret.