### PR TITLE
Expose second port as USB2 port

### DIFF
--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -211,8 +211,12 @@ pub mod xhci {
     pub const OP_BASE: u64 = 0x40;
     /// Runtime register base offset.
     pub const RUN_BASE: u64 = 0x3000;
+    /// Number of USB 3 ports that we use
+    pub const NUM_USB3_PORTS: u64 = 1;
+    /// Number of USB 2 ports that we use
+    pub const NUM_USB2_PORTS: u64 = 1;
     /// Maximum number of supported ports.
-    pub const MAX_PORTS: u64 = 1;
+    pub const MAX_PORTS: u64 = NUM_USB3_PORTS + NUM_USB2_PORTS;
     /// Maximum number of supported interrupter register sets.
     pub const MAX_INTRS: u64 = 1;
     /// Maximum number of supported device slots.
@@ -241,6 +245,8 @@ pub mod xhci {
         /// Extended Capabilities
         pub const SUPPORTED_PROTOCOLS: u64 = 0x20;
         pub const SUPPORTED_PROTOCOLS_CONFIG: u64 = 0x28;
+        pub const SUPPORTED_PROTOCOLS_USB2: u64 = 0x30;
+        pub const SUPPORTED_PROTOCOLS_USB2_CONFIG: u64 = 0x38;
 
         /// Operational Register Offsets
         pub const USBCMD: u64 = super::OP_BASE;
@@ -254,9 +260,12 @@ pub mod xhci {
         pub const CONFIG: u64 = super::OP_BASE + 0x38;
 
         /// Per Port Operational Register Offsets
-        pub const PORTSC: u64 = super::OP_BASE + 0x400; /* +(0x10 * (portnr-1)) */
-        pub const PORTPMSC: u64 = super::OP_BASE + 0x404;
-        pub const PORTLI: u64 = super::OP_BASE + 0x408;
+        pub const PORTSC_USB3: u64 = super::OP_BASE + 0x400; /* +(0x10 * (portnr-1)) */
+        pub const PORTPMSC_USB3: u64 = super::OP_BASE + 0x404;
+        pub const PORTLI_USB3: u64 = super::OP_BASE + 0x408;
+        pub const PORTSC_USB2: u64 = super::OP_BASE + 0x410;
+        pub const PORTPMSC_USB2: u64 = super::OP_BASE + 0x414;
+        pub const PORTLI_USB2: u64 = super::OP_BASE + 0x418;
 
         /// Runtime Register Offsets
         pub const MFINDEX: u64 = super::RUN_BASE;
@@ -290,9 +299,21 @@ pub mod xhci {
             const ID: u64 = 2;
             const MAJOR: u64 = 0x03;
             const MINOR: u64 = 0x20;
+            const NEXT: u64 = (super::super::offset::SUPPORTED_PROTOCOLS_USB2
+                - super::super::offset::SUPPORTED_PROTOCOLS)
+                >> 2;
+            pub const CAP_INFO: u64 = ID | (MAJOR << 24) | (MINOR << 16) | (NEXT << 8);
+            pub const CONFIG: u64 = 1 | (super::super::NUM_USB3_PORTS << 8);
+        }
+
+        pub mod supported_protocols_usb2 {
+            const ID: u64 = 2;
+            const MAJOR: u64 = 0x02;
+            const MINOR: u64 = 0x00;
             const NEXT: u64 = 0;
             pub const CAP_INFO: u64 = ID | (MAJOR << 24) | (MINOR << 16) | (NEXT << 8);
-            pub const CONFIG: u64 = 1 | (super::super::MAX_PORTS << 8);
+            pub const CONFIG: u64 =
+                (super::super::NUM_USB3_PORTS + 1) | (super::super::NUM_USB2_PORTS << 8);
         }
     }
 

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -70,8 +70,11 @@ pub struct XhciController {
     /// The interrupt line triggered to signal device events.
     interrupt_line: Arc<dyn InterruptLine>,
 
-    /// State of the PORTSC register
-    portsc: PortscRegister,
+    /// State of the USB3 PORTSC register
+    portsc_usb3: PortscRegister,
+
+    /// State of the USB2 PORTSC register
+    portsc_usb2: PortscRegister,
 }
 
 impl XhciController {
@@ -104,9 +107,10 @@ impl XhciController {
             interrupt_management: 0,
             interrupt_moderation_interval: runtime::IMOD_DEFAULT,
             interrupt_line: Arc::new(DummyInterruptLine::default()),
-            portsc: PortscRegister::new(
+            portsc_usb3: PortscRegister::new(
                 portsc::CCS | portsc::PED | portsc::PP | portsc::CSC | portsc::PEC | portsc::PRC,
             ),
+            portsc_usb2: PortscRegister::new(portsc::PP),
         }
     }
 
@@ -451,7 +455,8 @@ impl PciDevice for Mutex<XhciController> {
             offset::CONFIG => self.lock().unwrap().enable_slots(value),
             // USBSTS writes occur but we can ignore them (to get a device enumerated)
             offset::USBSTS => {}
-            offset::PORTSC => self.lock().unwrap().portsc.write(value),
+            offset::PORTSC_USB3 => self.lock().unwrap().portsc_usb3.write(value),
+            offset::PORTSC_USB2 => self.lock().unwrap().portsc_usb2.write(value),
 
             // xHC Runtime Registers
             offset::IMAN => self.lock().unwrap().interrupt_management = value,
@@ -495,6 +500,8 @@ impl PciDevice for Mutex<XhciController> {
             // xHC Extended Capability ("Supported Protocols Capability")
             offset::SUPPORTED_PROTOCOLS => capability::supported_protocols::CAP_INFO,
             offset::SUPPORTED_PROTOCOLS_CONFIG => capability::supported_protocols::CONFIG,
+            offset::SUPPORTED_PROTOCOLS_USB2 => capability::supported_protocols_usb2::CAP_INFO,
+            offset::SUPPORTED_PROTOCOLS_USB2_CONFIG => capability::supported_protocols_usb2::CONFIG,
 
             // xHC Operational Registers
             offset::USBCMD => 0,
@@ -507,8 +514,10 @@ impl PciDevice for Mutex<XhciController> {
             offset::PAGESIZE => 0x1, /* 4k Pages */
             offset::CONFIG => self.lock().unwrap().config(),
 
-            offset::PORTSC => self.lock().unwrap().portsc.read(),
-            offset::PORTLI => 0,
+            offset::PORTSC_USB3 => self.lock().unwrap().portsc_usb3.read(),
+            offset::PORTLI_USB3 => 0,
+            offset::PORTSC_USB2 => self.lock().unwrap().portsc_usb2.read(),
+            offset::PORTLI_USB2 => 0,
 
             // xHC Runtime Registers
             offset::IMAN => self.lock().unwrap().interrupt_management,


### PR DESCRIPTION
so far, we reported that we only support a single port, which supported USB 3.2. This port supports 3.0, 3.1, and 3.2 device, but does not support USB 2. Further, the kernel is confused by us reporting a single USB 3 port—usually, an USB-3-capable physical port would report both a USB 2 as well as a USB 3 port (the kernel assumes there are two ports both they both map to our single port).

This PR adds a second port and configures the port's protocol to USB 2. For now, we indicate with the associated PORTSC that no device is connected. The functionality of the existing USB 3 port is unaffected.

I propose this as a single PR with the thought that @ziyifu225 can work on supporting n ports with USB 2 in mind, while I focus on making USB 2 devices work.