### PR TITLE
Bulk Endpoint Handling

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -25,6 +25,9 @@ let
         # Enable debug verbosity.
         boot.consoleLogLevel = 8;
 
+        # allow disk access for users
+        users.users.nixos.extraGroups = [ "disk" ];
+
         # Convenience packages for interactive use
         environment.systemPackages = with pkgs; [ pciutils usbutils ];
 
@@ -42,6 +45,8 @@ let
                 ${pkgs.usbutils}/bin/lsusb
                 echo
                 ${pkgs.util-linux}/bin/fdisk -l
+                echo
+                cat /dev/sda
               '';
               StandardOutput = "journal+console";
               StandardError = "journal+console";
@@ -189,6 +194,7 @@ in
       machine.wait_until_succeeds("grep -Eq '\s+[1-9][0-9]*\s+PCI-MSIX.*xhci_hcd' ${cloudHypervisorLog}")
       machine.wait_until_succeeds("grep -q 'ID ${vendorId}:${productId} QEMU QEMU USB HARDDRIVE' ${cloudHypervisorLog}")
       machine.wait_until_succeeds("grep -q 'Disk /dev/sda:' ${cloudHypervisorLog}")
+      machine.wait_until_succeeds("grep -q 'This is an uninitialized drive.' ${cloudHypervisorLog}")
     '';
   };
 }

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -153,6 +153,8 @@ in
           after = [ "usbvfiod.service" ];
 
           serviceConfig = {
+            Restart = "on-failure";
+            RestartSec = "2s";
             ExecStart = ''
               ${lib.getExe pkgs.cloud-hypervisor} --memory size=2G,shared=on --console off --serial file=${cloudHypervisorLog} \
                 --kernel ${netboot.kernel} \

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -47,6 +47,9 @@ let
                 ${pkgs.util-linux}/bin/fdisk -l
                 echo
                 cat /dev/sda
+                echo
+                echo -n "You are" > /dev/sda
+                cat /dev/sda
               '';
               StandardOutput = "journal+console";
               StandardError = "journal+console";
@@ -195,6 +198,7 @@ in
       machine.wait_until_succeeds("grep -q 'ID ${vendorId}:${productId} QEMU QEMU USB HARDDRIVE' ${cloudHypervisorLog}")
       machine.wait_until_succeeds("grep -q 'Disk /dev/sda:' ${cloudHypervisorLog}")
       machine.wait_until_succeeds("grep -q 'This is an uninitialized drive.' ${cloudHypervisorLog}")
+      machine.wait_until_succeeds("grep -q 'You are an uninitialized drive.' ${cloudHypervisorLog}")
     '';
   };
 }

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -40,6 +40,8 @@ let
                 cat /proc/interrupts
                 echo
                 ${pkgs.usbutils}/bin/lsusb
+                echo
+                ${pkgs.util-linux}/bin/fdisk -l
               '';
               StandardOutput = "journal+console";
               StandardError = "journal+console";
@@ -186,6 +188,7 @@ in
       # Read the diagnostic information after login.
       machine.wait_until_succeeds("grep -Eq '\s+[1-9][0-9]*\s+PCI-MSIX.*xhci_hcd' ${cloudHypervisorLog}")
       machine.wait_until_succeeds("grep -q 'ID ${vendorId}:${productId} QEMU QEMU USB HARDDRIVE' ${cloudHypervisorLog}")
+      machine.wait_until_succeeds("grep -q 'Disk /dev/sda:' ${cloudHypervisorLog}")
     '';
   };
 }

--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -394,4 +394,23 @@ pub mod xhci {
             }
         }
     }
+
+    /// Constants specific to device slots and their context structures
+    pub mod device_slots {
+        /// The slot state encoded in the slot context
+        pub mod slot_state {
+            pub const DISABLED_ENABLED: u8 = 0;
+            pub const DEFAULT: u8 = 1;
+            pub const ADDRESSED: u8 = 2;
+            pub const CONFIGURED: u8 = 3;
+        }
+        /// The endpoint state encoded in endpoint contexts
+        pub mod endpoint_state {
+            pub const DISABLED: u8 = 0;
+            pub const RUNNING: u8 = 1;
+            pub const HALTED: u8 = 2;
+            pub const STOPPED: u8 = 3;
+            pub const ERROR: u8 = 4;
+        }
+    }
 }

