### PR TITLE
test(bus): unify test BusDevice implementations

### DIFF
--- a/src/device/bus.rs
+++ b/src/device/bus.rs
@@ -712,7 +712,16 @@ pub mod testutils {
                     self.read_bulk(req.addr, &mut bytes);
                     u32::from_le_bytes(bytes) as u64
                 }
-                _ => panic!("Only supporting 4-byte and 8-byte reads"),
+                RequestSize::Size2 => {
+                    let mut bytes = [0u8; 2];
+                    self.read_bulk(req.addr, &mut bytes);
+                    u16::from_le_bytes(bytes) as u64
+                }
+                RequestSize::Size1 => {
+                    let mut bytes = [0u8; 1];
+                    self.read_bulk(req.addr, &mut bytes);
+                    bytes[0] as u64
+                }
             }
         }
 

--- a/src/device/bus.rs
+++ b/src/device/bus.rs
@@ -674,7 +674,7 @@ pub mod testutils {
     use super::*;
     use std::sync::Mutex;
 
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     pub struct TestBusDevice {
         data: Mutex<Vec<u8>>,
     }

--- a/src/device/bus.rs
+++ b/src/device/bus.rs
@@ -670,6 +670,72 @@ impl BusDevice for Bus {
 }
 
 #[cfg(test)]
+pub mod testutils {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Debug)]
+    pub struct TestBusDevice {
+        data: Mutex<Vec<u8>>,
+    }
+
+    impl TestBusDevice {
+        pub fn new(data: &[u8]) -> Self {
+            Self {
+                data: Mutex::new(data.to_vec()),
+            }
+        }
+
+        pub fn read_bulk(&self, offset: u64, data: &mut [u8]) {
+            <Self as BusDevice>::read_bulk(self, offset, data)
+        }
+
+        pub fn write_bulk(&self, offset: u64, data: &[u8]) {
+            <Self as BusDevice>::write_bulk(self, offset, data)
+        }
+    }
+
+    impl BusDevice for TestBusDevice {
+        fn size(&self) -> u64 {
+            self.data.lock().unwrap().len().try_into().unwrap()
+        }
+
+        fn read(&self, req: Request) -> u64 {
+            match req.size {
+                RequestSize::Size8 => {
+                    let mut bytes = [0; 8];
+                    self.read_bulk(req.addr, &mut bytes);
+                    u64::from_le_bytes(bytes)
+                }
+                RequestSize::Size4 => {
+                    let mut bytes = [0; 4];
+                    self.read_bulk(req.addr, &mut bytes);
+                    u32::from_le_bytes(bytes) as u64
+                }
+                _ => panic!("Only supporting 4-byte and 8-byte reads"),
+            }
+        }
+
+        fn write(&self, req: Request, value: u64) {
+            if req.size != RequestSize::Size8 {
+                panic!("Only supporting 8-byte writes");
+            }
+            self.write_bulk(req.addr, &value.to_le_bytes());
+        }
+
+        fn read_bulk(&self, offset: u64, data: &mut [u8]) {
+            let offset: usize = offset.try_into().unwrap();
+            data.copy_from_slice(&self.data.lock().unwrap()[offset..(offset + data.len())])
+        }
+
+        fn write_bulk(&self, offset: u64, data: &[u8]) {
+            let offset: usize = offset.try_into().unwrap();
+            self.data.lock().unwrap()[offset..(offset + data.len())].copy_from_slice(data)
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use std::sync::{
         atomic::{AtomicU64, Ordering::SeqCst},

--- a/src/device/pci/device_slots.rs
+++ b/src/device/pci/device_slots.rs
@@ -281,30 +281,15 @@ mod tests {
 
     use std::sync::Arc;
 
-    use crate::device::bus::BusDevice;
+    use crate::device::bus::testutils::TestBusDevice;
 
     use super::*;
-
-    #[derive(Debug, Default)]
-    struct DummyMemory {}
-
-    impl BusDevice for DummyMemory {
-        fn size(&self) -> u64 {
-            0
-        }
-
-        fn read(&self, _: crate::device::bus::Request) -> u64 {
-            0
-        }
-
-        fn write(&self, _: crate::device::bus::Request, _: u64) {}
-    }
 
     #[test]
     fn device_slot_reservation() {
         // we test with only one device slot, because that case is currently
         // what we run with
-        let mut device_slot_manager = DeviceSlotManager::new(1, Arc::new(DummyMemory::default()));
+        let mut device_slot_manager = DeviceSlotManager::new(1, Arc::new(TestBusDevice::default()));
 
         // reserve the only slot
         assert_eq!(device_slot_manager.reserve_slot(), Some(1));

--- a/src/dynamic_bus.rs
+++ b/src/dynamic_bus.rs
@@ -70,31 +70,15 @@ impl BusDevice for DynamicBus {
 
 #[cfg(test)]
 mod tests {
+    use crate::device::bus::testutils::TestBusDevice;
     use crate::device::bus::RequestSize;
 
     use super::*;
 
-    #[derive(Debug, Default)]
-    struct TestDevice {}
-
-    impl BusDevice for TestDevice {
-        fn size(&self) -> u64 {
-            0x1000
-        }
-
-        fn read(&self, _req: Request) -> u64 {
-            42
-        }
-
-        fn write(&self, _req: Request, _value: u64) {
-            // Ignore
-        }
-    }
-
     #[test]
     fn can_add_devices() {
         let bus = DynamicBus::default();
-        let device1 = Arc::new(TestDevice::default());
+        let device1 = Arc::new(TestBusDevice::new(&[42u8; 0x1000]));
 
         assert_eq!(bus.read(Request::new(0x1000, RequestSize::Size1)), 0xFF);
 


### PR DESCRIPTION
This PR replaces custom inline `BusDevice` implementations in tests with the shared `TestBusDevice` from `testutils`.
It reduces duplication, keeps test setup consistent, and makes maintenance easier by centralizing changes to test devices.

