### PR TITLE
Correct USB speed ids

### DIFF
--- a/src/device/pci/realdevice.rs
+++ b/src/device/pci/realdevice.rs
@@ -9,8 +9,8 @@ use std::fmt::{self, Debug};
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Speed {
-    Low = 1,
-    Full = 2,
+    Full = 1,
+    Low = 2,
     High = 3,
     Super = 4,
     SuperPlus = 5,


### PR DESCRIPTION
In #80, I mixed up the speed identifier for fullspeed and lowspeed. I did not notice the issue because I could only test with a USB flashdrive, which was a highspeed device. While working on enabling interrupt endpoints, I noticed that the driver was unhappy with the lowspeed mouse and keyboard I connected.