--- a/src/device/pci/device_slots.rs
+++ b/src/device/pci/device_slots.rs
@@ -2,6 +2,8 @@
 //!
 //! This module offers an abstraction for device slots.
 
+use tracing::debug;
+
 use crate::device::bus::{BusDeviceRef, Request, RequestSize};
 
 use super::rings::TransferRing;
@@ -181,6 +183,79 @@ impl DeviceContext {
         // fill slot context and ep0 context (as indicated by flags A0 and A1)
         self.dma_bus
             .write_bulk(self.address, &input_context[32..96]);
+    }
+
+    /// Update the device context with an input context.
+    ///
+    /// Call this function on ConfigureEndpointCommand. The command contains a
+    /// pointer to an input context (which is this function's parameter).
+    /// The XHCI controller is supposed to validate the values and copy the
+    /// data to the device context---we only do the latter and assume the
+    /// input is fine.
+    ///
+    /// The function returns the enabled endpoints, so that the same
+    /// endpoints can be configured on the real device.
+    ///
+    /// # Parameters
+    ///
+    /// - addr_input_context: address of the input context used for
+    ///   initialization.
+    pub fn configure_endpoints(&self, addr_input_context: u64) -> Vec<u8> {
+        let drop_flags = self
+            .dma_bus
+            .read(Request::new(addr_input_context, RequestSize::Size4));
+        let add_flags = self
+            .dma_bus
+            .read(Request::new(addr_input_context + 4, RequestSize::Size4));
+
+        // read slot and endpoint contexts
+        let mut input_context = [0; 1024];
+        self.dma_bus
+            .read_bulk(addr_input_context + 32, &mut input_context);
+
+        // disable dropped endpoints
+        for i in 2..=31 {
+            if drop_flags & (1 << i) == 0 {
+                continue;
+            }
+
+            debug!("Configure Endpoint: D{} is set", i);
+
+            let ep_context_offset = i * 32;
+            self.dma_bus.write(
+                Request::new(self.address + ep_context_offset, RequestSize::Size1),
+                0,
+            );
+        }
+
+        let mut enabled_endpoints = vec![];
+
+        // copy context of added endpoints and enable
+        for i in 1..=31 {
+            if add_flags & (1 << i) == 0 {
+                continue;
+            }
+            enabled_endpoints.push(i as u8);
+
+            debug!("Configure Endpoint: A{} is set", i);
+
+            let ep_context_offset = i * 32;
+            input_context[ep_context_offset] = 1;
+            self.dma_bus.write_bulk(
+                self.address + ep_context_offset as u64,
+                &input_context[ep_context_offset..ep_context_offset + 32],
+            );
+        }
+
+        // copy slot context
+        assert_eq!(add_flags & 0x1, 1, "Flag A0 should always be set");
+
+        let slot_state_configured = 3;
+        input_context[15] = slot_state_configured << 3;
+
+        self.dma_bus.write_bulk(self.address, &input_context[0..32]);
+
+        enabled_endpoints
     }
 
     /// Give access to an endpoint context based on its index in the device

--- a/src/device/pci/device_slots.rs
+++ b/src/device/pci/device_slots.rs
@@ -6,7 +6,7 @@ use tracing::debug;
 
 use crate::device::bus::{BusDeviceRef, Request, RequestSize};
 
-use super::rings::TransferRing;
+use super::{constants::xhci::device_slots::endpoint_state::*, rings::TransferRing};
 
 /// Abstraction for Device Slots.
 ///
