### PR TITLE
Identify endpoint types

### DIFF
--- a/src/device/pci/nusb.rs
+++ b/src/device/pci/nusb.rs
@@ -5,7 +5,7 @@ use tracing::{debug, warn};
 use crate::device::bus::BusDeviceRef;
 use crate::device::pci::trb::CompletionCode;
 
-use super::realdevice::Speed;
+use super::realdevice::{EndpointType, Speed};
 use super::trb::{NormalTrbData, TransferTrb, TransferTrbVariant};
 use super::{realdevice::RealDevice, usbrequest::UsbRequest};
 use std::cmp::Ordering::*;
@@ -228,7 +228,7 @@ impl RealDevice for NusbDeviceWrapper {
         (CompletionCode::Success, 0)
     }
 
-    fn enable_endpoint(&mut self, endpoint_id: u8) {
+    fn enable_endpoint(&mut self, endpoint_id: u8, _endpoint_type: EndpointType) {
         if endpoint_id == 1 {
             // id of the control endpoint
             //

--- a/src/device/pci/realdevice.rs
+++ b/src/device/pci/realdevice.rs
@@ -38,7 +38,7 @@ impl fmt::Display for Speed {
 pub trait RealDevice: Debug {
     fn speed(&self) -> Option<Speed>;
     fn control_transfer(&self, request: &UsbRequest, dma_bus: &BusDeviceRef);
-    fn enable_endpoint(&mut self, endpoint_id: u8);
+    fn enable_endpoint(&mut self, endpoint_id: u8, endpoint_type: EndpointType);
     fn transfer_out(
         &mut self,
         endpoint_id: u8,

--- a/src/device/pci/realdevice.rs
+++ b/src/device/pci/realdevice.rs
@@ -52,3 +52,11 @@ pub trait RealDevice: Debug {
         dma_bus: &BusDeviceRef,
     ) -> (CompletionCode, u32);
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndpointType {
+    Control,
+    BulkIn,
+    BulkOut,
+    InterruptIn,
+}

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -318,7 +318,7 @@ impl XhciController {
         let device_context = self.device_slot_manager.get_device_context(data.slot_id);
         let enabled_endpoints = device_context.configure_endpoints(data.input_context_pointer);
         // Program requires real USB device for all XHCI operations (pattern used throughout file)
-        for i in enabled_endpoints {
+        for (i, _ep_type) in enabled_endpoints {
             self.real_device.as_mut().unwrap().enable_endpoint(i);
         }
     }

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -318,8 +318,11 @@ impl XhciController {
         let device_context = self.device_slot_manager.get_device_context(data.slot_id);
         let enabled_endpoints = device_context.configure_endpoints(data.input_context_pointer);
         // Program requires real USB device for all XHCI operations (pattern used throughout file)
-        for (i, _ep_type) in enabled_endpoints {
-            self.real_device.as_mut().unwrap().enable_endpoint(i);
+        for (i, ep_type) in enabled_endpoints {
+            self.real_device
+                .as_mut()
+                .unwrap()
+                .enable_endpoint(i, ep_type);
         }
     }
 


### PR DESCRIPTION
So far, we assumed that everything except the control endpoint EP0 is a bulk endpoint. We want to support InterruptIn endpoints soon, so we need to be able to distinguish the configured endpoint type, so we can access the endpoints on the real device correctly. This PR implements the functionality to extract the endpoint-type information from the input context in the Configure Endpoint Command and to provide the information to the `enable_endpoint` function of the `realdevice` trait, where it will be needed to enable the correct endpoints on the real USB device.

This PR does not change the nusb implementation of `realdevice`, because the `enable_endpoint` function will receive substantial rework to make the existing bulk-endpoint handling asynchronous; making changes to handle interrupt endpoints does not make sense yet.
