### PR TITLE
Event Ring: multi-segment + dynamic ERSTSZ support (with tests)

### DIFF
--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -217,6 +217,13 @@ pub mod xhci {
     pub const MAX_INTRS: u64 = 1;
     /// Maximum number of supported device slots.
     pub const MAX_SLOTS: u64 = 1;
+    /// Maximum Event Ring Segment Table size as an exponent.
+    ///
+    /// The actual maximum number of segments is 2^MAX_ERST_SIZE_EXP.
+    /// This value is encoded in the HCSPARAMS2 register to inform
+    /// the driver about the Event Ring capabilities.
+    /// Current value allows up to 2^15 = 32768 segments.
+    pub const MAX_ERST_SIZE_EXP: u64 = 15;
 
     /// Offsets of various fields from the start of the XHCI MMIO region.
     pub mod offset {
@@ -276,6 +283,7 @@ pub mod xhci {
         pub const HCIVERSION: u64 = 0x100;
         pub const HCSPARAMS1: u64 =
             (super::MAX_PORTS << 24) | (super::MAX_INTRS << 8) | super::MAX_SLOTS;
+        pub const HCSPARAMS2: u64 = super::MAX_ERST_SIZE_EXP << 4;
         pub const HCCPARAMS1: u64 = super::offset::SUPPORTED_PROTOCOLS << 14;
 
         pub mod supported_protocols {

--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -397,7 +397,7 @@ pub mod xhci {
         pub mod event_ring {
             /// The offsets to fields in Event Ring Segment Table Entries (ERSTE)
             pub mod segments_table_entry_offsets {
-                pub const BASE_ADDR: u64 = 0;
+                pub const SEGMENT_BASE: u64 = 0;
                 pub const SIZE: u64 = 8;
             }
         }

--- a/src/device/pci/rings.rs
+++ b/src/device/pci/rings.rs
@@ -184,6 +184,11 @@ impl EventRing {
         self.dequeue_pointer
     }
 
+    /// Handle reads to the Event Ring Segment Table Size (ERSTSZ).
+    pub const fn read_erst_size(&self) -> u64 {
+        self.erst_size as u64
+    }
+
     /// Enqueue a new Event TRB into the Ring.
     ///
     /// # Parameters

--- a/src/device/pci/rings.rs
+++ b/src/device/pci/rings.rs
@@ -133,7 +133,7 @@ impl EventRing {
 
         self.base_address = erstba;
         self.enqueue_pointer = self.dma_bus.read(Request::new(
-            erstba.wrapping_add(BASE_ADDR),
+            erstba.wrapping_add(SEGMENT_BASE),
             RequestSize::Size8,
         ));
         self.trb_count = self
@@ -243,7 +243,7 @@ impl EventRing {
 
             let entry_addr = self.base_address.wrapping_add((next_seg as u64) * 16);
             let next_seg_pointer = self.dma_bus.read(Request::new(
-                entry_addr.wrapping_add(BASE_ADDR),
+                entry_addr.wrapping_add(SEGMENT_BASE),
                 RequestSize::Size8,
             ));
 
@@ -269,7 +269,7 @@ impl EventRing {
             .base_address
             .wrapping_add((self.erst_count as u64) * 16);
         self.enqueue_pointer = self.dma_bus.read(Request::new(
-            entry_addr.wrapping_add(BASE_ADDR),
+            entry_addr.wrapping_add(SEGMENT_BASE),
             RequestSize::Size8,
         ));
         self.trb_count = self.dma_bus.read(Request::new(


### PR DESCRIPTION
This PR upgrades the Event Ring from single segment to multi-segment and adds support for dynamic ERST size changes at runtime (grow, shrink, overwrite entries). The ring now advances across segments, wraps correctly to segment 0, and flips the producer cycle bit only on full wraps. Dynamic changes take effect on the next segment boundary, keeping the ring usable while ERST is updated.

### Key changes

- Implement multi-segment traversal and wrap logic; re-read ERST on each segment transition.
- When not configured, the default value for ERSTSZ is 1.

### Tests added

- Multi-segment: single wrap, multiple wraps (cycle toggles).
- Ring-full detection (boundary case).
- Dynamic ERST: grow 1→3, shrink →1, and overwrite ERST entries;
- Defaulting behavior: ERSTSZ defaults to 1 when unset.

### Validation
Verified multi-segment behavior on a real USB device

When segment 0 is full, enqueue pointer advance to the next segment(segment 1). And cycle status isn't toggled.(cycle status = true)
<img width="1623" height="83" alt="image_009" src="https://github.com/user-attachments/assets/c5692103-6dfe-423f-813c-5ea3b1e4186c" />

When the ring is full, enqueue pointer wrap to segment 0 and cycle status is toggled.(cycle status = false)
<img width="1630" height="56" alt="image1" src="https://github.com/user-attachments/assets/058f9b0c-58a5-4c49-b530-98b84ae4f1f8" />

Successfully wraparound
<img width="1629" height="440" alt="image" src="https://github.com/user-attachments/assets/28f6a556-93c2-4bcd-a690-8cb528499536" />

> In my tests with a real USB device/guest, the Event Ring Segment Table Size (ERSTSZ) consistently ends up as 2. It appears to be programmed by the guest xHCI driver, not by our device code.
I haven’t found a reliable way to make the guest request >2 segments for validation. So far I’ve only exercised and verified the 2-segment path.

**Questions for reviewers**

1. Is “ERSTSZ = 2 in practice” expected for common guest kernels?
2. Do we have a recommended method to drive a larger ERSTSZ (e.g., kernel config/param, known guest, or a reproducible setup)?
3. For now, is validating with 2 segments considered sufficient?