@@ -303,6 +303,18 @@ impl DeviceContext {
     pub fn get_control_transfer_ring(&self) -> TransferRing {
         TransferRing::new(self.get_control_endpoint_context(), self.dma_bus.clone())
     }
+
+    pub fn get_transfer_ring(&self, endpoint_index: u64) -> TransferRing {
+        let endpoint_context = self.get_endpoint_context_internal(endpoint_index);
+        match endpoint_context.get_state() {
+            DISABLED => {
+                panic!("requested transferring for disabled EP{}", endpoint_index)
+            }
+            RUNNING => {}
+            _ => endpoint_context.set_state(RUNNING),
+        };
+        TransferRing::new(endpoint_context, self.dma_bus.clone())
+    }
 }
 
 /// A wrapper around DMA accesses to endpoint context structures.
@@ -355,6 +367,16 @@ impl EndpointContext {
             Request::new(self.address.wrapping_add(8), RequestSize::Size8),
             dequeue_pointer | cycle_state as u64,
         )
+    }
+
+    fn get_state(&self) -> u8 {
+        self.dma_bus
+            .read(Request::new(self.address, RequestSize::Size1)) as u8
+    }
+
+    fn set_state(&self, state: u8) {
+        self.dma_bus
+            .write(Request::new(self.address, RequestSize::Size1), state as u64);
     }
 }
 

--- a/src/device/pci/device_slots.rs
+++ b/src/device/pci/device_slots.rs
@@ -258,6 +258,13 @@ impl DeviceContext {
         enabled_endpoints
     }
 
+    pub fn set_endpoint_state(&self, endpoint_id: u8, state: u8) {
+        self.dma_bus.write(
+            Request::new(self.address + endpoint_id as u64 * 32, RequestSize::Size1),
+            state as u64,
+        );
+    }
+
     /// Give access to an endpoint context based on its index in the device
     /// context.
     ///

--- a/src/device/pci/nusb.rs
+++ b/src/device/pci/nusb.rs
@@ -1,11 +1,13 @@
-use nusb::transfer::{ControlIn, ControlOut, ControlType, Recipient};
+use nusb::transfer::{Buffer, Bulk, ControlIn, ControlOut, ControlType, In, Out, Recipient};
 use nusb::MaybeFuture;
 use tracing::{debug, warn};
 
 use crate::device::bus::BusDeviceRef;
+use crate::device::pci::trb::CompletionCode;
 
-use super::trb::{CompletionCode, EventTrb, TransferTrb};
+use super::trb::{NormalTrbData, TransferTrb, TransferTrbVariant};
 use super::{realdevice::RealDevice, usbrequest::UsbRequest};
