### PR TITLE
xhci: dequeue OUT transfer ring TRBs until empty

### DIFF
--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -378,29 +378,26 @@ impl XhciController {
             .get_device_context(slot)
             .get_transfer_ring(ep as u64);
 
-        // TODO: Implement same behavior for `check_in_endpoint`.
-        // We assume that OUT doorbell should guarantee TRB availability.
-        // panic if OUT transfer ring is empty, so that we will notice any violation
-        // of our assumption.
-        let trb = transfer_ring.next_transfer_trb().unwrap();
-        debug!("TRB on endpoint {} (OUT): {:?}", ep, trb);
-        let (completion_code, residual_bytes) = self
-            .real_device
-            .as_mut()
-            .unwrap()
-            .transfer_out(&trb, &self.dma_bus);
-        // send transfer event
-        let trb = EventTrb::new_transfer_event_trb(
-            trb.address,
-            residual_bytes,
-            completion_code,
-            false,
-            ep,
-            slot,
-        );
-        self.event_ring.enqueue(&trb);
-        self.interrupt_line.interrupt();
-        debug!("sent Transfer Event and signaled interrupt");
+        while let Some(trb) = transfer_ring.next_transfer_trb() {
+            debug!("TRB on endpoint {} (OUT): {:?}", ep, trb);
+            let (completion_code, residual_bytes) = self
+                .real_device
+                .as_mut()
+                .unwrap()
+                .transfer_out(&trb, &self.dma_bus);
+            // send transfer event
+            let trb = EventTrb::new_transfer_event_trb(
+                trb.address,
+                residual_bytes,
+                completion_code,
+                false,
+                ep,
+                slot,
+            );
+            self.event_ring.enqueue(&trb);
+            self.interrupt_line.interrupt();
+            debug!("sent Transfer Event and signaled interrupt");
+        }
     }
 
     fn check_in_endpoint(&mut self, slot: u8, ep: u8) {


### PR DESCRIPTION
So far, we only dequeued a single TRB from a transfer ring when the device doorbell was rang for the associated endpoint. If multiple TRBs were present (apparently has not happened, but the situation is very possible), we would only process the first. If no TRB is present, we panic (that should be fine, I don't think the driver should ring the doorbell when there is nothing for us to do).

This PR introduces a loop that dequeues and processes TRBs from an OUT endpoint until the ring is empty. This changes matches the OUT handling with the IN handling (where we have already observed that multi-TRB processing is necessary).