+use std::cmp::Ordering::*;
 use std::{
     fmt::Debug,
     sync::atomic::{fence, Ordering},
@@ -14,6 +16,9 @@ use std::{
 
 pub struct NusbDeviceWrapper {
     device: nusb::Device,
+    interface: nusb::Interface,
+    ep_in: Option<nusb::Endpoint<Bulk, In>>,
+    ep_out: Option<nusb::Endpoint<Bulk, Out>>,
 }
 
 impl Debug for NusbDeviceWrapper {
@@ -27,8 +32,14 @@ impl Debug for NusbDeviceWrapper {
 }
 
 impl NusbDeviceWrapper {
-    pub const fn new(device: nusb::Device) -> Self {
-        Self { device }
+    pub fn new(device: nusb::Device) -> Self {
+        let interface = device.detach_and_claim_interface(0).wait().unwrap();
+        Self {
+            device,
+            interface,
+            ep_in: None,
+            ep_out: None,
+        }
     }
 
     fn control_transfer_device_to_host(&self, request: &UsbRequest, dma_bus: &BusDeviceRef) {
@@ -102,14 +113,113 @@ impl RealDevice for NusbDeviceWrapper {
     }
 
     fn out(&mut self, trb: &TransferTrb, dma_bus: &BusDeviceRef) -> (CompletionCode, u32) {
-        todo!();
+        assert!(
+            matches!(trb.variant, TransferTrbVariant::Normal(_)),
+            "Expected Normal TRB but got {:?}",
+            trb
+        );
+
+        let ep_out = self.ep_out.as_mut().unwrap();
+        let normal_data = extract_normal_trb_data(trb).unwrap();
+
+        let mut data = vec![0; normal_data.transfer_length as usize];
+        dma_bus.read_bulk(normal_data.data_pointer, &mut data);
+        ep_out.submit(data.into());
+        ep_out
+            .wait_next_complete(Duration::from_millis(400))
+            .unwrap();
+        (CompletionCode::Success, 0)
     }
 
     fn in_(&mut self, trb: &TransferTrb, dma_bus: &BusDeviceRef) -> (CompletionCode, u32) {
-        todo!();
+        assert!(
+            matches!(trb.variant, TransferTrbVariant::Normal(_)),
+            "Expected Normal TRB but got {:?}",
+            trb
+        );
+
+        let ep_in = self.ep_in.as_mut().unwrap();
+        let normal_data = extract_normal_trb_data(trb).unwrap();
+        let transfer_length = normal_data.transfer_length as usize;
+
+        let buffer_size = determine_buffer_size(transfer_length, ep_in.max_packet_size());
+        let buffer = Buffer::new(buffer_size);
+        ep_in.submit(buffer);
+        let buffer = ep_in
+            .wait_next_complete(Duration::from_millis(400))
+            .unwrap();
+        let byte_count_dma = match buffer.actual_len.cmp(&transfer_length) {
+            Greater => {
+                // Got more data than requested. We must not write more data than
+                // the guest driver requested with the transfer length, otherwise
+                // we might write out of the buffer.
+                //
+                // Why does this case happen? Sometimes the driver asks for, e.g.,
+                // 36 bytes. We have to request max_packet_size (e.g., 1024 bytes).
+                // The real device then provides 1024 bytes of data (looks like
+                // zero padding).
+                transfer_length
+            }
+            Less => {
+                // Got less data than requested. That case happens for example when
+                // the driver sends a Mode Sense(6) SCSI command. The response size
+                // is variable, so the driver asks for 192 bytes but is also fine
+                // with less.
+                //
+                // We copy all the data over that we got.
+                // TODO: currently, we just report success and 0 residual bytes,
+                // even though we probably should report something like short
+                // packet and the difference between requested and actual byte
+                // count. We get away with the simplified handling for now.
+                // The Mode Sense(6) response encodes the size of the response in
+                // the first byte, so the driver is not unhappy that we reported
+                // 192 bytes but only deliver, e.g., 36 bytes.
+                buffer.actual_len
+            }
+            Equal => {
+                // We got exactly the right amount of bytes.
+                transfer_length
+            }
+        };
+        dma_bus.write_bulk(normal_data.data_pointer, &buffer.buffer[..byte_count_dma]);
+        (CompletionCode::Success, 0)
     }
 
     fn enable_endpoint(&mut self, endpoint_id: u8) {
-        todo!();
+        match endpoint_id {
+            3 => {
+                if self.ep_in.is_some() {
+                    return;
+                }
+                self.ep_in = Some(self.interface.endpoint::<Bulk, In>(0x81).unwrap());
+                debug!("enabled EP3 on real device");
+            }
+            4 => {
+                if self.ep_out.is_some() {
+                    return;
+                }
+                self.ep_out = Some(self.interface.endpoint::<Bulk, Out>(0x2).unwrap());
+                debug!("enabled EP4 on real device");
+            }
+            1 => {}
+            _ => todo!(),
+        }
+    }
+}
+
+const fn extract_normal_trb_data(trb: &TransferTrb) -> Option<&NormalTrbData> {
+    match &trb.variant {
+        TransferTrbVariant::Normal(data) => Some(data),
+        _ => None,
+    }
+}
+
+fn determine_buffer_size(guest_transfer_length: usize, max_packet_size: usize) -> usize {
+    if guest_transfer_length < max_packet_size {
+        max_packet_size
+    } else if guest_transfer_length % max_packet_size == 0 {
+        guest_transfer_length
+    } else {
+        panic!("unexpected IN transfer length {}", guest_transfer_length);
     }
 }

--- a/src/device/pci/nusb.rs
+++ b/src/device/pci/nusb.rs
@@ -4,6 +4,7 @@ use tracing::{debug, warn};
 
 use crate::device::bus::BusDeviceRef;
 
+use super::trb::{CompletionCode, EventTrb, TransferTrb};
 use super::{realdevice::RealDevice, usbrequest::UsbRequest};
 use std::{
     fmt::Debug,
@@ -98,5 +99,17 @@ impl RealDevice for NusbDeviceWrapper {
             true => self.control_transfer_device_to_host(request, dma_bus),
             false => self.control_transfer_host_to_device(request, dma_bus),
         }
+    }
+
+    fn out(&mut self, trb: &TransferTrb, dma_bus: &BusDeviceRef) -> (CompletionCode, u32) {
+        todo!();
+    }
+
+    fn in_(&mut self, trb: &TransferTrb, dma_bus: &BusDeviceRef) -> (CompletionCode, u32) {
+        todo!();
+    }
+
+    fn enable_endpoint(&mut self, endpoint_id: u8) {
+        todo!();
     }
 }

--- a/src/device/pci/realdevice.rs
+++ b/src/device/pci/realdevice.rs
@@ -1,8 +1,14 @@
 use crate::device::bus::BusDeviceRef;
 
-use super::usbrequest::UsbRequest;
+use super::{
+    trb::{CompletionCode, TransferTrb},
+    usbrequest::UsbRequest,
+};
 use std::fmt::Debug;
 
 pub trait RealDevice: Debug {
     fn control_transfer(&self, request: &UsbRequest, dma_bus: &BusDeviceRef);
+    fn enable_endpoint(&mut self, endpoint_id: u8);
+    fn out(&mut self, trb: &TransferTrb, dma_bus: &BusDeviceRef) -> (CompletionCode, u32);
+    fn in_(&mut self, trb: &TransferTrb, dma_bus: &BusDeviceRef) -> (CompletionCode, u32);
 }

--- a/src/device/pci/trb.rs
+++ b/src/device/pci/trb.rs
@@ -419,7 +419,6 @@ impl CommandTrbVariant {
     }
 }
 
-/// Custom error type to represent errors in TRB parsing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkTrbData {
     /// The address of the next ring segment.
@@ -681,6 +680,7 @@ impl TrbData for DataStageTrbData {
     }
 }
 
+/// Custom error type to represent errors in TRB parsing.
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum TrbParseError {
     #[error("TRB type {0} refers to \"{1}\", which is optional and not supported.")]

--- a/src/device/pci/trb.rs
+++ b/src/device/pci/trb.rs
@@ -345,7 +345,7 @@ pub enum CommandTrbVariant {
     EnableSlot,
     DisableSlot,
     AddressDevice(AddressDeviceCommandTrbData),
-    ConfigureEndpoint,
+    ConfigureEndpoint(ConfigureEndpointCommandTrbData),
     EvaluateContext,
     ResetEndpoint,
     StopEndpoint(StopEndpointCommandTrbData),
@@ -381,7 +381,7 @@ impl CommandTrbVariant {
             trb_types::ENABLE_SLOT_COMMAND => Self::EnableSlot,
             trb_types::DISABLE_SLOT_COMMAND => Self::DisableSlot,
             trb_types::ADDRESS_DEVICE_COMMAND => parse(Self::AddressDevice, bytes),
-            trb_types::CONFIGURE_ENDPOINT_COMMAND => Self::ConfigureEndpoint,
+            trb_types::CONFIGURE_ENDPOINT_COMMAND => parse(Self::ConfigureEndpoint, bytes),
             trb_types::EVALUATE_CONTEXT_COMMAND => Self::EvaluateContext,
             trb_types::RESET_ENDPOINT_COMMAND => Self::ResetEndpoint,
             trb_types::STOP_ENDPOINT_COMMAND => parse(Self::StopEndpoint, bytes),
@@ -507,6 +507,51 @@ impl TrbData for AddressDeviceCommandTrbData {
         Ok(Self {
             input_context_pointer,
             block_set_address_request,
+            slot_id,
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ConfigureEndpointCommandTrbData {
+    pub input_context_pointer: u64,
+    pub deconfigure: bool,
+    pub slot_id: u8,
+}
+
+impl TrbData for ConfigureEndpointCommandTrbData {
+    /// Parse data of a Configure Endpoint Command TRB.
+    ///
+    /// Only `CommandTrb::try_from` should call this function.
+    ///
+    /// # Limitations
+    ///
+    /// The function currently does not check if the slice respects all RsvdZ
+    /// fields.
+    fn parse(trb_bytes: RawTrbBuffer) -> Result<Self, TrbParseError> {
+        let trb_type = trb_bytes[13] >> 2;
+        assert_eq!(
+            trb_types::CONFIGURE_ENDPOINT_COMMAND,
+            trb_type,
+            "ConfigureEndpointCommandTrbData::parse called on TRB data with incorrect TRB type ({:#x})",
+            trb_type
+        );
+
+        let icp_bytes: [u8; 8] = trb_bytes[0..8].try_into().unwrap();
+        let input_context_pointer = u64::from_le_bytes(icp_bytes);
+
+        // the lowest four bit of the pointer are RsvdZ to ensure 16-byte
+        // alignment.
+        if input_context_pointer & 0xf != 0 {
+            return Err(TrbParseError::RsvdZViolation);
+        }
+
+        let deconfigure = trb_bytes[13] & 0x2 != 0;
+        let slot_id = trb_bytes[15];
+
+        Ok(Self {
+            input_context_pointer,
+            deconfigure,
             slot_id,
         })
     }
@@ -727,6 +772,20 @@ mod tests {
         let expected = CommandTrbVariant::AddressDevice(AddressDeviceCommandTrbData {
             input_context_pointer: 0x1122334455667780,
             block_set_address_request: true,
+            slot_id: 0x13,
+        });
+        assert_eq!(CommandTrbVariant::parse(trb_bytes), expected);
+    }
+
+    #[test]
+    fn parse_configure_endpoint_command_trb() {
+        let trb_bytes = [
+            0x80, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00, 0x00, 0x00, 0x00, 0x02, 0x32,
+            0x00, 0x13,
+        ];
+        let expected = CommandTrbVariant::ConfigureEndpoint(ConfigureEndpointCommandTrbData {
+            input_context_pointer: 0x1122334455667780,
+            deconfigure: true,
             slot_id: 0x13,
         });
         assert_eq!(CommandTrbVariant::parse(trb_bytes), expected);

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -175,15 +175,8 @@ impl XhciController {
 
     fn doorbell_controller(&mut self) {
         debug!("Ding Dong!");
-        // check command available
-        let next = self.command_ring.next_command_trb();
-        if let Some(cmd) = next {
+        while let Some(cmd) = self.command_ring.next_command_trb() {
             self.handle_command(cmd);
-        } else {
-            debug!(
-                "Doorbell was rang, but no (valid) command found on the command ring ({:?})",
-                next
-            );
         }
     }
 

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -214,7 +214,7 @@ impl XhciController {
                     data.slot_id,
                 )
             }
-            CommandTrbVariant::ConfigureEndpoint => {
+            CommandTrbVariant::ConfigureEndpoint(_data) => {
                 // TODO actually configure the endpoint.
                 // For now we just acknowledge the configuration.
                 EventTrb::new_command_completion_event_trb(

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -25,7 +25,7 @@ use crate::device::{
 
 use super::{
     config_space::BarInfo,
-    constants::xhci::operational::usbsts,
+    constants::xhci::{device_slots::endpoint_state, operational::usbsts},
     device_slots::DeviceSlotManager,
     realdevice::RealDevice,
     registers::PortscRegister,
@@ -222,10 +222,7 @@ impl XhciController {
             CommandTrbVariant::EvaluateContext => todo!(),
             CommandTrbVariant::ResetEndpoint => todo!(),
             CommandTrbVariant::StopEndpoint(data) => {
-                // TODO this command probably requires more handling.
-                // Currently, we just acknowledge to not crash usbvfiod in the
-                // integration test.
-                let _ = data.endpoint_id;
+                self.handle_stop_endpoint(&data);
                 EventTrb::new_command_completion_event_trb(
                     cmd.address,
                     0,
@@ -302,6 +299,11 @@ impl XhciController {
         for i in enabled_endpoints {
             self.real_device.as_mut().unwrap().enable_endpoint(i);
         }
+    }
+
+    fn handle_stop_endpoint(&self, data: &StopEndpointCommandTrbData) {
+        let device_context = self.device_slot_manager.get_device_context(data.slot_id);
+        device_context.set_endpoint_state(data.endpoint_id, endpoint_state::RUNNING);
     }
 
     fn doorbell_device(&mut self, value: u32) {

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -401,22 +401,23 @@ impl XhciController {
             .get_device_context(slot)
             .get_transfer_ring(ep as u64);
 
-        let trb = transfer_ring.next_transfer_trb().unwrap();
-        debug!("TRB on endpoint {} (IN): {:?}", ep, trb);
-        let (completion_code, residual_bytes) =
-            self.real_device.as_mut().unwrap().in_(&trb, &self.dma_bus);
-        // send transfer event
-        let transfer_event = EventTrb::new_transfer_event_trb(
-            trb.address,
-            residual_bytes,
-            completion_code,
-            false,
-            ep,
-            slot,
-        );
-        self.event_ring.enqueue(&transfer_event);
-        self.interrupt_line.interrupt();
-        debug!("sent Transfer Event and signaled interrupt");
+        while let Some(trb) = transfer_ring.next_transfer_trb() {
+            debug!("TRB on endpoint {} (IN): {:?}", ep, trb);
+            let (completion_code, residual_bytes) =
+                self.real_device.as_mut().unwrap().in_(&trb, &self.dma_bus);
+            // send transfer event
+            let transfer_event = EventTrb::new_transfer_event_trb(
+                trb.address,
+                residual_bytes,
+                completion_code,
+                false,
+                ep,
+                slot,
+            );
+            self.event_ring.enqueue(&transfer_event);
+            self.interrupt_line.interrupt();
+            debug!("sent Transfer Event and signaled interrupt");
+        }
     }
 }
 

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -30,7 +30,10 @@ use super::{
     realdevice::RealDevice,
     registers::PortscRegister,
     rings::{CommandRing, EventRing},
-    trb::{AddressDeviceCommandTrbData, CommandTrb},
+    trb::{
+        AddressDeviceCommandTrbData, CommandTrb, ConfigureEndpointCommandTrbData,
+        StopEndpointCommandTrbData,
+    },
 };
 
 /// The emulation of a XHCI controller.
@@ -207,14 +210,13 @@ impl XhciController {
                     data.slot_id,
                 )
             }
-            CommandTrbVariant::ConfigureEndpoint(_data) => {
-                // TODO actually configure the endpoint.
-                // For now we just acknowledge the configuration.
+            CommandTrbVariant::ConfigureEndpoint(data) => {
+                self.handle_configure_endpoint(&data);
                 EventTrb::new_command_completion_event_trb(
                     cmd.address,
                     0,
                     CompletionCode::Success,
-                    1,
+                    data.slot_id,
                 )
             }
             CommandTrbVariant::EvaluateContext => todo!(),
@@ -289,6 +291,17 @@ impl XhciController {
         }
         let device_context = self.device_slot_manager.get_device_context(data.slot_id);
         device_context.initialize(data.input_context_pointer);
+    }
+
+    fn handle_configure_endpoint(&mut self, data: &ConfigureEndpointCommandTrbData) {
+        if data.deconfigure {
+            panic!("encountered Configure Endpoint Command with deconfigure set");
+        }
+        let device_context = self.device_slot_manager.get_device_context(data.slot_id);
+        let enabled_endpoints = device_context.configure_endpoints(data.input_context_pointer);
+        for i in enabled_endpoints {
+            self.real_device.as_mut().unwrap().enable_endpoint(i);
+        }
     }
 
     fn doorbell_device(&mut self, value: u32) {

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -308,14 +308,20 @@ impl XhciController {
 
     fn doorbell_device(&mut self, value: u32) {
         debug!("Ding Dong Device with value {}!", value);
-        // TODO inspect value
-        // currently we assume it is 1, which indicates a request on the control transfer ring
-        assert_eq!(1, value, "currently only implemented doorbell rings that indicate requests on the control transfer ring");
 
+        match value {
+            ep if ep == 0 || ep > 31 => panic!("invalid value {} on doorbell write", ep),
+            1 => self.check_control_endpoint(1),
+            ep if ep % 2 == 0 => self.check_out_endpoint(1, value as u8),
+            ep => self.check_in_endpoint(1, ep as u8),
+        };
+    }
+
+    fn check_control_endpoint(&mut self, slot: u8) {
         // check request available
         let transfer_ring = self
             .device_slot_manager
-            .get_device_context(1)
+            .get_device_context(slot)
             .get_control_transfer_ring();
 
         let request = match transfer_ring.next_request() {
@@ -358,9 +364,57 @@ impl XhciController {
             CompletionCode::Success,
             false,
             1,
-            1,
+            slot,
         );
         self.event_ring.enqueue(&trb);
+        self.interrupt_line.interrupt();
+        debug!("sent Transfer Event and signaled interrupt");
+    }
+
+    fn check_out_endpoint(&mut self, slot: u8, ep: u8) {
+        let transfer_ring = self
+            .device_slot_manager
+            .get_device_context(slot)
+            .get_transfer_ring(ep as u64);
+
+        let trb = transfer_ring.next_transfer_trb().unwrap();
+        debug!("TRB on endpoint {} (OUT): {:?}", ep, trb);
+        let (completion_code, residual_bytes) =
+            self.real_device.as_mut().unwrap().out(&trb, &self.dma_bus);
+        // send transfer event
+        let trb = EventTrb::new_transfer_event_trb(
+            trb.address,
+            residual_bytes,
+            completion_code,
+            false,
+            ep,
+            slot,
+        );
+        self.event_ring.enqueue(&trb);
+        self.interrupt_line.interrupt();
+        debug!("sent Transfer Event and signaled interrupt");
+    }
+
+    fn check_in_endpoint(&mut self, slot: u8, ep: u8) {
+        let transfer_ring = self
+            .device_slot_manager
+            .get_device_context(slot)
+            .get_transfer_ring(ep as u64);
+
+        let trb = transfer_ring.next_transfer_trb().unwrap();
+        debug!("TRB on endpoint {} (IN): {:?}", ep, trb);
+        let (completion_code, residual_bytes) =
+            self.real_device.as_mut().unwrap().in_(&trb, &self.dma_bus);
+        // send transfer event
+        let transfer_event = EventTrb::new_transfer_event_trb(
+            trb.address,
+            residual_bytes,
+            completion_code,
+            false,
+            ep,
+            slot,
+        );
+        self.event_ring.enqueue(&transfer_event);
         self.interrupt_line.interrupt();
         debug!("sent Transfer Event and signaled interrupt");
     }


### PR DESCRIPTION
This PR implements the necessary functionality to enable endpoints and handle requests on their transfer rings.
Overall, these changes allow the usage of a USB storage device in the guest—reading, writing, mounting work.

Screenshot of a USB 3 flash drive with NixOS installer passed through to a VM. 
<img width="3252" height="1284" alt="image" src="https://github.com/user-attachments/assets/fbf1419f-3490-44ad-8655-bf7fc5a5f48d" />

Functionality implemented:
- handle Configure Endpoint Command (used to enable the bulk endpoints)
- handle Stop Endpoint Command (the driver puts the endpoints to sleep after configuring them. Stopping an endpoint is different from disabling an endpoint!)
- retrieve Normal TRBs from the endpoints' transfer rings
- "forward" the transfers to the real device with nusb (this part is still very much specific to storage/bulk devices and will not work for other kinds of devices)

Extension of the integration test:
- check that the guest recognizes the QEMU usb drive as a storage device by check fdisk for existence of /dev/sda
- check that the content of the usb drive can be read
- check that the content of the usb drive can be overwriten

Other fixes:
- moved a misplaced doc string around
- allowed cloud-hypervisor service in the integration test to restart on failure to avoid failure due to a race for the usbvfiod socket