### PR TITLE
Add PCAP logging option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,6 +49,11 @@ pub struct Cli {
     /// for hotplug commands.
     #[arg(long, value_name = "PATH")]
     pub hotplug_socket_path: Option<PathBuf>,
+
+    /// Enable PCAP logging and write captured USB traffic to this file.
+    /// The file will be created when the first packet is logged.
+    #[arg(long, value_name = "PATH")]
+    pub pcap_path: Option<PathBuf>,
 }
 
 /// The location of the server socket for the vfio-user client connection.

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -13,6 +13,7 @@ pub mod bus;
 pub mod interrupt_line;
 pub mod interval;
 pub mod msi_message;
+pub mod pcap;
 pub mod pci;
 pub mod register_set;
 pub mod xhci;

--- a/src/device/pcap/meta.rs
+++ b/src/device/pcap/meta.rs
@@ -4,10 +4,11 @@ use crate::device::xhci::real_endpoint_handle::{
 };
 
 const LINUX_ENODEV: i32 = 19;
+const LINUX_EINVAL: i32 = 22;
 const LINUX_EPIPE: i32 = 32;
 const LINUX_EPROTO: i32 = 71;
 
-const fn errno_status(errno: i32) -> i32 {
+pub const fn errno_status(errno: i32) -> i32 {
     -errno
 }
 
@@ -83,6 +84,10 @@ pub const fn control_error_status(error: &ControlRequestProcessingResult) -> i32
         ControlRequestProcessingResult::SuccessfulControlIn(_)
         | ControlRequestProcessingResult::SuccessfulControlOut => 0,
     }
+}
+
+pub const fn trb_error_status() -> i32 {
+    errno_status(LINUX_EINVAL)
 }
 
 pub const fn in_error_status(error: &InTrbProcessingResult) -> i32 {

--- a/src/device/pcap/meta.rs
+++ b/src/device/pcap/meta.rs
@@ -1,0 +1,109 @@
+use super::packet::{UsbDirection, UsbTransferType};
+use crate::device::xhci::real_endpoint_handle::{
+    ControlRequestProcessingResult, InTrbProcessingResult, OutTrbProcessingResult,
+};
+
+const LINUX_ENODEV: i32 = 19;
+const LINUX_EINVAL: i32 = 22;
+const LINUX_EPIPE: i32 = 32;
+const LINUX_EPROTO: i32 = 71;
+
+pub const fn errno_status(errno: i32) -> i32 {
+    -errno
+}
+
+/// Context passed from endpoint handlers to PCAP logging, describing
+/// which USB endpoint a record belongs to.
+#[derive(Clone, Copy, Debug)]
+pub struct EndpointPcapMeta {
+    pub bus_number: u16,
+    pub device_address: u8,
+    pub endpoint_id: u8,
+    pub transfer_type: UsbTransferType,
+    pub direction: UsbDirection,
+}
+
+impl EndpointPcapMeta {
+    pub const fn control(bus: u16, dev: u8, ep: u8) -> Self {
+        Self {
+            bus_number: bus,
+            device_address: dev,
+            endpoint_id: ep,
+            transfer_type: UsbTransferType::Control,
+            // Placeholder only: control direction is determined per request and overwritten later.
+            direction: UsbDirection::HostToDevice,
+        }
+    }
+
+    pub const fn bulk_in(bus: u16, dev: u8, ep: u8) -> Self {
+        Self {
+            bus_number: bus,
+            device_address: dev,
+            endpoint_id: ep,
+            transfer_type: UsbTransferType::Bulk,
+            direction: UsbDirection::DeviceToHost,
+        }
+    }
+
+    pub const fn bulk_out(bus: u16, dev: u8, ep: u8) -> Self {
+        Self {
+            bus_number: bus,
+            device_address: dev,
+            endpoint_id: ep,
+            transfer_type: UsbTransferType::Bulk,
+            direction: UsbDirection::HostToDevice,
+        }
+    }
+
+    pub const fn interrupt_in(bus: u16, dev: u8, ep: u8) -> Self {
+        Self {
+            bus_number: bus,
+            device_address: dev,
+            endpoint_id: ep,
+            transfer_type: UsbTransferType::Interrupt,
+            direction: UsbDirection::DeviceToHost,
+        }
+    }
+
+    pub const fn interrupt_out(bus: u16, dev: u8, ep: u8) -> Self {
+        Self {
+            bus_number: bus,
+            device_address: dev,
+            endpoint_id: ep,
+            transfer_type: UsbTransferType::Interrupt,
+            direction: UsbDirection::HostToDevice,
+        }
+    }
+}
+
+pub const fn control_error_status(error: &ControlRequestProcessingResult) -> i32 {
+    match error {
+        ControlRequestProcessingResult::Disconnect => errno_status(LINUX_ENODEV),
+        ControlRequestProcessingResult::Stall => errno_status(LINUX_EPIPE),
+        ControlRequestProcessingResult::TransactionError => errno_status(LINUX_EPROTO),
+        ControlRequestProcessingResult::SuccessfulControlIn(_)
+        | ControlRequestProcessingResult::SuccessfulControlOut => 0,
+    }
+}
+
+pub const fn trb_error_status() -> i32 {
+    errno_status(LINUX_EINVAL)
+}
+
+pub const fn in_error_status(error: &InTrbProcessingResult) -> i32 {
+    match error {
+        InTrbProcessingResult::Disconnect => errno_status(LINUX_ENODEV),
+        InTrbProcessingResult::Stall => errno_status(LINUX_EPIPE),
+        InTrbProcessingResult::TransactionError => errno_status(LINUX_EPROTO),
+        InTrbProcessingResult::Success(_) => 0,
+    }
+}
+
+pub const fn out_error_status(error: &OutTrbProcessingResult) -> i32 {
+    match error {
+        OutTrbProcessingResult::Disconnect => errno_status(LINUX_ENODEV),
+        OutTrbProcessingResult::Stall => errno_status(LINUX_EPIPE),
+        OutTrbProcessingResult::TransactionError => errno_status(LINUX_EPROTO),
+        OutTrbProcessingResult::Success => 0,
+    }
+}

--- a/src/device/pcap/meta.rs
+++ b/src/device/pcap/meta.rs
@@ -1,4 +1,4 @@
-use super::packet::{UsbDirection, UsbTransferType};
+use super::packet::UsbTransferType;
 use crate::device::xhci::real_endpoint_handle::{
     ControlRequestProcessingResult, InTrbProcessingResult, OutTrbProcessingResult,
 };
@@ -20,7 +20,6 @@ pub struct EndpointPcapMeta {
     pub device_address: u8,
     pub endpoint_id: u8,
     pub transfer_type: UsbTransferType,
-    pub direction: UsbDirection,
 }
 
 impl EndpointPcapMeta {
@@ -30,48 +29,24 @@ impl EndpointPcapMeta {
             device_address: dev,
             endpoint_id: ep,
             transfer_type: UsbTransferType::Control,
-            // Placeholder only: control direction is determined per request and overwritten later.
-            direction: UsbDirection::HostToDevice,
         }
     }
 
-    pub const fn bulk_in(bus: u16, dev: u8, ep: u8) -> Self {
+    pub const fn bulk(bus: u16, dev: u8, ep: u8) -> Self {
         Self {
             bus_number: bus,
             device_address: dev,
             endpoint_id: ep,
             transfer_type: UsbTransferType::Bulk,
-            direction: UsbDirection::DeviceToHost,
         }
     }
 
-    pub const fn bulk_out(bus: u16, dev: u8, ep: u8) -> Self {
-        Self {
-            bus_number: bus,
-            device_address: dev,
-            endpoint_id: ep,
-            transfer_type: UsbTransferType::Bulk,
-            direction: UsbDirection::HostToDevice,
-        }
-    }
-
-    pub const fn interrupt_in(bus: u16, dev: u8, ep: u8) -> Self {
+    pub const fn interrupt(bus: u16, dev: u8, ep: u8) -> Self {
         Self {
             bus_number: bus,
             device_address: dev,
             endpoint_id: ep,
             transfer_type: UsbTransferType::Interrupt,
-            direction: UsbDirection::DeviceToHost,
-        }
-    }
-
-    pub const fn interrupt_out(bus: u16, dev: u8, ep: u8) -> Self {
-        Self {
-            bus_number: bus,
-            device_address: dev,
-            endpoint_id: ep,
-            transfer_type: UsbTransferType::Interrupt,
-            direction: UsbDirection::HostToDevice,
         }
     }
 }

--- a/src/device/pcap/meta.rs
+++ b/src/device/pcap/meta.rs
@@ -1,4 +1,15 @@
 use super::packet::{UsbDirection, UsbTransferType};
+use crate::device::xhci::real_endpoint_handle::{
+    ControlRequestProcessingResult, InTrbProcessingResult, OutTrbProcessingResult,
+};
+
+const LINUX_ENODEV: i32 = 19;
+const LINUX_EPIPE: i32 = 32;
+const LINUX_EPROTO: i32 = 71;
+
+const fn errno_status(errno: i32) -> i32 {
+    -errno
+}
 
 /// Context passed from endpoint handlers to PCAP logging, describing
 /// which USB endpoint a record belongs to.
@@ -61,5 +72,33 @@ impl EndpointPcapMeta {
             transfer_type: UsbTransferType::Interrupt,
             direction: UsbDirection::HostToDevice,
         }
+    }
+}
+
+pub const fn control_error_status(error: &ControlRequestProcessingResult) -> i32 {
+    match error {
+        ControlRequestProcessingResult::Disconnect => errno_status(LINUX_ENODEV),
+        ControlRequestProcessingResult::Stall => errno_status(LINUX_EPIPE),
+        ControlRequestProcessingResult::TransactionError => errno_status(LINUX_EPROTO),
+        ControlRequestProcessingResult::SuccessfulControlIn(_)
+        | ControlRequestProcessingResult::SuccessfulControlOut => 0,
+    }
+}
+
+pub const fn in_error_status(error: &InTrbProcessingResult) -> i32 {
+    match error {
+        InTrbProcessingResult::Disconnect => errno_status(LINUX_ENODEV),
+        InTrbProcessingResult::Stall => errno_status(LINUX_EPIPE),
+        InTrbProcessingResult::TransactionError => errno_status(LINUX_EPROTO),
+        InTrbProcessingResult::Success(_) => 0,
+    }
+}
+
+pub const fn out_error_status(error: &OutTrbProcessingResult) -> i32 {
+    match error {
+        OutTrbProcessingResult::Disconnect => errno_status(LINUX_ENODEV),
+        OutTrbProcessingResult::Stall => errno_status(LINUX_EPIPE),
+        OutTrbProcessingResult::TransactionError => errno_status(LINUX_EPROTO),
+        OutTrbProcessingResult::Success => 0,
     }
 }

--- a/src/device/pcap/meta.rs
+++ b/src/device/pcap/meta.rs
@@ -1,0 +1,65 @@
+use super::packet::{UsbDirection, UsbTransferType};
+
+/// Context passed from endpoint handlers to PCAP logging, describing
+/// which USB endpoint a record belongs to.
+#[derive(Clone, Copy, Debug)]
+pub struct EndpointPcapMeta {
+    pub bus_number: u16,
+    pub device_address: u8,
+    pub endpoint_id: u8,
+    pub transfer_type: UsbTransferType,
+    pub direction: UsbDirection,
+}
+
+impl EndpointPcapMeta {
+    pub const fn control(bus: u16, dev: u8, ep: u8) -> Self {
+        Self {
+            bus_number: bus,
+            device_address: dev,
+            endpoint_id: ep,
+            transfer_type: UsbTransferType::Control,
+            // Placeholder only: control direction is determined per request and overwritten later.
+            direction: UsbDirection::HostToDevice,
+        }
+    }
+
+    pub const fn bulk_in(bus: u16, dev: u8, ep: u8) -> Self {
+        Self {
+            bus_number: bus,
+            device_address: dev,
+            endpoint_id: ep,
+            transfer_type: UsbTransferType::Bulk,
+            direction: UsbDirection::DeviceToHost,
+        }
+    }
+
+    pub const fn bulk_out(bus: u16, dev: u8, ep: u8) -> Self {
+        Self {
+            bus_number: bus,
+            device_address: dev,
+            endpoint_id: ep,
+            transfer_type: UsbTransferType::Bulk,
+            direction: UsbDirection::HostToDevice,
+        }
+    }
+
+    pub const fn interrupt_in(bus: u16, dev: u8, ep: u8) -> Self {
+        Self {
+            bus_number: bus,
+            device_address: dev,
+            endpoint_id: ep,
+            transfer_type: UsbTransferType::Interrupt,
+            direction: UsbDirection::DeviceToHost,
+        }
+    }
+
+    pub const fn interrupt_out(bus: u16, dev: u8, ep: u8) -> Self {
+        Self {
+            bus_number: bus,
+            device_address: dev,
+            endpoint_id: ep,
+            transfer_type: UsbTransferType::Interrupt,
+            direction: UsbDirection::HostToDevice,
+        }
+    }
+}

--- a/src/device/pcap/mod.rs
+++ b/src/device/pcap/mod.rs
@@ -2,7 +2,7 @@ pub mod meta;
 pub mod packet;
 
 pub use meta::EndpointPcapMeta;
-pub use packet::{Timestamp, UsbDirection, UsbEventType, UsbPcapManager};
+pub use packet::{UsbDirection, UsbEventType, UsbPcapManager};
 
 use crate::device::xhci::{
     real_endpoint_handle::{
@@ -11,52 +11,36 @@ use crate::device::xhci::{
     usbrequest::UsbRequest,
 };
 
-pub fn control_submission(base: EndpointPcapMeta, req: &UsbRequest, event_timestamp: Timestamp) {
+pub fn control_submission(base: EndpointPcapMeta, req: &UsbRequest) {
     let direction = if req.request_type & 0x80 == 0 {
         UsbDirection::HostToDevice
     } else {
         UsbDirection::DeviceToHost
     };
     let meta = EndpointPcapMeta { direction, ..base };
-    packet::log_control_submission(
-        meta,
-        req,
-        event_timestamp,
-        req.data.as_deref().unwrap_or(&[]),
-    );
+    packet::log_control_submission(meta, req, req.data.as_deref().unwrap_or(&[]));
 }
 
-pub fn control_completion_in(
-    base: EndpointPcapMeta,
-    urb_id: u64,
-    data: &[u8],
-    event_timestamp: Timestamp,
-) {
+pub fn control_completion_in(base: EndpointPcapMeta, urb_id: u64, data: &[u8]) {
     let meta = EndpointPcapMeta {
         direction: UsbDirection::DeviceToHost,
         ..base
     };
-    packet::log_control_completion(meta, urb_id, event_timestamp, 0, data.len() as u32, data);
+    packet::log_control_completion(meta, urb_id, 0, data.len() as u32, data);
 }
 
-pub fn control_completion_out(
-    base: EndpointPcapMeta,
-    urb_id: u64,
-    len: u32,
-    event_timestamp: Timestamp,
-) {
+pub fn control_completion_out(base: EndpointPcapMeta, urb_id: u64, len: u32) {
     let meta = EndpointPcapMeta {
         direction: UsbDirection::HostToDevice,
         ..base
     };
-    packet::log_control_completion(meta, urb_id, event_timestamp, 0, len, &[]);
+    packet::log_control_completion(meta, urb_id, 0, len, &[]);
 }
 
 pub fn control_in_error(
     base: EndpointPcapMeta,
     req: &UsbRequest,
     error: &ControlRequestProcessingResult,
-    event_timestamp: Timestamp,
 ) {
     let meta = EndpointPcapMeta {
         direction: UsbDirection::DeviceToHost,
@@ -66,7 +50,6 @@ pub fn control_in_error(
         meta,
         req.address,
         UsbEventType::Error,
-        event_timestamp,
         meta::control_error_status(error),
         Some(packet::build_setup_bytes(req)),
         req.data.as_deref().unwrap_or(&[]),
@@ -77,7 +60,6 @@ pub fn control_out_error(
     base: EndpointPcapMeta,
     req: &UsbRequest,
     error: &ControlRequestProcessingResult,
-    event_timestamp: Timestamp,
 ) {
     let meta = EndpointPcapMeta {
         direction: UsbDirection::HostToDevice,
@@ -87,55 +69,37 @@ pub fn control_out_error(
         meta,
         req.address,
         UsbEventType::Error,
-        event_timestamp,
         meta::control_error_status(error),
         Some(packet::build_setup_bytes(req)),
         req.data.as_deref().unwrap_or(&[]),
     );
 }
 
-pub fn in_submission(
-    base: EndpointPcapMeta,
-    urb_id: u64,
-    expected_len: u32,
-    event_timestamp: Timestamp,
-) {
-    packet::log_submission(base, urb_id, event_timestamp, expected_len, None, &[]);
+pub fn in_submission(base: EndpointPcapMeta, urb_id: u64, expected_len: u32) {
+    packet::log_submission(base, urb_id, expected_len, None, &[]);
 }
 
-pub fn in_completion(base: EndpointPcapMeta, urb_id: u64, data: &[u8], event_timestamp: Timestamp) {
-    packet::log_completion(base, urb_id, event_timestamp, 0, data.len() as u32, data);
+pub fn in_completion(base: EndpointPcapMeta, urb_id: u64, data: &[u8]) {
+    packet::log_completion(base, urb_id, 0, data.len() as u32, data);
 }
 
-pub fn in_error(
-    meta: EndpointPcapMeta,
-    urb_id: u64,
-    error: &InTrbProcessingResult,
-    event_timestamp: Timestamp,
-) {
+pub fn in_error(meta: EndpointPcapMeta, urb_id: u64, error: &InTrbProcessingResult) {
     packet::log_error(
         meta,
         urb_id,
         UsbEventType::Error,
-        event_timestamp,
         meta::in_error_status(error),
         None,
         &[],
     );
 }
 
-pub fn out_submission(
-    meta: EndpointPcapMeta,
-    urb_id: u64,
-    payload: &[u8],
-    expected_len: u32,
-    event_timestamp: Timestamp,
-) {
-    packet::log_submission(meta, urb_id, event_timestamp, expected_len, None, payload);
+pub fn out_submission(meta: EndpointPcapMeta, urb_id: u64, payload: &[u8], expected_len: u32) {
+    packet::log_submission(meta, urb_id, expected_len, None, payload);
 }
 
-pub fn out_completion(meta: EndpointPcapMeta, urb_id: u64, len: u32, event_timestamp: Timestamp) {
-    packet::log_completion(meta, urb_id, event_timestamp, 0, len, &[]);
+pub fn out_completion(meta: EndpointPcapMeta, urb_id: u64, len: u32) {
+    packet::log_completion(meta, urb_id, 0, len, &[]);
 }
 
 pub fn out_error(
@@ -143,25 +107,22 @@ pub fn out_error(
     urb_id: u64,
     error: &OutTrbProcessingResult,
     payload: &[u8],
-    event_timestamp: Timestamp,
 ) {
     packet::log_error(
         meta,
         urb_id,
         UsbEventType::Error,
-        event_timestamp,
         meta::out_error_status(error),
         None,
         payload,
     );
 }
 
-pub fn trb_error(meta: EndpointPcapMeta, urb_id: u64, event_timestamp: Timestamp) {
+pub fn trb_error(meta: EndpointPcapMeta, urb_id: u64) {
     packet::log_error(
         meta,
         urb_id,
         UsbEventType::Error,
-        event_timestamp,
         meta::trb_error_status(),
         None,
         &[],

--- a/src/device/pcap/mod.rs
+++ b/src/device/pcap/mod.rs
@@ -1,0 +1,75 @@
+pub mod meta;
+pub mod packet;
+
+pub use meta::EndpointPcapMeta;
+pub use packet::{Timestamp, UsbDirection, UsbEventType, UsbPcapManager, UsbTransferType};
+
+use crate::device::xhci::usbrequest::UsbRequest;
+
+pub fn control_submission(base: EndpointPcapMeta, req: &UsbRequest, event_timestamp: Timestamp) {
+    let direction = if req.request_type & 0x80 == 0 {
+        UsbDirection::HostToDevice
+    } else {
+        UsbDirection::DeviceToHost
+    };
+    let meta = EndpointPcapMeta { direction, ..base };
+    packet::log_control_submission(
+        meta,
+        req,
+        event_timestamp,
+        req.data.as_deref().unwrap_or(&[]),
+    );
+}
+
+pub fn control_completion_in(
+    base: EndpointPcapMeta,
+    urb_id: u64,
+    data: &[u8],
+    event_timestamp: Timestamp,
+) {
+    let meta = EndpointPcapMeta {
+        direction: UsbDirection::DeviceToHost,
+        ..base
+    };
+    packet::log_control_completion(meta, urb_id, event_timestamp, 0, data.len() as u32, data);
+}
+
+pub fn control_completion_out(
+    base: EndpointPcapMeta,
+    urb_id: u64,
+    len: u32,
+    event_timestamp: Timestamp,
+) {
+    let meta = EndpointPcapMeta {
+        direction: UsbDirection::HostToDevice,
+        ..base
+    };
+    packet::log_control_completion(meta, urb_id, event_timestamp, 0, len, &[]);
+}
+
+pub fn in_submission(
+    base: EndpointPcapMeta,
+    urb_id: u64,
+    expected_len: u32,
+    event_timestamp: Timestamp,
+) {
+    packet::log_submission(base, urb_id, event_timestamp, expected_len, None, &[]);
+}
+
+pub fn in_completion(base: EndpointPcapMeta, urb_id: u64, data: &[u8], event_timestamp: Timestamp) {
+    packet::log_completion(base, urb_id, event_timestamp, 0, data.len() as u32, data);
+}
+
+pub fn out_submission(
+    meta: EndpointPcapMeta,
+    urb_id: u64,
+    payload: &[u8],
+    expected_len: u32,
+    event_timestamp: Timestamp,
+) {
+    packet::log_submission(meta, urb_id, event_timestamp, expected_len, None, payload);
+}
+
+pub fn out_completion(meta: EndpointPcapMeta, urb_id: u64, len: u32, event_timestamp: Timestamp) {
+    packet::log_completion(meta, urb_id, event_timestamp, 0, len, &[]);
+}

--- a/src/device/pcap/mod.rs
+++ b/src/device/pcap/mod.rs
@@ -12,29 +12,32 @@ use crate::device::xhci::{
 };
 
 pub fn control_submission(base: EndpointPcapMeta, req: &UsbRequest) {
-    let direction = if req.request_type & 0x80 == 0 {
+    let control_direction = if req.request_type & 0x80 == 0 {
         UsbDirection::HostToDevice
     } else {
         UsbDirection::DeviceToHost
     };
-    let meta = EndpointPcapMeta { direction, ..base };
-    packet::log_control_submission(meta, req, req.data.as_deref().unwrap_or(&[]));
+    packet::log_control_submission(
+        base,
+        control_direction,
+        req,
+        req.data.as_deref().unwrap_or(&[]),
+    );
 }
 
 pub fn control_completion_in(base: EndpointPcapMeta, urb_id: u64, data: &[u8]) {
-    let meta = EndpointPcapMeta {
-        direction: UsbDirection::DeviceToHost,
-        ..base
-    };
-    packet::log_control_completion(meta, urb_id, 0, data.len() as u32, data);
+    packet::log_control_completion(
+        base,
+        UsbDirection::DeviceToHost,
+        urb_id,
+        0,
+        data.len() as u32,
+        data,
+    );
 }
 
 pub fn control_completion_out(base: EndpointPcapMeta, urb_id: u64, len: u32) {
-    let meta = EndpointPcapMeta {
-        direction: UsbDirection::HostToDevice,
-        ..base
-    };
-    packet::log_control_completion(meta, urb_id, 0, len, &[]);
+    packet::log_control_completion(base, UsbDirection::HostToDevice, urb_id, 0, len, &[]);
 }
 
 pub fn control_in_error(
@@ -42,12 +45,9 @@ pub fn control_in_error(
     req: &UsbRequest,
     error: &ControlRequestProcessingResult,
 ) {
-    let meta = EndpointPcapMeta {
-        direction: UsbDirection::DeviceToHost,
-        ..base
-    };
     packet::log_error(
-        meta,
+        base,
+        Some(UsbDirection::DeviceToHost),
         req.address,
         UsbEventType::Error,
         meta::control_error_status(error),
@@ -61,12 +61,9 @@ pub fn control_out_error(
     req: &UsbRequest,
     error: &ControlRequestProcessingResult,
 ) {
-    let meta = EndpointPcapMeta {
-        direction: UsbDirection::HostToDevice,
-        ..base
-    };
     packet::log_error(
-        meta,
+        base,
+        Some(UsbDirection::HostToDevice),
         req.address,
         UsbEventType::Error,
         meta::control_error_status(error),
@@ -76,16 +73,17 @@ pub fn control_out_error(
 }
 
 pub fn in_submission(base: EndpointPcapMeta, urb_id: u64, expected_len: u32) {
-    packet::log_submission(base, urb_id, expected_len, None, &[]);
+    packet::log_submission(base, None, urb_id, expected_len, None, &[]);
 }
 
 pub fn in_completion(base: EndpointPcapMeta, urb_id: u64, data: &[u8]) {
-    packet::log_completion(base, urb_id, 0, data.len() as u32, data);
+    packet::log_completion(base, None, urb_id, 0, data.len() as u32, data);
 }
 
 pub fn in_error(meta: EndpointPcapMeta, urb_id: u64, error: &InTrbProcessingResult) {
     packet::log_error(
         meta,
+        None,
         urb_id,
         UsbEventType::Error,
         meta::in_error_status(error),
@@ -95,11 +93,11 @@ pub fn in_error(meta: EndpointPcapMeta, urb_id: u64, error: &InTrbProcessingResu
 }
 
 pub fn out_submission(meta: EndpointPcapMeta, urb_id: u64, payload: &[u8], expected_len: u32) {
-    packet::log_submission(meta, urb_id, expected_len, None, payload);
+    packet::log_submission(meta, None, urb_id, expected_len, None, payload);
 }
 
 pub fn out_completion(meta: EndpointPcapMeta, urb_id: u64, len: u32) {
-    packet::log_completion(meta, urb_id, 0, len, &[]);
+    packet::log_completion(meta, None, urb_id, 0, len, &[]);
 }
 
 pub fn out_error(
@@ -110,6 +108,7 @@ pub fn out_error(
 ) {
     packet::log_error(
         meta,
+        None,
         urb_id,
         UsbEventType::Error,
         meta::out_error_status(error),
@@ -121,6 +120,7 @@ pub fn out_error(
 pub fn trb_error(meta: EndpointPcapMeta, urb_id: u64) {
     packet::log_error(
         meta,
+        None,
         urb_id,
         UsbEventType::Error,
         meta::trb_error_status(),

--- a/src/device/pcap/mod.rs
+++ b/src/device/pcap/mod.rs
@@ -1,0 +1,130 @@
+pub mod meta;
+pub mod packet;
+
+pub use meta::EndpointPcapMeta;
+pub use packet::{UsbDirection, UsbEventType, UsbPcapManager};
+
+use crate::device::xhci::{
+    real_endpoint_handle::{
+        ControlRequestProcessingResult, InTrbProcessingResult, OutTrbProcessingResult,
+    },
+    usbrequest::UsbRequest,
+};
+
+pub fn control_submission(base: EndpointPcapMeta, req: &UsbRequest) {
+    let direction = if req.request_type & 0x80 == 0 {
+        UsbDirection::HostToDevice
+    } else {
+        UsbDirection::DeviceToHost
+    };
+    let meta = EndpointPcapMeta { direction, ..base };
+    packet::log_control_submission(meta, req, req.data.as_deref().unwrap_or(&[]));
+}
+
+pub fn control_completion_in(base: EndpointPcapMeta, urb_id: u64, data: &[u8]) {
+    let meta = EndpointPcapMeta {
+        direction: UsbDirection::DeviceToHost,
+        ..base
+    };
+    packet::log_control_completion(meta, urb_id, 0, data.len() as u32, data);
+}
+
+pub fn control_completion_out(base: EndpointPcapMeta, urb_id: u64, len: u32) {
+    let meta = EndpointPcapMeta {
+        direction: UsbDirection::HostToDevice,
+        ..base
+    };
+    packet::log_control_completion(meta, urb_id, 0, len, &[]);
+}
+
+pub fn control_in_error(
+    base: EndpointPcapMeta,
+    req: &UsbRequest,
+    error: &ControlRequestProcessingResult,
+) {
+    let meta = EndpointPcapMeta {
+        direction: UsbDirection::DeviceToHost,
+        ..base
+    };
+    packet::log_error(
+        meta,
+        req.address,
+        UsbEventType::Error,
+        meta::control_error_status(error),
+        Some(packet::build_setup_bytes(req)),
+        req.data.as_deref().unwrap_or(&[]),
+    );
+}
+
+pub fn control_out_error(
+    base: EndpointPcapMeta,
+    req: &UsbRequest,
+    error: &ControlRequestProcessingResult,
+) {
+    let meta = EndpointPcapMeta {
+        direction: UsbDirection::HostToDevice,
+        ..base
+    };
+    packet::log_error(
+        meta,
+        req.address,
+        UsbEventType::Error,
+        meta::control_error_status(error),
+        Some(packet::build_setup_bytes(req)),
+        req.data.as_deref().unwrap_or(&[]),
+    );
+}
+
+pub fn in_submission(base: EndpointPcapMeta, urb_id: u64, expected_len: u32) {
+    packet::log_submission(base, urb_id, expected_len, None, &[]);
+}
+
+pub fn in_completion(base: EndpointPcapMeta, urb_id: u64, data: &[u8]) {
+    packet::log_completion(base, urb_id, 0, data.len() as u32, data);
+}
+
+pub fn in_error(meta: EndpointPcapMeta, urb_id: u64, error: &InTrbProcessingResult) {
+    packet::log_error(
+        meta,
+        urb_id,
+        UsbEventType::Error,
+        meta::in_error_status(error),
+        None,
+        &[],
+    );
+}
+
+pub fn out_submission(meta: EndpointPcapMeta, urb_id: u64, payload: &[u8], expected_len: u32) {
+    packet::log_submission(meta, urb_id, expected_len, None, payload);
+}
+
+pub fn out_completion(meta: EndpointPcapMeta, urb_id: u64, len: u32) {
+    packet::log_completion(meta, urb_id, 0, len, &[]);
+}
+
+pub fn out_error(
+    meta: EndpointPcapMeta,
+    urb_id: u64,
+    error: &OutTrbProcessingResult,
+    payload: &[u8],
+) {
+    packet::log_error(
+        meta,
+        urb_id,
+        UsbEventType::Error,
+        meta::out_error_status(error),
+        None,
+        payload,
+    );
+}
+
+pub fn trb_error(meta: EndpointPcapMeta, urb_id: u64) {
+    packet::log_error(
+        meta,
+        urb_id,
+        UsbEventType::Error,
+        meta::trb_error_status(),
+        None,
+        &[],
+    );
+}

--- a/src/device/pcap/mod.rs
+++ b/src/device/pcap/mod.rs
@@ -2,9 +2,14 @@ pub mod meta;
 pub mod packet;
 
 pub use meta::EndpointPcapMeta;
-pub use packet::{Timestamp, UsbDirection, UsbEventType, UsbPcapManager, UsbTransferType};
+pub use packet::{Timestamp, UsbDirection, UsbEventType, UsbPcapManager};
 
-use crate::device::xhci::usbrequest::UsbRequest;
+use crate::device::xhci::{
+    real_endpoint_handle::{
+        ControlRequestProcessingResult, InTrbProcessingResult, OutTrbProcessingResult,
+    },
+    usbrequest::UsbRequest,
+};
 
 pub fn control_submission(base: EndpointPcapMeta, req: &UsbRequest, event_timestamp: Timestamp) {
     let direction = if req.request_type & 0x80 == 0 {
@@ -47,6 +52,48 @@ pub fn control_completion_out(
     packet::log_control_completion(meta, urb_id, event_timestamp, 0, len, &[]);
 }
 
+pub fn control_in_error(
+    base: EndpointPcapMeta,
+    req: &UsbRequest,
+    error: &ControlRequestProcessingResult,
+    event_timestamp: Timestamp,
+) {
+    let meta = EndpointPcapMeta {
+        direction: UsbDirection::DeviceToHost,
+        ..base
+    };
+    packet::log_error(
+        meta,
+        req.address,
+        UsbEventType::Error,
+        event_timestamp,
+        meta::control_error_status(error),
+        Some(packet::build_setup_bytes(req)),
+        req.data.as_deref().unwrap_or(&[]),
+    );
+}
+
+pub fn control_out_error(
+    base: EndpointPcapMeta,
+    req: &UsbRequest,
+    error: &ControlRequestProcessingResult,
+    event_timestamp: Timestamp,
+) {
+    let meta = EndpointPcapMeta {
+        direction: UsbDirection::HostToDevice,
+        ..base
+    };
+    packet::log_error(
+        meta,
+        req.address,
+        UsbEventType::Error,
+        event_timestamp,
+        meta::control_error_status(error),
+        Some(packet::build_setup_bytes(req)),
+        req.data.as_deref().unwrap_or(&[]),
+    );
+}
+
 pub fn in_submission(
     base: EndpointPcapMeta,
     urb_id: u64,
@@ -58,6 +105,23 @@ pub fn in_submission(
 
 pub fn in_completion(base: EndpointPcapMeta, urb_id: u64, data: &[u8], event_timestamp: Timestamp) {
     packet::log_completion(base, urb_id, event_timestamp, 0, data.len() as u32, data);
+}
+
+pub fn in_error(
+    meta: EndpointPcapMeta,
+    urb_id: u64,
+    error: &InTrbProcessingResult,
+    event_timestamp: Timestamp,
+) {
+    packet::log_error(
+        meta,
+        urb_id,
+        UsbEventType::Error,
+        event_timestamp,
+        meta::in_error_status(error),
+        None,
+        &[],
+    );
 }
 
 pub fn out_submission(
@@ -72,4 +136,22 @@ pub fn out_submission(
 
 pub fn out_completion(meta: EndpointPcapMeta, urb_id: u64, len: u32, event_timestamp: Timestamp) {
     packet::log_completion(meta, urb_id, event_timestamp, 0, len, &[]);
+}
+
+pub fn out_error(
+    meta: EndpointPcapMeta,
+    urb_id: u64,
+    error: &OutTrbProcessingResult,
+    payload: &[u8],
+    event_timestamp: Timestamp,
+) {
+    packet::log_error(
+        meta,
+        urb_id,
+        UsbEventType::Error,
+        event_timestamp,
+        meta::out_error_status(error),
+        None,
+        payload,
+    );
 }

--- a/src/device/pcap/mod.rs
+++ b/src/device/pcap/mod.rs
@@ -155,3 +155,15 @@ pub fn out_error(
         payload,
     );
 }
+
+pub fn trb_error(meta: EndpointPcapMeta, urb_id: u64, event_timestamp: Timestamp) {
+    packet::log_error(
+        meta,
+        urb_id,
+        UsbEventType::Error,
+        event_timestamp,
+        meta::trb_error_status(),
+        None,
+        &[],
+    );
+}

--- a/src/device/pcap/packet.rs
+++ b/src/device/pcap/packet.rs
@@ -1,0 +1,434 @@
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
+
+use crate::device::xhci::usbrequest::UsbRequest;
+use tracing::warn;
+
+const LINKTYPE_USB_LINUX: u32 = 189;
+const PCAP_MAGIC: u32 = 0xa1b2c3d4;
+const PCAP_MAJOR: u16 = 2;
+const PCAP_MINOR: u16 = 4;
+const SNAPLEN: u32 = 65_535;
+
+/// USB event type stored as an ASCII code in the packet header.
+#[derive(Clone, Copy)]
+pub enum UsbEventType {
+    Submission,
+    Completion,
+    Error,
+}
+
+impl UsbEventType {
+    const fn code(self) -> u8 {
+        match self {
+            Self::Submission => b'S',
+            Self::Completion => b'C',
+            Self::Error => b'E',
+        }
+    }
+}
+
+/// USB transfer type stored in the linktype header.
+#[derive(Clone, Copy, Debug)]
+pub enum UsbTransferType {
+    // TODO: implement isochronous transfer logging
+    // Isochronous,
+    Control,
+    Bulk,
+    Interrupt,
+}
+
+impl UsbTransferType {
+    const fn code(self) -> u8 {
+        match self {
+            // TODO: implement isochronous transfer logging
+            // Self::Isochronous => 0,
+            Self::Interrupt => 1,
+            Self::Control => 2,
+            Self::Bulk => 3,
+        }
+    }
+}
+
+/// USB direction used to set the endpoint address IN/OUT bit.
+#[derive(Clone, Copy, Debug)]
+pub enum UsbDirection {
+    HostToDevice,
+    DeviceToHost,
+}
+
+impl UsbDirection {
+    const fn endpoint_address(self, xhci_endpoint_id: u8) -> u8 {
+        let endpoint_number = xhci_endpoint_id / 2;
+        match self {
+            Self::HostToDevice => endpoint_number,
+            Self::DeviceToHost => endpoint_number | 0x80,
+        }
+    }
+}
+
+/// Packet timestamp in seconds and microseconds.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Timestamp {
+    pub seconds: u32,
+    pub microseconds: u32,
+}
+
+impl From<SystemTime> for Timestamp {
+    fn from(value: SystemTime) -> Self {
+        let duration = value
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default();
+        Self {
+            seconds: duration.as_secs() as u32,
+            microseconds: duration.subsec_micros(),
+        }
+    }
+}
+
+/// Linux USB per-packet header for PCAP linktype 189.
+///
+/// `header_bytes` writes the fields in little-endian order.
+pub struct UsbPacketLinktypeHeader {
+    pub id: u64,
+    pub event_type: u8,
+    pub transfer_type: u8,
+    pub endpoint_address: u8,
+    pub device_address: u8,
+    pub bus_number: u16,
+    pub setup_flag: u8,
+    pub data_flag: u8,
+    pub status: i32,
+    pub data_length: u32,
+    pub delivered_data_length: u32,
+    pub setup: [u8; 8],
+}
+
+impl UsbPacketLinktypeHeader {
+    pub fn header_bytes(&self, event_timestamp: Timestamp) -> [u8; 48] {
+        let mut header = [0u8; 48];
+        header[0..8].copy_from_slice(&self.id.to_le_bytes());
+        header[8] = self.event_type;
+        header[9] = self.transfer_type;
+        header[10] = self.endpoint_address;
+        header[11] = self.device_address;
+        header[12..14].copy_from_slice(&self.bus_number.to_le_bytes());
+        header[14] = self.setup_flag;
+        header[15] = self.data_flag;
+        header[16..24].copy_from_slice(&(event_timestamp.seconds as i64).to_le_bytes());
+        header[24..28].copy_from_slice(&(event_timestamp.microseconds as i32).to_le_bytes());
+        header[28..32].copy_from_slice(&self.status.to_le_bytes());
+        header[32..36].copy_from_slice(&self.data_length.to_le_bytes());
+        header[36..40].copy_from_slice(&self.delivered_data_length.to_le_bytes());
+        header[40..48].copy_from_slice(&self.setup);
+        header
+    }
+}
+
+/// Builds the fixed PCAP file header.
+pub fn pcap_global_header_bytes() -> [u8; 24] {
+    let mut header = [0u8; 24];
+    header[0..4].copy_from_slice(&PCAP_MAGIC.to_le_bytes());
+    header[4..6].copy_from_slice(&PCAP_MAJOR.to_le_bytes());
+    header[6..8].copy_from_slice(&PCAP_MINOR.to_le_bytes());
+    header[8..12].copy_from_slice(&0u32.to_le_bytes());
+    header[12..16].copy_from_slice(&0u32.to_le_bytes());
+    header[16..20].copy_from_slice(&SNAPLEN.to_le_bytes());
+    header[20..24].copy_from_slice(&LINKTYPE_USB_LINUX.to_le_bytes());
+    header
+}
+
+/// Builds one PCAP record from the record header, linktype header, and payload.
+pub fn pcap_record_bytes(
+    capture_timestamp: Timestamp,
+    event_timestamp: Timestamp,
+    meta: &UsbPacketLinktypeHeader,
+    payload: &[u8],
+) -> Vec<u8> {
+    let link_header = meta.header_bytes(event_timestamp);
+    let original_len = link_header.len() + payload.len();
+    let captured_len = original_len.min(SNAPLEN as usize);
+    let mut record = Vec::with_capacity(16 + captured_len);
+    record.extend_from_slice(&capture_timestamp.seconds.to_le_bytes());
+    record.extend_from_slice(&capture_timestamp.microseconds.to_le_bytes());
+    record.extend_from_slice(&(captured_len as u32).to_le_bytes());
+    record.extend_from_slice(&(original_len as u32).to_le_bytes());
+
+    if captured_len <= link_header.len() {
+        record.extend_from_slice(&link_header[..captured_len]);
+        return record;
+    }
+
+    record.extend_from_slice(&link_header);
+    let remaining = captured_len - link_header.len();
+    record.extend_from_slice(&payload[..remaining]);
+    record
+}
+
+/// Lazily opens the PCAP file and writes the global header once.
+///
+/// I/O failures disable PCAP logging and emit a warning.
+pub struct PcapManager {
+    path: Option<PathBuf>,
+    writer: Option<BufWriter<File>>,
+    warned: bool,
+}
+
+impl PcapManager {
+    pub const fn new(path: Option<PathBuf>) -> Self {
+        Self {
+            path,
+            writer: None,
+            warned: false,
+        }
+    }
+
+    fn ensure_writer(&mut self) -> Option<&mut BufWriter<File>> {
+        let file_path = self.path.clone()?;
+
+        if self.writer.is_some() {
+            return self.writer.as_mut();
+        }
+
+        if let Some(parent) = file_path.parent() {
+            if let Err(error) = fs::create_dir_all(parent) {
+                if !self.warned {
+                    warn!(
+                        "Disabling USB PCAP logging after failing to create {}: {}",
+                        parent.display(),
+                        error
+                    );
+                    self.warned = true;
+                }
+                self.path = None;
+                return None;
+            }
+        }
+
+        let mut writer = match File::create(&file_path).map(BufWriter::new) {
+            Ok(writer) => writer,
+            Err(error) => {
+                if !self.warned {
+                    warn!(
+                        "Disabling USB PCAP logging after failing to open {}: {}",
+                        file_path.display(),
+                        error
+                    );
+                    self.warned = true;
+                }
+                self.path = None;
+                return None;
+            }
+        };
+
+        if let Err(error) = writer.write_all(&pcap_global_header_bytes()) {
+            if !self.warned {
+                warn!(
+                    "Disabling USB PCAP logging after failing to write header to {}: {}",
+                    file_path.display(),
+                    error
+                );
+                self.warned = true;
+            }
+            self.path = None;
+            return None;
+        }
+
+        self.writer = Some(writer);
+        self.writer.as_mut()
+    }
+
+    pub fn write_record(&mut self, record: &[u8]) {
+        let writer = match self.ensure_writer() {
+            Some(writer) => writer,
+            None => return,
+        };
+
+        if let Err(error) = writer.write_all(record).and_then(|_| writer.flush()) {
+            if !self.warned {
+                warn!("Failed to write USB PCAP record: {}", error);
+                self.warned = true;
+            }
+            self.path = None;
+            self.writer = None;
+        }
+    }
+}
+
+static MANAGER: OnceLock<Mutex<PcapManager>> = OnceLock::new();
+
+/// Process-wide entry point for optional USB PCAP logging.
+pub struct UsbPcapManager;
+
+impl UsbPcapManager {
+    pub fn init(path: Option<PathBuf>) {
+        if path.is_some() {
+            let _ = MANAGER.set(Mutex::new(PcapManager::new(path)));
+        }
+    }
+
+    pub fn write_record(record: &[u8]) {
+        if let Some(manager) = MANAGER.get() {
+            manager.lock().unwrap().write_record(record);
+        }
+    }
+}
+
+/// Emit a PCAP record for a control transfer submission event.
+pub fn log_control_submission(
+    meta: super::meta::EndpointPcapMeta,
+    request: &UsbRequest,
+    payload: &[u8],
+) {
+    log_submission(
+        meta,
+        request.address,
+        u32::from(request.length),
+        Some(build_setup_bytes(request)),
+        payload,
+    );
+}
+
+/// Emit a PCAP record for a control transfer completion event
+pub fn log_control_completion(
+    meta: super::meta::EndpointPcapMeta,
+    urb_id: u64,
+    status: i32,
+    actual_length: u32,
+    payload: &[u8],
+) {
+    log_completion(meta, urb_id, status, actual_length, payload);
+}
+
+/// Emit a PCAP record for an error-related event with optional setup data.
+pub fn log_error(
+    meta: super::meta::EndpointPcapMeta,
+    urb_id: u64,
+    event: UsbEventType,
+    status: i32,
+    setup: Option<[u8; 8]>,
+    payload: &[u8],
+) {
+    let event_timestamp = Timestamp::from(SystemTime::now());
+    log_packet(
+        urb_id,
+        event,
+        meta,
+        event_timestamp,
+        status,
+        payload.len() as u32,
+        setup,
+        payload,
+    );
+}
+
+/// Emit a PCAP record for a transfer submission event.
+pub fn log_submission(
+    meta: super::meta::EndpointPcapMeta,
+    urb_id: u64,
+    expected_length: u32,
+    setup: Option<[u8; 8]>,
+    payload: &[u8],
+) {
+    let event_timestamp = Timestamp::from(SystemTime::now());
+    log_packet(
+        urb_id,
+        UsbEventType::Submission,
+        meta,
+        event_timestamp,
+        0,
+        expected_length,
+        setup,
+        payload,
+    );
+}
+
+/// Emit a PCAP record for a transfer completion event.
+pub fn log_completion(
+    meta: super::meta::EndpointPcapMeta,
+    urb_id: u64,
+    status: i32,
+    actual_length: u32,
+    payload: &[u8],
+) {
+    let event_timestamp = Timestamp::from(SystemTime::now());
+    log_packet(
+        urb_id,
+        UsbEventType::Completion,
+        meta,
+        event_timestamp,
+        status,
+        actual_length,
+        None,
+        payload,
+    );
+}
+
+pub const fn build_setup_bytes(request: &UsbRequest) -> [u8; 8] {
+    [
+        request.request_type,
+        request.request,
+        (request.value & 0x00ff) as u8,
+        (request.value >> 8) as u8,
+        (request.index & 0x00ff) as u8,
+        (request.index >> 8) as u8,
+        (request.length & 0x00ff) as u8,
+        (request.length >> 8) as u8,
+    ]
+}
+
+#[allow(clippy::too_many_arguments)]
+fn log_packet(
+    urb_id: u64,
+    event: UsbEventType,
+    meta: super::meta::EndpointPcapMeta,
+    event_timestamp: Timestamp,
+    status: i32,
+    data_length: u32,
+    setup: Option<[u8; 8]>,
+    payload: &[u8],
+) {
+    let meta = UsbPacketLinktypeHeader {
+        id: urb_id,
+        event_type: event.code(),
+        transfer_type: meta.transfer_type.code(),
+        endpoint_address: meta.direction.endpoint_address(meta.endpoint_id),
+        device_address: meta.device_address,
+        bus_number: meta.bus_number,
+        setup_flag: setup_flag_value(meta.transfer_type, setup.is_some()),
+        data_flag: data_flag_value(payload.len()),
+        status,
+        data_length,
+        delivered_data_length: payload.len() as u32,
+        setup: if matches!(meta.transfer_type, UsbTransferType::Control) {
+            setup.unwrap_or([0; 8])
+        } else {
+            [0; 8]
+        },
+    };
+
+    let capture_timestamp = Timestamp::from(SystemTime::now());
+    let record = pcap_record_bytes(capture_timestamp, event_timestamp, &meta, payload);
+    UsbPcapManager::write_record(&record);
+}
+
+// zero only for control with setup data.
+const fn setup_flag_value(transfer_type: UsbTransferType, has_setup: bool) -> u8 {
+    if matches!(transfer_type, UsbTransferType::Control) && has_setup {
+        b'\0'
+    } else {
+        b'-'
+    }
+}
+
+// non-zero when there is no payload data.
+const fn data_flag_value(payload_len: usize) -> u8 {
+    if payload_len == 0 {
+        1
+    } else {
+        0
+    }
+}

--- a/src/device/pcap/packet.rs
+++ b/src/device/pcap/packet.rs
@@ -280,13 +280,11 @@ impl UsbPcapManager {
 pub fn log_control_submission(
     meta: super::meta::EndpointPcapMeta,
     request: &UsbRequest,
-    event_timestamp: Timestamp,
     payload: &[u8],
 ) {
     log_submission(
         meta,
         request.address,
-        event_timestamp,
         u32::from(request.length),
         Some(build_setup_bytes(request)),
         payload,
@@ -297,19 +295,11 @@ pub fn log_control_submission(
 pub fn log_control_completion(
     meta: super::meta::EndpointPcapMeta,
     urb_id: u64,
-    event_timestamp: Timestamp,
     status: i32,
     actual_length: u32,
     payload: &[u8],
 ) {
-    log_completion(
-        meta,
-        urb_id,
-        event_timestamp,
-        status,
-        actual_length,
-        payload,
-    );
+    log_completion(meta, urb_id, status, actual_length, payload);
 }
 
 /// Emit a PCAP record for an error-related event with optional setup data.
@@ -317,11 +307,11 @@ pub fn log_error(
     meta: super::meta::EndpointPcapMeta,
     urb_id: u64,
     event: UsbEventType,
-    event_timestamp: Timestamp,
     status: i32,
     setup: Option<[u8; 8]>,
     payload: &[u8],
 ) {
+    let event_timestamp = Timestamp::from(SystemTime::now());
     log_packet(
         urb_id,
         event,
@@ -338,11 +328,11 @@ pub fn log_error(
 pub fn log_submission(
     meta: super::meta::EndpointPcapMeta,
     urb_id: u64,
-    event_timestamp: Timestamp,
     expected_length: u32,
     setup: Option<[u8; 8]>,
     payload: &[u8],
 ) {
+    let event_timestamp = Timestamp::from(SystemTime::now());
     log_packet(
         urb_id,
         UsbEventType::Submission,
@@ -359,11 +349,11 @@ pub fn log_submission(
 pub fn log_completion(
     meta: super::meta::EndpointPcapMeta,
     urb_id: u64,
-    event_timestamp: Timestamp,
     status: i32,
     actual_length: u32,
     payload: &[u8],
 ) {
+    let event_timestamp = Timestamp::from(SystemTime::now());
     log_packet(
         urb_id,
         UsbEventType::Completion,

--- a/src/device/pcap/packet.rs
+++ b/src/device/pcap/packet.rs
@@ -1,0 +1,443 @@
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
+
+use crate::device::xhci::usbrequest::UsbRequest;
+use tracing::warn;
+
+const LINKTYPE_USB_LINUX: u32 = 189;
+const PCAP_MAGIC: u32 = 0xa1b2c3d4;
+const PCAP_MAJOR: u16 = 2;
+const PCAP_MINOR: u16 = 4;
+const SNAPLEN: u32 = 65_535;
+
+/// USB event type stored as an ASCII code in the packet header.
+#[derive(Clone, Copy)]
+pub enum UsbEventType {
+    Submission,
+    Completion,
+    Error,
+}
+
+impl UsbEventType {
+    const fn code(self) -> u8 {
+        match self {
+            Self::Submission => b'S',
+            Self::Completion => b'C',
+            Self::Error => b'E',
+        }
+    }
+}
+
+/// USB transfer type stored in the linktype header.
+#[derive(Clone, Copy, Debug)]
+pub enum UsbTransferType {
+    // TODO: implement isochronous transfer logging
+    // Isochronous,
+    Control,
+    Bulk,
+    Interrupt,
+}
+
+impl UsbTransferType {
+    const fn code(self) -> u8 {
+        match self {
+            // TODO: implement isochronous transfer logging
+            // Self::Isochronous => 0,
+            Self::Interrupt => 1,
+            Self::Control => 2,
+            Self::Bulk => 3,
+        }
+    }
+}
+
+/// USB direction used to set the endpoint address IN/OUT bit.
+#[derive(Clone, Copy, Debug)]
+pub enum UsbDirection {
+    HostToDevice,
+    DeviceToHost,
+}
+
+impl UsbDirection {
+    const fn endpoint_address(self, endpoint: u8) -> u8 {
+        match self {
+            Self::HostToDevice => endpoint & 0x7f,
+            Self::DeviceToHost => endpoint | 0x80,
+        }
+    }
+}
+
+/// Packet timestamp in seconds and microseconds.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Timestamp {
+    pub seconds: u32,
+    pub microseconds: u32,
+}
+
+impl From<SystemTime> for Timestamp {
+    fn from(value: SystemTime) -> Self {
+        let duration = value
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default();
+        Self {
+            seconds: duration.as_secs() as u32,
+            microseconds: duration.subsec_micros(),
+        }
+    }
+}
+
+/// Linux USB per-packet header for PCAP linktype 189.
+///
+/// `header_bytes` writes the fields in little-endian order.
+pub struct UsbPacketLinktypeHeader {
+    pub id: u64,
+    pub event_type: u8,
+    pub transfer_type: u8,
+    pub endpoint_address: u8,
+    pub device_address: u8,
+    pub bus_number: u16,
+    pub setup_flag: u8,
+    pub data_flag: u8,
+    pub status: i32,
+    pub data_length: u32,
+    pub delivered_data_length: u32,
+    pub setup: [u8; 8],
+}
+
+impl UsbPacketLinktypeHeader {
+    pub fn header_bytes(&self, event_timestamp: Timestamp) -> [u8; 48] {
+        let mut header = [0u8; 48];
+        header[0..8].copy_from_slice(&self.id.to_le_bytes());
+        header[8] = self.event_type;
+        header[9] = self.transfer_type;
+        header[10] = self.endpoint_address;
+        header[11] = self.device_address;
+        header[12..14].copy_from_slice(&self.bus_number.to_le_bytes());
+        header[14] = self.setup_flag;
+        header[15] = self.data_flag;
+        header[16..24].copy_from_slice(&(event_timestamp.seconds as i64).to_le_bytes());
+        header[24..28].copy_from_slice(&(event_timestamp.microseconds as i32).to_le_bytes());
+        header[28..32].copy_from_slice(&self.status.to_le_bytes());
+        header[32..36].copy_from_slice(&self.data_length.to_le_bytes());
+        header[36..40].copy_from_slice(&self.delivered_data_length.to_le_bytes());
+        header[40..48].copy_from_slice(&self.setup);
+        header
+    }
+}
+
+/// Builds the fixed PCAP file header.
+pub fn pcap_global_header_bytes() -> [u8; 24] {
+    let mut header = [0u8; 24];
+    header[0..4].copy_from_slice(&PCAP_MAGIC.to_le_bytes());
+    header[4..6].copy_from_slice(&PCAP_MAJOR.to_le_bytes());
+    header[6..8].copy_from_slice(&PCAP_MINOR.to_le_bytes());
+    header[8..12].copy_from_slice(&0u32.to_le_bytes());
+    header[12..16].copy_from_slice(&0u32.to_le_bytes());
+    header[16..20].copy_from_slice(&SNAPLEN.to_le_bytes());
+    header[20..24].copy_from_slice(&LINKTYPE_USB_LINUX.to_le_bytes());
+    header
+}
+
+/// Builds one PCAP record from the record header, linktype header, and payload.
+pub fn pcap_record_bytes(
+    capture_timestamp: Timestamp,
+    event_timestamp: Timestamp,
+    meta: &UsbPacketLinktypeHeader,
+    payload: &[u8],
+) -> Vec<u8> {
+    let link_header = meta.header_bytes(event_timestamp);
+    let original_len = link_header.len() + payload.len();
+    let captured_len = original_len.min(SNAPLEN as usize);
+    let mut record = Vec::with_capacity(16 + captured_len);
+    record.extend_from_slice(&capture_timestamp.seconds.to_le_bytes());
+    record.extend_from_slice(&capture_timestamp.microseconds.to_le_bytes());
+    record.extend_from_slice(&(captured_len as u32).to_le_bytes());
+    record.extend_from_slice(&(original_len as u32).to_le_bytes());
+
+    if captured_len <= link_header.len() {
+        record.extend_from_slice(&link_header[..captured_len]);
+        return record;
+    }
+
+    record.extend_from_slice(&link_header);
+    let remaining = captured_len - link_header.len();
+    record.extend_from_slice(&payload[..remaining]);
+    record
+}
+
+/// Lazily opens the PCAP file and writes the global header once.
+///
+/// I/O failures disable PCAP logging and emit a warning.
+pub struct PcapManager {
+    path: Option<PathBuf>,
+    writer: Option<BufWriter<File>>,
+    warned: bool,
+}
+
+impl PcapManager {
+    pub const fn new(path: Option<PathBuf>) -> Self {
+        Self {
+            path,
+            writer: None,
+            warned: false,
+        }
+    }
+
+    fn ensure_writer(&mut self) -> Option<&mut BufWriter<File>> {
+        let file_path = self.path.clone()?;
+
+        if self.writer.is_some() {
+            return self.writer.as_mut();
+        }
+
+        if let Some(parent) = file_path.parent() {
+            if let Err(error) = fs::create_dir_all(parent) {
+                if !self.warned {
+                    warn!(
+                        "Disabling USB PCAP logging after failing to create {}: {}",
+                        parent.display(),
+                        error
+                    );
+                    self.warned = true;
+                }
+                self.path = None;
+                return None;
+            }
+        }
+
+        let mut writer = match File::create(&file_path).map(BufWriter::new) {
+            Ok(writer) => writer,
+            Err(error) => {
+                if !self.warned {
+                    warn!(
+                        "Disabling USB PCAP logging after failing to open {}: {}",
+                        file_path.display(),
+                        error
+                    );
+                    self.warned = true;
+                }
+                self.path = None;
+                return None;
+            }
+        };
+
+        if let Err(error) = writer.write_all(&pcap_global_header_bytes()) {
+            if !self.warned {
+                warn!(
+                    "Disabling USB PCAP logging after failing to write header to {}: {}",
+                    file_path.display(),
+                    error
+                );
+                self.warned = true;
+            }
+            self.path = None;
+            return None;
+        }
+
+        self.writer = Some(writer);
+        self.writer.as_mut()
+    }
+
+    pub fn write_record(&mut self, record: &[u8]) {
+        let writer = match self.ensure_writer() {
+            Some(writer) => writer,
+            None => return,
+        };
+
+        if let Err(error) = writer.write_all(record).and_then(|_| writer.flush()) {
+            if !self.warned {
+                warn!("Failed to write USB PCAP record: {}", error);
+                self.warned = true;
+            }
+            self.path = None;
+            self.writer = None;
+        }
+    }
+}
+
+static MANAGER: OnceLock<Mutex<PcapManager>> = OnceLock::new();
+
+/// Process-wide entry point for optional USB PCAP logging.
+pub struct UsbPcapManager;
+
+impl UsbPcapManager {
+    pub fn init(path: Option<PathBuf>) {
+        if path.is_some() {
+            let _ = MANAGER.set(Mutex::new(PcapManager::new(path)));
+        }
+    }
+
+    pub fn write_record(record: &[u8]) {
+        if let Some(manager) = MANAGER.get() {
+            manager.lock().unwrap().write_record(record);
+        }
+    }
+}
+
+/// Emit a PCAP record for a control transfer submission event.
+pub fn log_control_submission(
+    meta: super::meta::EndpointPcapMeta,
+    request: &UsbRequest,
+    event_timestamp: Timestamp,
+    payload: &[u8],
+) {
+    log_submission(
+        meta,
+        request.address,
+        event_timestamp,
+        u32::from(request.length),
+        Some(build_setup_bytes(request)),
+        payload,
+    );
+}
+
+/// Emit a PCAP record for a control transfer completion event
+pub fn log_control_completion(
+    meta: super::meta::EndpointPcapMeta,
+    urb_id: u64,
+    event_timestamp: Timestamp,
+    status: i32,
+    actual_length: u32,
+    payload: &[u8],
+) {
+    log_completion(
+        meta,
+        urb_id,
+        event_timestamp,
+        status,
+        actual_length,
+        payload,
+    );
+}
+
+/// Emit a PCAP record for an error-related event with optional setup data.
+pub fn log_error(
+    meta: super::meta::EndpointPcapMeta,
+    urb_id: u64,
+    event: UsbEventType,
+    event_timestamp: Timestamp,
+    status: i32,
+    setup: Option<[u8; 8]>,
+    payload: &[u8],
+) {
+    log_packet(
+        urb_id,
+        event,
+        meta,
+        event_timestamp,
+        status,
+        payload.len() as u32,
+        setup,
+        payload,
+    );
+}
+
+/// Emit a PCAP record for a transfer submission event.
+pub fn log_submission(
+    meta: super::meta::EndpointPcapMeta,
+    urb_id: u64,
+    event_timestamp: Timestamp,
+    expected_length: u32,
+    setup: Option<[u8; 8]>,
+    payload: &[u8],
+) {
+    log_packet(
+        urb_id,
+        UsbEventType::Submission,
+        meta,
+        event_timestamp,
+        0,
+        expected_length,
+        setup,
+        payload,
+    );
+}
+
+/// Emit a PCAP record for a transfer completion event.
+pub fn log_completion(
+    meta: super::meta::EndpointPcapMeta,
+    urb_id: u64,
+    event_timestamp: Timestamp,
+    status: i32,
+    actual_length: u32,
+    payload: &[u8],
+) {
+    log_packet(
+        urb_id,
+        UsbEventType::Completion,
+        meta,
+        event_timestamp,
+        status,
+        actual_length,
+        None,
+        payload,
+    );
+}
+
+pub const fn build_setup_bytes(request: &UsbRequest) -> [u8; 8] {
+    [
+        request.request_type,
+        request.request,
+        (request.value & 0x00ff) as u8,
+        (request.value >> 8) as u8,
+        (request.index & 0x00ff) as u8,
+        (request.index >> 8) as u8,
+        (request.length & 0x00ff) as u8,
+        (request.length >> 8) as u8,
+    ]
+}
+
+#[allow(clippy::too_many_arguments)]
+fn log_packet(
+    urb_id: u64,
+    event: UsbEventType,
+    meta: super::meta::EndpointPcapMeta,
+    event_timestamp: Timestamp,
+    status: i32,
+    data_length: u32,
+    setup: Option<[u8; 8]>,
+    payload: &[u8],
+) {
+    let meta = UsbPacketLinktypeHeader {
+        id: urb_id,
+        event_type: event.code(),
+        transfer_type: meta.transfer_type.code(),
+        endpoint_address: meta.direction.endpoint_address(meta.endpoint_id),
+        device_address: meta.device_address,
+        bus_number: meta.bus_number,
+        setup_flag: setup_flag_value(meta.transfer_type, setup.is_some()),
+        data_flag: data_flag_value(payload.len()),
+        status,
+        data_length,
+        delivered_data_length: payload.len() as u32,
+        setup: if matches!(meta.transfer_type, UsbTransferType::Control) {
+            setup.unwrap_or([0; 8])
+        } else {
+            [0; 8]
+        },
+    };
+
+    let capture_timestamp = Timestamp::from(SystemTime::now());
+    let record = pcap_record_bytes(capture_timestamp, event_timestamp, &meta, payload);
+    UsbPcapManager::write_record(&record);
+}
+
+// zero only for control with setup data.
+const fn setup_flag_value(transfer_type: UsbTransferType, has_setup: bool) -> u8 {
+    if matches!(transfer_type, UsbTransferType::Control) && has_setup {
+        b'\0'
+    } else {
+        b'-'
+    }
+}
+
+// non-zero when there is no payload data.
+const fn data_flag_value(payload_len: usize) -> u8 {
+    if payload_len == 0 {
+        1
+    } else {
+        0
+    }
+}

--- a/src/device/pcap/packet.rs
+++ b/src/device/pcap/packet.rs
@@ -61,10 +61,11 @@ pub enum UsbDirection {
 }
 
 impl UsbDirection {
-    const fn endpoint_address(self, endpoint: u8) -> u8 {
+    const fn endpoint_address(self, xhci_endpoint_id: u8) -> u8 {
+        let endpoint_number = xhci_endpoint_id / 2;
         match self {
-            Self::HostToDevice => endpoint & 0x7f,
-            Self::DeviceToHost => endpoint | 0x80,
+            Self::HostToDevice => endpoint_number,
+            Self::DeviceToHost => endpoint_number | 0x80,
         }
     }
 }

--- a/src/device/pcap/packet.rs
+++ b/src/device/pcap/packet.rs
@@ -2,7 +2,7 @@ use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use crate::device::xhci::usbrequest::UsbRequest;
 use tracing::warn;
@@ -80,25 +80,6 @@ const fn endpoint_address(
     }
 }
 
-/// Packet timestamp in seconds and microseconds.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct Timestamp {
-    pub seconds: u32,
-    pub microseconds: u32,
-}
-
-impl From<SystemTime> for Timestamp {
-    fn from(value: SystemTime) -> Self {
-        let duration = value
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_default();
-        Self {
-            seconds: duration.as_secs() as u32,
-            microseconds: duration.subsec_micros(),
-        }
-    }
-}
-
 /// Linux USB per-packet header for PCAP linktype 189.
 ///
 /// `header_bytes` writes the fields in little-endian order.
@@ -118,7 +99,7 @@ pub struct UsbPacketLinktypeHeader {
 }
 
 impl UsbPacketLinktypeHeader {
-    pub fn header_bytes(&self, event_timestamp: Timestamp) -> [u8; 48] {
+    pub fn header_bytes(&self, now: Duration) -> [u8; 48] {
         let mut header = [0u8; 48];
         header[0..8].copy_from_slice(&self.id.to_le_bytes());
         header[8] = self.event_type;
@@ -128,8 +109,8 @@ impl UsbPacketLinktypeHeader {
         header[12..14].copy_from_slice(&self.bus_number.to_le_bytes());
         header[14] = self.setup_flag;
         header[15] = self.data_flag;
-        header[16..24].copy_from_slice(&(event_timestamp.seconds as i64).to_le_bytes());
-        header[24..28].copy_from_slice(&(event_timestamp.microseconds as i32).to_le_bytes());
+        header[16..24].copy_from_slice(&(now.as_secs() as i64).to_le_bytes());
+        header[24..28].copy_from_slice(&(now.subsec_micros() as i32).to_le_bytes());
         header[28..32].copy_from_slice(&self.status.to_le_bytes());
         header[32..36].copy_from_slice(&self.data_length.to_le_bytes());
         header[36..40].copy_from_slice(&self.delivered_data_length.to_le_bytes());
@@ -152,18 +133,18 @@ pub fn pcap_global_header_bytes() -> [u8; 24] {
 }
 
 /// Builds one PCAP record from the record header, linktype header, and payload.
-pub fn pcap_record_bytes(
-    capture_timestamp: Timestamp,
-    event_timestamp: Timestamp,
-    meta: &UsbPacketLinktypeHeader,
-    payload: &[u8],
-) -> Vec<u8> {
-    let link_header = meta.header_bytes(event_timestamp);
+pub fn pcap_record_bytes(meta: &UsbPacketLinktypeHeader, payload: &[u8]) -> Vec<u8> {
+    // Safety: the current system time should not be before the Unix epoch
+    // unless the system clock is badly misconfigured.
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let link_header = meta.header_bytes(now);
     let original_len = link_header.len() + payload.len();
     let captured_len = original_len.min(SNAPLEN as usize);
     let mut record = Vec::with_capacity(16 + captured_len);
-    record.extend_from_slice(&capture_timestamp.seconds.to_le_bytes());
-    record.extend_from_slice(&capture_timestamp.microseconds.to_le_bytes());
+    record.extend_from_slice(&(now.as_secs() as u32).to_le_bytes());
+    record.extend_from_slice(&now.subsec_micros().to_le_bytes());
     record.extend_from_slice(&(captured_len as u32).to_le_bytes());
     record.extend_from_slice(&(original_len as u32).to_le_bytes());
 
@@ -333,13 +314,11 @@ pub fn log_error(
     setup: Option<[u8; 8]>,
     payload: &[u8],
 ) {
-    let event_timestamp = Timestamp::from(SystemTime::now());
     log_packet(
         urb_id,
         event,
         meta,
         control_direction,
-        event_timestamp,
         status,
         payload.len() as u32,
         setup,
@@ -356,13 +335,11 @@ pub fn log_submission(
     setup: Option<[u8; 8]>,
     payload: &[u8],
 ) {
-    let event_timestamp = Timestamp::from(SystemTime::now());
     log_packet(
         urb_id,
         UsbEventType::Submission,
         meta,
         control_direction,
-        event_timestamp,
         0,
         expected_length,
         setup,
@@ -379,13 +356,11 @@ pub fn log_completion(
     actual_length: u32,
     payload: &[u8],
 ) {
-    let event_timestamp = Timestamp::from(SystemTime::now());
     log_packet(
         urb_id,
         UsbEventType::Completion,
         meta,
         control_direction,
-        event_timestamp,
         status,
         actual_length,
         None,
@@ -412,7 +387,6 @@ fn log_packet(
     event: UsbEventType,
     meta: super::meta::EndpointPcapMeta,
     control_direction: Option<UsbDirection>,
-    event_timestamp: Timestamp,
     status: i32,
     data_length: u32,
     setup: Option<[u8; 8]>,
@@ -440,8 +414,7 @@ fn log_packet(
         },
     };
 
-    let capture_timestamp = Timestamp::from(SystemTime::now());
-    let record = pcap_record_bytes(capture_timestamp, event_timestamp, &meta, payload);
+    let record = pcap_record_bytes(&meta, payload);
     UsbPcapManager::write_record(&record);
 }
 

--- a/src/device/pcap/packet.rs
+++ b/src/device/pcap/packet.rs
@@ -53,20 +53,30 @@ impl UsbTransferType {
     }
 }
 
-/// USB direction used to set the endpoint address IN/OUT bit.
+/// USB direction for metadata that is not encoded in the endpoint id.
 #[derive(Clone, Copy, Debug)]
 pub enum UsbDirection {
     HostToDevice,
     DeviceToHost,
 }
 
-impl UsbDirection {
-    const fn endpoint_address(self, xhci_endpoint_id: u8) -> u8 {
-        let endpoint_number = xhci_endpoint_id / 2;
-        match self {
-            Self::HostToDevice => endpoint_number,
-            Self::DeviceToHost => endpoint_number | 0x80,
+// Convert an xHCI endpoint id to the USB endpoint address stored in PCAP
+// records. Normal endpoints encode their direction in the low bit of the xHCI
+// endpoint id, so rotating right moves that bit into the USB IN position
+// (0x80). Control endpoints always use endpoint number zero, so their direction
+// has to come from the control request/response tracked by the caller instead.
+const fn endpoint_address(
+    transfer_type: UsbTransferType,
+    control_direction: Option<UsbDirection>,
+    xhci_endpoint_id: u8,
+) -> u8 {
+    if matches!(transfer_type, UsbTransferType::Control) {
+        match control_direction.expect("control direction is required") {
+            UsbDirection::HostToDevice => 0,
+            UsbDirection::DeviceToHost => 0x80,
         }
+    } else {
+        xhci_endpoint_id.rotate_right(1)
     }
 }
 
@@ -280,11 +290,13 @@ impl UsbPcapManager {
 /// Emit a PCAP record for a control transfer submission event.
 pub fn log_control_submission(
     meta: super::meta::EndpointPcapMeta,
+    control_direction: UsbDirection,
     request: &UsbRequest,
     payload: &[u8],
 ) {
     log_submission(
         meta,
+        Some(control_direction),
         request.address,
         u32::from(request.length),
         Some(build_setup_bytes(request)),
@@ -295,17 +307,26 @@ pub fn log_control_submission(
 /// Emit a PCAP record for a control transfer completion event
 pub fn log_control_completion(
     meta: super::meta::EndpointPcapMeta,
+    control_direction: UsbDirection,
     urb_id: u64,
     status: i32,
     actual_length: u32,
     payload: &[u8],
 ) {
-    log_completion(meta, urb_id, status, actual_length, payload);
+    log_completion(
+        meta,
+        Some(control_direction),
+        urb_id,
+        status,
+        actual_length,
+        payload,
+    );
 }
 
 /// Emit a PCAP record for an error-related event with optional setup data.
 pub fn log_error(
     meta: super::meta::EndpointPcapMeta,
+    control_direction: Option<UsbDirection>,
     urb_id: u64,
     event: UsbEventType,
     status: i32,
@@ -317,6 +338,7 @@ pub fn log_error(
         urb_id,
         event,
         meta,
+        control_direction,
         event_timestamp,
         status,
         payload.len() as u32,
@@ -328,6 +350,7 @@ pub fn log_error(
 /// Emit a PCAP record for a transfer submission event.
 pub fn log_submission(
     meta: super::meta::EndpointPcapMeta,
+    control_direction: Option<UsbDirection>,
     urb_id: u64,
     expected_length: u32,
     setup: Option<[u8; 8]>,
@@ -338,6 +361,7 @@ pub fn log_submission(
         urb_id,
         UsbEventType::Submission,
         meta,
+        control_direction,
         event_timestamp,
         0,
         expected_length,
@@ -349,6 +373,7 @@ pub fn log_submission(
 /// Emit a PCAP record for a transfer completion event.
 pub fn log_completion(
     meta: super::meta::EndpointPcapMeta,
+    control_direction: Option<UsbDirection>,
     urb_id: u64,
     status: i32,
     actual_length: u32,
@@ -359,6 +384,7 @@ pub fn log_completion(
         urb_id,
         UsbEventType::Completion,
         meta,
+        control_direction,
         event_timestamp,
         status,
         actual_length,
@@ -385,6 +411,7 @@ fn log_packet(
     urb_id: u64,
     event: UsbEventType,
     meta: super::meta::EndpointPcapMeta,
+    control_direction: Option<UsbDirection>,
     event_timestamp: Timestamp,
     status: i32,
     data_length: u32,
@@ -395,7 +422,7 @@ fn log_packet(
         id: urb_id,
         event_type: event.code(),
         transfer_type: meta.transfer_type.code(),
-        endpoint_address: meta.direction.endpoint_address(meta.endpoint_id),
+        endpoint_address: endpoint_address(meta.transfer_type, control_direction, meta.endpoint_id),
         device_address: meta.device_address,
         bus_number: meta.bus_number,
         setup_flag: setup_flag_value(meta.transfer_type, setup.is_some()),

--- a/src/device/pcap/packet.rs
+++ b/src/device/pcap/packet.rs
@@ -418,6 +418,9 @@ fn log_packet(
     setup: Option<[u8; 8]>,
     payload: &[u8],
 ) {
+    let direction = endpoint_direction(control_direction, meta.endpoint_id);
+    let data_flag = data_flag_value(event, direction);
+    let payload = packet_payload(data_flag, payload);
     let meta = UsbPacketLinktypeHeader {
         id: urb_id,
         event_type: event.code(),
@@ -426,7 +429,7 @@ fn log_packet(
         device_address: meta.device_address,
         bus_number: meta.bus_number,
         setup_flag: setup_flag_value(meta.transfer_type, setup.is_some()),
-        data_flag: data_flag_value(payload.len()),
+        data_flag,
         status,
         data_length,
         delivered_data_length: payload.len() as u32,
@@ -451,11 +454,33 @@ const fn setup_flag_value(transfer_type: UsbTransferType, has_setup: bool) -> u8
     }
 }
 
-// non-zero when there is no payload data.
-const fn data_flag_value(payload_len: usize) -> u8 {
-    if payload_len == 0 {
-        1
+const fn packet_payload(data_flag: u8, payload: &[u8]) -> &[u8] {
+    if data_flag == 0 {
+        payload
     } else {
-        0
+        &[]
+    }
+}
+
+const fn endpoint_direction(
+    control_direction: Option<UsbDirection>,
+    xhci_endpoint_id: u8,
+) -> UsbDirection {
+    if let Some(direction) = control_direction {
+        direction
+    } else if xhci_endpoint_id & 1 == 0 {
+        UsbDirection::HostToDevice
+    } else {
+        UsbDirection::DeviceToHost
+    }
+}
+
+// zero for records that may carry data; otherwise use the event marker.
+const fn data_flag_value(event: UsbEventType, direction: UsbDirection) -> u8 {
+    match event {
+        UsbEventType::Submission if matches!(direction, UsbDirection::DeviceToHost) => b'<',
+        UsbEventType::Completion if matches!(direction, UsbDirection::HostToDevice) => b'>',
+        UsbEventType::Error => b'E',
+        UsbEventType::Submission | UsbEventType::Completion => 0,
     }
 }

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -1,10 +1,10 @@
-use std::{fmt::Debug, future::Future, mem, ops::ControlFlow, pin::Pin, time::SystemTime};
+use std::{fmt::Debug, future::Future, mem, ops::ControlFlow, pin::Pin};
 
 use tracing::debug;
 
 use crate::device::{
     bus::BusDeviceRef,
-    pcap::{self, EndpointPcapMeta, Timestamp},
+    pcap::{self, EndpointPcapMeta},
     xhci::{
         hotplug_endpoint_handle::BaseEndpointHandle,
         interrupter::EventSender,
@@ -117,8 +117,7 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                     let request_copy = request.clone_without_data();
                     let is_out_request = request.request_type & 0x80 == 0;
 
-                    let event_timestamp = Timestamp::from(SystemTime::now());
-                    pcap::control_submission(self.pcap_meta, &request, event_timestamp);
+                    pcap::control_submission(self.pcap_meta, &request);
 
                     self.real_ep.submit_control_request(request)?;
 
@@ -143,8 +142,7 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
             let result = match self.submission_state {
                 ControlSubmissionState::ParserConsumedTrb => TrbProcessingResult::Ok,
                 ControlSubmissionState::ParserError(trb_address) => {
-                    let event_timestamp = Timestamp::from(SystemTime::now());
-                    pcap::trb_error(self.pcap_meta, trb_address, event_timestamp);
+                    pcap::trb_error(self.pcap_meta, trb_address);
                     let event = EventTrb::new_transfer_event_trb(
                         trb_address,
                         0,
@@ -161,13 +159,7 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                     match processing_result {
                         ControlRequestProcessingResult::SuccessfulControlIn(data) => {
                             debug!("got data from control in: {data:?}");
-                            let event_timestamp = Timestamp::from(SystemTime::now());
-                            pcap::control_completion_in(
-                                self.pcap_meta,
-                                usb_request.address,
-                                &data,
-                                event_timestamp,
-                            );
+                            pcap::control_completion_in(self.pcap_meta, usb_request.address, &data);
                             if let Some(data_pointer) = usb_request.data_pointer {
                                 debug!("writing data to {data_pointer}");
                                 self.dma_bus.write_bulk(data_pointer, &data);
@@ -187,13 +179,7 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                         }
                         ControlRequestProcessingResult::SuccessfulControlOut => unreachable!(),
                         processing_error => {
-                            let event_timestamp = Timestamp::from(SystemTime::now());
-                            pcap::control_in_error(
-                                self.pcap_meta,
-                                usb_request,
-                                &processing_error,
-                                event_timestamp,
-                            );
+                            pcap::control_in_error(self.pcap_meta, usb_request, &processing_error);
                             self.handle_processing_error(processing_error, usb_request.address)?
                         }
                     }
@@ -205,12 +191,10 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                             unreachable!()
                         }
                         ControlRequestProcessingResult::SuccessfulControlOut => {
-                            let event_timestamp = Timestamp::from(SystemTime::now());
                             pcap::control_completion_out(
                                 self.pcap_meta,
                                 usb_request.address,
                                 u32::from(usb_request.length),
-                                event_timestamp,
                             );
                             let event = EventTrb::new_transfer_event_trb(
                                 usb_request.address,
@@ -225,13 +209,7 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                             TrbProcessingResult::Ok
                         }
                         processing_error => {
-                            let event_timestamp = Timestamp::from(SystemTime::now());
-                            pcap::control_out_error(
-                                self.pcap_meta,
-                                usb_request,
-                                &processing_error,
-                                event_timestamp,
-                            );
+                            pcap::control_out_error(self.pcap_meta, usb_request, &processing_error);
                             self.handle_processing_error(processing_error, usb_request.address)?
                         }
                     }
@@ -448,13 +426,11 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
             TransferTrbVariant::Normal(normal_data) => {
                 let mut data = vec![0; normal_data.transfer_length as usize];
                 self.dma_bus.read_bulk(normal_data.data_pointer, &mut data);
-                let event_timestamp = Timestamp::from(SystemTime::now());
                 pcap::out_submission(
                     self.pcap_meta,
                     trb.address,
                     &data,
                     normal_data.transfer_length,
-                    event_timestamp,
                 );
                 self.real_ep.submit(data)?;
                 self.submission_state = NormalSubmissionState::AwaitingRealTransfer(TransferTrb {
@@ -493,13 +469,11 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
                     let (completion_code, processing_result) =
                         match self.real_ep.next_completion().await? {
                             OutTrbProcessingResult::Disconnect => {
-                                let event_timestamp = Timestamp::from(SystemTime::now());
                                 pcap::out_error(
                                     self.pcap_meta,
                                     transfer_trb.address,
                                     &OutTrbProcessingResult::Disconnect,
                                     &[],
-                                    event_timestamp,
                                 );
                                 (
                                     Some(CompletionCode::UsbTransactionError),
@@ -507,24 +481,20 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
                                 )
                             }
                             OutTrbProcessingResult::Stall => {
-                                let event_timestamp = Timestamp::from(SystemTime::now());
                                 pcap::out_error(
                                     self.pcap_meta,
                                     transfer_trb.address,
                                     &OutTrbProcessingResult::Stall,
                                     &[],
-                                    event_timestamp,
                                 );
                                 (Some(CompletionCode::StallError), TrbProcessingResult::Stall)
                             }
                             OutTrbProcessingResult::TransactionError => {
-                                let event_timestamp = Timestamp::from(SystemTime::now());
                                 pcap::out_error(
                                     self.pcap_meta,
                                     transfer_trb.address,
                                     &OutTrbProcessingResult::TransactionError,
                                     &[],
-                                    event_timestamp,
                                 );
                                 (
                                     Some(CompletionCode::UsbTransactionError),
@@ -536,12 +506,10 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
                                     if let TransferTrbVariant::Normal(ref normal_data) =
                                         transfer_trb.variant
                                     {
-                                        let event_timestamp = Timestamp::from(SystemTime::now());
                                         pcap::out_completion(
                                             self.pcap_meta,
                                             transfer_trb.address,
                                             normal_data.transfer_length,
-                                            event_timestamp,
                                         );
                                         match normal_data.interrupt_on_completion {
                                             true => Some(CompletionCode::Success),
@@ -634,13 +602,7 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for InEndpointHandle<RIEH> {
         let transfer_trb = TransferTrbVariant::parse(trb.buffer);
         match &transfer_trb {
             TransferTrbVariant::Normal(normal_data) => {
-                let event_timestamp = Timestamp::from(SystemTime::now());
-                pcap::in_submission(
-                    self.pcap_meta,
-                    trb.address,
-                    normal_data.transfer_length,
-                    event_timestamp,
-                );
+                pcap::in_submission(self.pcap_meta, trb.address, normal_data.transfer_length);
                 self.real_ep.submit(normal_data.transfer_length as usize)?;
                 self.submission_state = NormalSubmissionState::AwaitingRealTransfer(TransferTrb {
                     address: trb.address,
@@ -681,12 +643,10 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for InEndpointHandle<RIEH> {
                         .await?
                     {
                         InTrbProcessingResult::Disconnect => {
-                            let event_timestamp = Timestamp::from(SystemTime::now());
                             pcap::in_error(
                                 self.pcap_meta,
                                 transfer_trb.address,
                                 &InTrbProcessingResult::Disconnect,
-                                event_timestamp,
                             );
                             (
                                 Some(CompletionCode::UsbTransactionError),
@@ -694,22 +654,18 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for InEndpointHandle<RIEH> {
                             )
                         }
                         InTrbProcessingResult::Stall => {
-                            let event_timestamp = Timestamp::from(SystemTime::now());
                             pcap::in_error(
                                 self.pcap_meta,
                                 transfer_trb.address,
                                 &InTrbProcessingResult::Stall,
-                                event_timestamp,
                             );
                             (Some(CompletionCode::StallError), TrbProcessingResult::Stall)
                         }
                         InTrbProcessingResult::TransactionError => {
-                            let event_timestamp = Timestamp::from(SystemTime::now());
                             pcap::in_error(
                                 self.pcap_meta,
                                 transfer_trb.address,
                                 &InTrbProcessingResult::TransactionError,
-                                event_timestamp,
                             );
                             (
                                 Some(CompletionCode::UsbTransactionError),
@@ -717,13 +673,7 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for InEndpointHandle<RIEH> {
                             )
                         }
                         InTrbProcessingResult::Success(data) => {
-                            let event_timestamp = Timestamp::from(SystemTime::now());
-                            pcap::in_completion(
-                                self.pcap_meta,
-                                transfer_trb.address,
-                                &data,
-                                event_timestamp,
-                            );
+                            pcap::in_completion(self.pcap_meta, transfer_trb.address, &data);
                             let completion_code = if let TransferTrbVariant::Normal(
                                 ref normal_data,
                             ) = transfer_trb.variant

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -1,9 +1,10 @@
-use std::{fmt::Debug, future::Future, mem, ops::ControlFlow, pin::Pin};
+use std::{fmt::Debug, future::Future, mem, ops::ControlFlow, pin::Pin, time::SystemTime};
 
 use tracing::debug;
 
 use crate::device::{
     bus::BusDeviceRef,
+    pcap::{self, EndpointPcapMeta, Timestamp},
     xhci::{
         hotplug_endpoint_handle::BaseEndpointHandle,
         interrupter::EventSender,
@@ -62,6 +63,7 @@ impl BaseEndpointHandle for DummyEndpointHandle {
 pub struct ControlEndpointHandle<RCEH: RealControlEndpointHandle> {
     slot_id: u8,
     endpoint_id: u8,
+    pcap_meta: EndpointPcapMeta,
     real_ep: RCEH,
     trb_parser: ControlRequestParser,
     dma_bus: BusDeviceRef,
@@ -73,6 +75,7 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
     pub fn new(
         slot_id: u8,
         endpoint_id: u8,
+        pcap_meta: EndpointPcapMeta,
         real_ep: RCEH,
         dma_bus: BusDeviceRef,
         event_sender: EventSender,
@@ -80,6 +83,7 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
         Self {
             slot_id,
             endpoint_id,
+            pcap_meta,
             real_ep,
             trb_parser: ControlRequestParser::new(dma_bus.clone()),
             dma_bus,
@@ -112,6 +116,9 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                 Ok(request) => {
                     let request_copy = request.clone_without_data();
                     let is_out_request = request.request_type & 0x80 == 0;
+
+                    let event_timestamp = Timestamp::from(SystemTime::now());
+                    pcap::control_submission(self.pcap_meta, &request, event_timestamp);
 
                     self.real_ep.submit_control_request(request)?;
 
@@ -152,6 +159,13 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                     match processing_result {
                         ControlRequestProcessingResult::SuccessfulControlIn(data) => {
                             debug!("got data from control in: {data:?}");
+                            let event_timestamp = Timestamp::from(SystemTime::now());
+                            pcap::control_completion_in(
+                                self.pcap_meta,
+                                usb_request.address,
+                                &data,
+                                event_timestamp,
+                            );
                             if let Some(data_pointer) = usb_request.data_pointer {
                                 debug!("writing data to {data_pointer}");
                                 self.dma_bus.write_bulk(data_pointer, &data);
@@ -182,6 +196,13 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                             unreachable!()
                         }
                         ControlRequestProcessingResult::SuccessfulControlOut => {
+                            let event_timestamp = Timestamp::from(SystemTime::now());
+                            pcap::control_completion_out(
+                                self.pcap_meta,
+                                usb_request.address,
+                                u32::from(usb_request.length),
+                                event_timestamp,
+                            );
                             let event = EventTrb::new_transfer_event_trb(
                                 usb_request.address,
                                 0,
@@ -360,6 +381,7 @@ impl ControlRequestParser {
 pub struct OutEndpointHandle<ROEH: RealOutEndpointHandle> {
     slot_id: u8,
     endpoint_id: u8,
+    pcap_meta: EndpointPcapMeta,
     real_ep: ROEH,
     dma_bus: BusDeviceRef,
     event_sender: EventSender,
@@ -370,6 +392,7 @@ impl<ROEH: RealOutEndpointHandle> OutEndpointHandle<ROEH> {
     pub fn new(
         slot_id: u8,
         endpoint_id: u8,
+        pcap_meta: EndpointPcapMeta,
         real_ep: ROEH,
         dma_bus: BusDeviceRef,
         event_sender: EventSender,
@@ -377,6 +400,7 @@ impl<ROEH: RealOutEndpointHandle> OutEndpointHandle<ROEH> {
         Self {
             slot_id,
             endpoint_id,
+            pcap_meta,
             real_ep,
             dma_bus,
             event_sender,
@@ -408,6 +432,14 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
             TransferTrbVariant::Normal(normal_data) => {
                 let mut data = vec![0; normal_data.transfer_length as usize];
                 self.dma_bus.read_bulk(normal_data.data_pointer, &mut data);
+                let event_timestamp = Timestamp::from(SystemTime::now());
+                pcap::out_submission(
+                    self.pcap_meta,
+                    trb.address,
+                    &data,
+                    normal_data.transfer_length,
+                    event_timestamp,
+                );
                 self.real_ep.submit(data)?;
                 self.submission_state = NormalSubmissionState::AwaitingRealTransfer(TransferTrb {
                     address: trb.address,
@@ -460,6 +492,13 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
                                     if let TransferTrbVariant::Normal(ref normal_data) =
                                         transfer_trb.variant
                                     {
+                                        let event_timestamp = Timestamp::from(SystemTime::now());
+                                        pcap::out_completion(
+                                            self.pcap_meta,
+                                            transfer_trb.address,
+                                            normal_data.transfer_length,
+                                            event_timestamp,
+                                        );
                                         match normal_data.interrupt_on_completion {
                                             true => Some(CompletionCode::Success),
                                             false => None,
@@ -510,6 +549,7 @@ impl<ROEH: RealOutEndpointHandle> BaseEndpointHandle for OutEndpointHandle<ROEH>
 pub struct InEndpointHandle<RIEH: RealInEndpointHandle> {
     slot_id: u8,
     endpoint_id: u8,
+    pcap_meta: EndpointPcapMeta,
     real_ep: RIEH,
     dma_bus: BusDeviceRef,
     event_sender: EventSender,
@@ -520,6 +560,7 @@ impl<RIEH: RealInEndpointHandle> InEndpointHandle<RIEH> {
     pub fn new(
         slot_id: u8,
         endpoint_id: u8,
+        pcap_meta: EndpointPcapMeta,
         real_ep: RIEH,
         dma_bus: BusDeviceRef,
         event_sender: EventSender,
@@ -527,6 +568,7 @@ impl<RIEH: RealInEndpointHandle> InEndpointHandle<RIEH> {
         Self {
             slot_id,
             endpoint_id,
+            pcap_meta,
             real_ep,
             dma_bus,
             event_sender,
@@ -548,6 +590,13 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for InEndpointHandle<RIEH> {
         let transfer_trb = TransferTrbVariant::parse(trb.buffer);
         match &transfer_trb {
             TransferTrbVariant::Normal(normal_data) => {
+                let event_timestamp = Timestamp::from(SystemTime::now());
+                pcap::in_submission(
+                    self.pcap_meta,
+                    trb.address,
+                    normal_data.transfer_length,
+                    event_timestamp,
+                );
                 self.real_ep.submit(normal_data.transfer_length as usize)?;
                 self.submission_state = NormalSubmissionState::AwaitingRealTransfer(TransferTrb {
                     address: trb.address,
@@ -599,6 +648,13 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for InEndpointHandle<RIEH> {
                             TrbProcessingResult::TransactionError,
                         ),
                         InTrbProcessingResult::Success(data) => {
+                            let event_timestamp = Timestamp::from(SystemTime::now());
+                            pcap::in_completion(
+                                self.pcap_meta,
+                                transfer_trb.address,
+                                &data,
+                                event_timestamp,
+                            );
                             let completion_code = if let TransferTrbVariant::Normal(
                                 ref normal_data,
                             ) = transfer_trb.variant

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -185,6 +185,13 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                         }
                         ControlRequestProcessingResult::SuccessfulControlOut => unreachable!(),
                         processing_error => {
+                            let event_timestamp = Timestamp::from(SystemTime::now());
+                            pcap::control_in_error(
+                                self.pcap_meta,
+                                usb_request,
+                                &processing_error,
+                                event_timestamp,
+                            );
                             self.handle_processing_error(processing_error, usb_request.address)?
                         }
                     }
@@ -216,6 +223,13 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                             TrbProcessingResult::Ok
                         }
                         processing_error => {
+                            let event_timestamp = Timestamp::from(SystemTime::now());
+                            pcap::control_out_error(
+                                self.pcap_meta,
+                                usb_request,
+                                &processing_error,
+                                event_timestamp,
+                            );
                             self.handle_processing_error(processing_error, usb_request.address)?
                         }
                     }
@@ -476,17 +490,45 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
                 NormalSubmissionState::AwaitingRealTransfer(ref transfer_trb) => {
                     let (completion_code, processing_result) =
                         match self.real_ep.next_completion().await? {
-                            OutTrbProcessingResult::Disconnect => (
-                                Some(CompletionCode::UsbTransactionError),
-                                TrbProcessingResult::Disconnect,
-                            ),
+                            OutTrbProcessingResult::Disconnect => {
+                                let event_timestamp = Timestamp::from(SystemTime::now());
+                                pcap::out_error(
+                                    self.pcap_meta,
+                                    transfer_trb.address,
+                                    &OutTrbProcessingResult::Disconnect,
+                                    &[],
+                                    event_timestamp,
+                                );
+                                (
+                                    Some(CompletionCode::UsbTransactionError),
+                                    TrbProcessingResult::Disconnect,
+                                )
+                            }
                             OutTrbProcessingResult::Stall => {
+                                let event_timestamp = Timestamp::from(SystemTime::now());
+                                pcap::out_error(
+                                    self.pcap_meta,
+                                    transfer_trb.address,
+                                    &OutTrbProcessingResult::Stall,
+                                    &[],
+                                    event_timestamp,
+                                );
                                 (Some(CompletionCode::StallError), TrbProcessingResult::Stall)
                             }
-                            OutTrbProcessingResult::TransactionError => (
-                                Some(CompletionCode::UsbTransactionError),
-                                TrbProcessingResult::TransactionError,
-                            ),
+                            OutTrbProcessingResult::TransactionError => {
+                                let event_timestamp = Timestamp::from(SystemTime::now());
+                                pcap::out_error(
+                                    self.pcap_meta,
+                                    transfer_trb.address,
+                                    &OutTrbProcessingResult::TransactionError,
+                                    &[],
+                                    event_timestamp,
+                                );
+                                (
+                                    Some(CompletionCode::UsbTransactionError),
+                                    TrbProcessingResult::TransactionError,
+                                )
+                            }
                             OutTrbProcessingResult::Success => {
                                 let completion_code =
                                     if let TransferTrbVariant::Normal(ref normal_data) =
@@ -636,17 +678,42 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for InEndpointHandle<RIEH> {
                         .next_completion()
                         .await?
                     {
-                        InTrbProcessingResult::Disconnect => (
-                            Some(CompletionCode::UsbTransactionError),
-                            TrbProcessingResult::Disconnect,
-                        ),
+                        InTrbProcessingResult::Disconnect => {
+                            let event_timestamp = Timestamp::from(SystemTime::now());
+                            pcap::in_error(
+                                self.pcap_meta,
+                                transfer_trb.address,
+                                &InTrbProcessingResult::Disconnect,
+                                event_timestamp,
+                            );
+                            (
+                                Some(CompletionCode::UsbTransactionError),
+                                TrbProcessingResult::Disconnect,
+                            )
+                        }
                         InTrbProcessingResult::Stall => {
+                            let event_timestamp = Timestamp::from(SystemTime::now());
+                            pcap::in_error(
+                                self.pcap_meta,
+                                transfer_trb.address,
+                                &InTrbProcessingResult::Stall,
+                                event_timestamp,
+                            );
                             (Some(CompletionCode::StallError), TrbProcessingResult::Stall)
                         }
-                        InTrbProcessingResult::TransactionError => (
-                            Some(CompletionCode::UsbTransactionError),
-                            TrbProcessingResult::TransactionError,
-                        ),
+                        InTrbProcessingResult::TransactionError => {
+                            let event_timestamp = Timestamp::from(SystemTime::now());
+                            pcap::in_error(
+                                self.pcap_meta,
+                                transfer_trb.address,
+                                &InTrbProcessingResult::TransactionError,
+                                event_timestamp,
+                            );
+                            (
+                                Some(CompletionCode::UsbTransactionError),
+                                TrbProcessingResult::TransactionError,
+                            )
+                        }
                         InTrbProcessingResult::Success(data) => {
                             let event_timestamp = Timestamp::from(SystemTime::now());
                             pcap::in_completion(

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -143,6 +143,8 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
             let result = match self.submission_state {
                 ControlSubmissionState::ParserConsumedTrb => TrbProcessingResult::Ok,
                 ControlSubmissionState::ParserError(trb_address) => {
+                    let event_timestamp = Timestamp::from(SystemTime::now());
+                    pcap::trb_error(self.pcap_meta, trb_address, event_timestamp);
                     let event = EventTrb::new_transfer_event_trb(
                         trb_address,
                         0,

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -4,6 +4,7 @@ use tracing::debug;
 
 use crate::device::{
     bus::BusDeviceRef,
+    pcap::{self, EndpointPcapMeta},
     xhci::{
         hotplug_endpoint_handle::BaseEndpointHandle,
         interrupter::EventSender,
@@ -62,6 +63,7 @@ impl BaseEndpointHandle for DummyEndpointHandle {
 pub struct ControlEndpointHandle<RCEH: RealControlEndpointHandle> {
     slot_id: u8,
     endpoint_id: u8,
+    pcap_meta: EndpointPcapMeta,
     real_ep: RCEH,
     trb_parser: ControlRequestParser,
     dma_bus: BusDeviceRef,
@@ -73,6 +75,7 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
     pub fn new(
         slot_id: u8,
         endpoint_id: u8,
+        pcap_meta: EndpointPcapMeta,
         real_ep: RCEH,
         dma_bus: BusDeviceRef,
         event_sender: EventSender,
@@ -80,6 +83,7 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
         Self {
             slot_id,
             endpoint_id,
+            pcap_meta,
             real_ep,
             trb_parser: ControlRequestParser::new(dma_bus.clone()),
             dma_bus,
@@ -112,6 +116,8 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                 Ok(request) => {
                     let request_copy = request.clone_without_data();
                     let is_out_request = request.request_type & 0x80 == 0;
+
+                    pcap::control_submission(self.pcap_meta, &request);
 
                     self.real_ep.submit_control_request(request)?;
 
@@ -152,6 +158,7 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                     match processing_result {
                         ControlRequestProcessingResult::SuccessfulControlIn(data) => {
                             debug!("got data from control in: {data:?}");
+                            pcap::control_completion_in(self.pcap_meta, usb_request.address, &data);
                             if let Some(data_pointer) = usb_request.data_pointer {
                                 debug!("writing data to {data_pointer}");
                                 self.dma_bus.write_bulk(data_pointer, &data);
@@ -182,6 +189,11 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                             unreachable!()
                         }
                         ControlRequestProcessingResult::SuccessfulControlOut => {
+                            pcap::control_completion_out(
+                                self.pcap_meta,
+                                usb_request.address,
+                                u32::from(usb_request.length),
+                            );
                             let event = EventTrb::new_transfer_event_trb(
                                 usb_request.address,
                                 0,
@@ -360,6 +372,7 @@ impl ControlRequestParser {
 pub struct OutEndpointHandle<ROEH: RealOutEndpointHandle> {
     slot_id: u8,
     endpoint_id: u8,
+    pcap_meta: EndpointPcapMeta,
     real_ep: ROEH,
     dma_bus: BusDeviceRef,
     event_sender: EventSender,
@@ -370,6 +383,7 @@ impl<ROEH: RealOutEndpointHandle> OutEndpointHandle<ROEH> {
     pub fn new(
         slot_id: u8,
         endpoint_id: u8,
+        pcap_meta: EndpointPcapMeta,
         real_ep: ROEH,
         dma_bus: BusDeviceRef,
         event_sender: EventSender,
@@ -377,6 +391,7 @@ impl<ROEH: RealOutEndpointHandle> OutEndpointHandle<ROEH> {
         Self {
             slot_id,
             endpoint_id,
+            pcap_meta,
             real_ep,
             dma_bus,
             event_sender,
@@ -408,6 +423,12 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
             TransferTrbVariant::Normal(normal_data) => {
                 let mut data = vec![0; normal_data.transfer_length as usize];
                 self.dma_bus.read_bulk(normal_data.data_pointer, &mut data);
+                pcap::out_submission(
+                    self.pcap_meta,
+                    trb.address,
+                    &data,
+                    normal_data.transfer_length,
+                );
                 self.real_ep.submit(data)?;
                 self.submission_state = NormalSubmissionState::AwaitingRealTransfer(TransferTrb {
                     address: trb.address,
@@ -460,6 +481,11 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
                                     if let TransferTrbVariant::Normal(ref normal_data) =
                                         transfer_trb.variant
                                     {
+                                        pcap::out_completion(
+                                            self.pcap_meta,
+                                            transfer_trb.address,
+                                            normal_data.transfer_length,
+                                        );
                                         match normal_data.interrupt_on_completion {
                                             true => Some(CompletionCode::Success),
                                             false => None,
@@ -510,6 +536,7 @@ impl<ROEH: RealOutEndpointHandle> BaseEndpointHandle for OutEndpointHandle<ROEH>
 pub struct InEndpointHandle<RIEH: RealInEndpointHandle> {
     slot_id: u8,
     endpoint_id: u8,
+    pcap_meta: EndpointPcapMeta,
     real_ep: RIEH,
     dma_bus: BusDeviceRef,
     event_sender: EventSender,
@@ -520,6 +547,7 @@ impl<RIEH: RealInEndpointHandle> InEndpointHandle<RIEH> {
     pub fn new(
         slot_id: u8,
         endpoint_id: u8,
+        pcap_meta: EndpointPcapMeta,
         real_ep: RIEH,
         dma_bus: BusDeviceRef,
         event_sender: EventSender,
@@ -527,6 +555,7 @@ impl<RIEH: RealInEndpointHandle> InEndpointHandle<RIEH> {
         Self {
             slot_id,
             endpoint_id,
+            pcap_meta,
             real_ep,
             dma_bus,
             event_sender,
@@ -548,6 +577,7 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for InEndpointHandle<RIEH> {
         let transfer_trb = TransferTrbVariant::parse(trb.buffer);
         match &transfer_trb {
             TransferTrbVariant::Normal(normal_data) => {
+                pcap::in_submission(self.pcap_meta, trb.address, normal_data.transfer_length);
                 self.real_ep.submit(normal_data.transfer_length as usize)?;
                 self.submission_state = NormalSubmissionState::AwaitingRealTransfer(TransferTrb {
                     address: trb.address,
@@ -599,6 +629,7 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for InEndpointHandle<RIEH> {
                             TrbProcessingResult::TransactionError,
                         ),
                         InTrbProcessingResult::Success(data) => {
+                            pcap::in_completion(self.pcap_meta, transfer_trb.address, &data);
                             let completion_code = if let TransferTrbVariant::Normal(
                                 ref normal_data,
                             ) = transfer_trb.variant

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -142,6 +142,7 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
             let result = match self.submission_state {
                 ControlSubmissionState::ParserConsumedTrb => TrbProcessingResult::Ok,
                 ControlSubmissionState::ParserError(trb_address) => {
+                    pcap::trb_error(self.pcap_meta, trb_address);
                     let event = EventTrb::new_transfer_event_trb(
                         trb_address,
                         0,
@@ -178,6 +179,7 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                         }
                         ControlRequestProcessingResult::SuccessfulControlOut => unreachable!(),
                         processing_error => {
+                            pcap::control_in_error(self.pcap_meta, usb_request, &processing_error);
                             self.handle_processing_error(processing_error, usb_request.address)?
                         }
                     }
@@ -207,6 +209,7 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                             TrbProcessingResult::Ok
                         }
                         processing_error => {
+                            pcap::control_out_error(self.pcap_meta, usb_request, &processing_error);
                             self.handle_processing_error(processing_error, usb_request.address)?
                         }
                     }
@@ -465,17 +468,39 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
                 NormalSubmissionState::AwaitingRealTransfer(ref transfer_trb) => {
                     let (completion_code, processing_result) =
                         match self.real_ep.next_completion().await? {
-                            OutTrbProcessingResult::Disconnect => (
-                                Some(CompletionCode::UsbTransactionError),
-                                TrbProcessingResult::Disconnect,
-                            ),
+                            OutTrbProcessingResult::Disconnect => {
+                                pcap::out_error(
+                                    self.pcap_meta,
+                                    transfer_trb.address,
+                                    &OutTrbProcessingResult::Disconnect,
+                                    &[],
+                                );
+                                (
+                                    Some(CompletionCode::UsbTransactionError),
+                                    TrbProcessingResult::Disconnect,
+                                )
+                            }
                             OutTrbProcessingResult::Stall => {
+                                pcap::out_error(
+                                    self.pcap_meta,
+                                    transfer_trb.address,
+                                    &OutTrbProcessingResult::Stall,
+                                    &[],
+                                );
                                 (Some(CompletionCode::StallError), TrbProcessingResult::Stall)
                             }
-                            OutTrbProcessingResult::TransactionError => (
-                                Some(CompletionCode::UsbTransactionError),
-                                TrbProcessingResult::TransactionError,
-                            ),
+                            OutTrbProcessingResult::TransactionError => {
+                                pcap::out_error(
+                                    self.pcap_meta,
+                                    transfer_trb.address,
+                                    &OutTrbProcessingResult::TransactionError,
+                                    &[],
+                                );
+                                (
+                                    Some(CompletionCode::UsbTransactionError),
+                                    TrbProcessingResult::TransactionError,
+                                )
+                            }
                             OutTrbProcessingResult::Success => {
                                 let completion_code =
                                     if let TransferTrbVariant::Normal(ref normal_data) =
@@ -617,17 +642,36 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for InEndpointHandle<RIEH> {
                         .next_completion()
                         .await?
                     {
-                        InTrbProcessingResult::Disconnect => (
-                            Some(CompletionCode::UsbTransactionError),
-                            TrbProcessingResult::Disconnect,
-                        ),
+                        InTrbProcessingResult::Disconnect => {
+                            pcap::in_error(
+                                self.pcap_meta,
+                                transfer_trb.address,
+                                &InTrbProcessingResult::Disconnect,
+                            );
+                            (
+                                Some(CompletionCode::UsbTransactionError),
+                                TrbProcessingResult::Disconnect,
+                            )
+                        }
                         InTrbProcessingResult::Stall => {
+                            pcap::in_error(
+                                self.pcap_meta,
+                                transfer_trb.address,
+                                &InTrbProcessingResult::Stall,
+                            );
                             (Some(CompletionCode::StallError), TrbProcessingResult::Stall)
                         }
-                        InTrbProcessingResult::TransactionError => (
-                            Some(CompletionCode::UsbTransactionError),
-                            TrbProcessingResult::TransactionError,
-                        ),
+                        InTrbProcessingResult::TransactionError => {
+                            pcap::in_error(
+                                self.pcap_meta,
+                                transfer_trb.address,
+                                &InTrbProcessingResult::TransactionError,
+                            );
+                            (
+                                Some(CompletionCode::UsbTransactionError),
+                                TrbProcessingResult::TransactionError,
+                            )
+                        }
                         InTrbProcessingResult::Success(data) => {
                             pcap::in_completion(self.pcap_meta, transfer_trb.address, &data);
                             let completion_code = if let TransferTrbVariant::Normal(

--- a/src/device/xhci/endpoint_launcher.rs
+++ b/src/device/xhci/endpoint_launcher.rs
@@ -154,7 +154,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                         )
                     }
                     EndpointType::BulkIn => {
-                        let pcap_meta = EndpointPcapMeta::bulk_in(
+                        let pcap_meta = EndpointPcapMeta::bulk(
                             pcap_usb_type,
                             request.slot_id,
                             request.endpoint_id,
@@ -170,7 +170,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                         )
                     }
                     EndpointType::BulkOut => {
-                        let pcap_meta = EndpointPcapMeta::bulk_out(
+                        let pcap_meta = EndpointPcapMeta::bulk(
                             pcap_usb_type,
                             request.slot_id,
                             request.endpoint_id,
@@ -186,7 +186,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                         )
                     }
                     EndpointType::InterruptIn => {
-                        let pcap_meta = EndpointPcapMeta::interrupt_in(
+                        let pcap_meta = EndpointPcapMeta::interrupt(
                             pcap_usb_type,
                             request.slot_id,
                             request.endpoint_id,
@@ -202,7 +202,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                         )
                     }
                     EndpointType::InterruptOut => {
-                        let pcap_meta = EndpointPcapMeta::interrupt_out(
+                        let pcap_meta = EndpointPcapMeta::interrupt(
                             pcap_usb_type,
                             request.slot_id,
                             request.endpoint_id,

--- a/src/device/xhci/endpoint_launcher.rs
+++ b/src/device/xhci/endpoint_launcher.rs
@@ -9,6 +9,7 @@ use tracing::{debug, info};
 use crate::{
     device::{
         bus::BusDeviceRef,
+        pcap::EndpointPcapMeta,
         xhci::{
             endpoint::{EndpointSender, EndpointWorker},
             endpoint_handle::{
@@ -118,32 +119,97 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             let endpoint_sender = match device {
                 Some(device) => match endpoint_type {
                     EndpointType::Control => {
+                        let pcap_meta = EndpointPcapMeta::control(
+                            Self::pcap_usb_type(device.as_ref()),
+                            request.slot_id,
+                            request.endpoint_id,
+                        );
                         let real_endpoint = device.realdevice_ref().control_endpoint_handle();
-                        self.launch_helper(ControlEndpointHandle::new, request.slot_id, request.endpoint_id, real_endpoint, request.endpoint_context, device.detach_token())
+                        self.launch_helper(
+                            ControlEndpointHandle::new,
+                            request.slot_id,
+                            request.endpoint_id,
+                            pcap_meta,
+                            real_endpoint,
+                            request.endpoint_context,
+                            device.detach_token(),
+                        )
                     }
                     EndpointType::BulkIn => {
+                        let pcap_meta = EndpointPcapMeta::bulk_in(
+                            Self::pcap_usb_type(device.as_ref()),
+                            request.slot_id,
+                            request.endpoint_id,
+                        );
                         let real_endpoint = device
                             .realdevice_ref()
                             .bulk_in_endpoint_handle(request.endpoint_id);
-                        self.launch_helper(InEndpointHandle::new, request.slot_id, request.endpoint_id, real_endpoint, request.endpoint_context, device.detach_token())
+                        self.launch_helper(
+                            InEndpointHandle::new,
+                            request.slot_id,
+                            request.endpoint_id,
+                            pcap_meta,
+                            real_endpoint,
+                            request.endpoint_context,
+                            device.detach_token(),
+                        )
                     }
                     EndpointType::BulkOut => {
+                        let pcap_meta = EndpointPcapMeta::bulk_out(
+                            Self::pcap_usb_type(device.as_ref()),
+                            request.slot_id,
+                            request.endpoint_id,
+                        );
                         let real_endpoint = device
                             .realdevice_ref()
                             .bulk_out_endpoint_handle(request.endpoint_id);
-                        self.launch_helper(OutEndpointHandle::new, request.slot_id, request.endpoint_id, real_endpoint, request.endpoint_context, device.detach_token())
+                        self.launch_helper(
+                            OutEndpointHandle::new,
+                            request.slot_id,
+                            request.endpoint_id,
+                            pcap_meta,
+                            real_endpoint,
+                            request.endpoint_context,
+                            device.detach_token(),
+                        )
                     }
                     EndpointType::InterruptIn => {
+                        let pcap_meta = EndpointPcapMeta::interrupt_in(
+                            Self::pcap_usb_type(device.as_ref()),
+                            request.slot_id,
+                            request.endpoint_id,
+                        );
                         let real_endpoint = device
                             .realdevice_ref()
                             .interrupt_in_endpoint_handle(request.endpoint_id);
-                        self.launch_helper(InEndpointHandle::new, request.slot_id, request.endpoint_id, real_endpoint, request.endpoint_context, device.detach_token())
+                        self.launch_helper(
+                            InEndpointHandle::new,
+                            request.slot_id,
+                            request.endpoint_id,
+                            pcap_meta,
+                            real_endpoint,
+                            request.endpoint_context,
+                            device.detach_token(),
+                        )
                     }
                     EndpointType::InterruptOut => {
+                        let pcap_meta = EndpointPcapMeta::interrupt_out(
+                            Self::pcap_usb_type(device.as_ref()),
+                            request.slot_id,
+                            request.endpoint_id,
+                        );
                         let real_endpoint = device
                             .realdevice_ref()
                             .interrupt_out_endpoint_handle(request.endpoint_id);
-                        self.launch_helper(OutEndpointHandle::new, request.slot_id, request.endpoint_id, real_endpoint, request.endpoint_context, device.detach_token())
+                        self.launch_helper(
+                            OutEndpointHandle::new,
+                            request.slot_id,
+                            request.endpoint_id,
+                            pcap_meta,
+                            real_endpoint,
+                            request.endpoint_context,
+                            device.detach_token(),
+                        )
                     }
                     EndpointType::Unsupported => unreachable!(
                         "the slot should early-reject configure endpoint commands with unsupported endpoint types"
@@ -178,22 +244,34 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             .ok_or_else(|| anyhow!("channel should never close"))
     }
 
+    fn pcap_usb_type(device: &CRD) -> u16 {
+        match device.realdevice_ref().speed() {
+            Some(speed) if speed.is_usb2_speed() => 2,
+            Some(_) => 3,
+            None => 0,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn launch_helper<RealEndpoint, Endpoint, EndpointConstructor>(
         &self,
         constructor: EndpointConstructor,
         slot_id: u8,
         endpoint_id: u8,
+        pcap_meta: EndpointPcapMeta,
         real_endpoint: RealEndpoint,
         endpoint_context: EndpointContext,
         detach_token: CancellationToken,
     ) -> EndpointSender
     where
         Endpoint: EndpointHandle,
-        EndpointConstructor: FnOnce(u8, u8, RealEndpoint, BusDeviceRef, EventSender) -> Endpoint,
+        EndpointConstructor:
+            FnOnce(u8, u8, EndpointPcapMeta, RealEndpoint, BusDeviceRef, EventSender) -> Endpoint,
     {
         let endpoint_handle = constructor(
             slot_id,
             endpoint_id,
+            pcap_meta,
             real_endpoint,
             self.dma_bus.clone(),
             self.event_sender.clone(),

--- a/src/device/xhci/endpoint_launcher.rs
+++ b/src/device/xhci/endpoint_launcher.rs
@@ -48,6 +48,14 @@ pub struct LaunchRequester {
     msg_send: mpsc::UnboundedSender<LaunchRequest>,
 }
 
+#[derive(Debug, Clone)]
+struct LaunchArgs {
+    slot_id: u8,
+    endpoint_id: u8,
+    endpoint_context: EndpointContext,
+    detach_token: CancellationToken,
+}
+
 impl LaunchRequester {
     pub async fn request_launch(
         &self,
@@ -123,6 +131,12 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                         Some(_) => 3,
                         None => 0,
                     };
+                    let launch_args = LaunchArgs {
+                        slot_id: request.slot_id,
+                        endpoint_id: request.endpoint_id,
+                        endpoint_context: request.endpoint_context,
+                        detach_token: device.detach_token(),
+                    };
 
                     match endpoint_type {
                     EndpointType::Control => {
@@ -134,12 +148,9 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                         let real_endpoint = device.realdevice_ref().control_endpoint_handle();
                         self.launch_helper(
                             ControlEndpointHandle::new,
-                            request.slot_id,
-                            request.endpoint_id,
+                            launch_args,
                             pcap_meta,
                             real_endpoint,
-                            request.endpoint_context,
-                            device.detach_token(),
                         )
                     }
                     EndpointType::BulkIn => {
@@ -153,12 +164,9 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                             .bulk_in_endpoint_handle(request.endpoint_id);
                         self.launch_helper(
                             InEndpointHandle::new,
-                            request.slot_id,
-                            request.endpoint_id,
+                            launch_args,
                             pcap_meta,
                             real_endpoint,
-                            request.endpoint_context,
-                            device.detach_token(),
                         )
                     }
                     EndpointType::BulkOut => {
@@ -172,12 +180,9 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                             .bulk_out_endpoint_handle(request.endpoint_id);
                         self.launch_helper(
                             OutEndpointHandle::new,
-                            request.slot_id,
-                            request.endpoint_id,
+                            launch_args,
                             pcap_meta,
                             real_endpoint,
-                            request.endpoint_context,
-                            device.detach_token(),
                         )
                     }
                     EndpointType::InterruptIn => {
@@ -191,12 +196,9 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                             .interrupt_in_endpoint_handle(request.endpoint_id);
                         self.launch_helper(
                             InEndpointHandle::new,
-                            request.slot_id,
-                            request.endpoint_id,
+                            launch_args,
                             pcap_meta,
                             real_endpoint,
-                            request.endpoint_context,
-                            device.detach_token(),
                         )
                     }
                     EndpointType::InterruptOut => {
@@ -210,12 +212,9 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                             .interrupt_out_endpoint_handle(request.endpoint_id);
                         self.launch_helper(
                             OutEndpointHandle::new,
-                            request.slot_id,
-                            request.endpoint_id,
+                            launch_args,
                             pcap_meta,
                             real_endpoint,
-                            request.endpoint_context,
-                            device.detach_token(),
                         )
                     }
                     EndpointType::Unsupported => unreachable!(
@@ -254,16 +253,12 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             .ok_or_else(|| anyhow!("channel should never close"))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn launch_helper<RealEndpoint, Endpoint, EndpointConstructor>(
         &self,
         constructor: EndpointConstructor,
-        slot_id: u8,
-        endpoint_id: u8,
+        launch_args: LaunchArgs,
         pcap_meta: EndpointPcapMeta,
         real_endpoint: RealEndpoint,
-        endpoint_context: EndpointContext,
-        detach_token: CancellationToken,
     ) -> EndpointSender
     where
         Endpoint: EndpointHandle,
@@ -271,19 +266,19 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             FnOnce(u8, u8, EndpointPcapMeta, RealEndpoint, BusDeviceRef, EventSender) -> Endpoint,
     {
         let endpoint_handle = constructor(
-            slot_id,
-            endpoint_id,
+            launch_args.slot_id,
+            launch_args.endpoint_id,
             pcap_meta,
             real_endpoint,
             self.dma_bus.clone(),
             self.event_sender.clone(),
         );
         let hotplug_endpoint_handle = HotplugEndpointHandleImpl::new(
-            slot_id,
-            endpoint_id,
+            launch_args.slot_id,
+            launch_args.endpoint_id,
             endpoint_handle,
             self.event_sender.clone(),
-            detach_token,
+            launch_args.detach_token,
             &self.async_runtime,
         );
 
@@ -291,7 +286,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             &self.async_runtime,
             self.dma_bus.clone(),
             hotplug_endpoint_handle,
-            endpoint_context,
+            launch_args.endpoint_context,
         )
     }
 }

--- a/src/device/xhci/endpoint_launcher.rs
+++ b/src/device/xhci/endpoint_launcher.rs
@@ -117,10 +117,17 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             debug!("endpoint context specifies endpoint type {endpoint_type:?}");
 
             let endpoint_sender = match device {
-                Some(device) => match endpoint_type {
+                Some(device) => {
+                    let pcap_usb_type = match device.realdevice_ref().speed() {
+                        Some(speed) if speed.is_usb2_speed() => 2,
+                        Some(_) => 3,
+                        None => 0,
+                    };
+
+                    match endpoint_type {
                     EndpointType::Control => {
                         let pcap_meta = EndpointPcapMeta::control(
-                            Self::pcap_usb_type(device.as_ref()),
+                            pcap_usb_type,
                             request.slot_id,
                             request.endpoint_id,
                         );
@@ -137,7 +144,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                     }
                     EndpointType::BulkIn => {
                         let pcap_meta = EndpointPcapMeta::bulk_in(
-                            Self::pcap_usb_type(device.as_ref()),
+                            pcap_usb_type,
                             request.slot_id,
                             request.endpoint_id,
                         );
@@ -156,7 +163,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                     }
                     EndpointType::BulkOut => {
                         let pcap_meta = EndpointPcapMeta::bulk_out(
-                            Self::pcap_usb_type(device.as_ref()),
+                            pcap_usb_type,
                             request.slot_id,
                             request.endpoint_id,
                         );
@@ -175,7 +182,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                     }
                     EndpointType::InterruptIn => {
                         let pcap_meta = EndpointPcapMeta::interrupt_in(
-                            Self::pcap_usb_type(device.as_ref()),
+                            pcap_usb_type,
                             request.slot_id,
                             request.endpoint_id,
                         );
@@ -194,7 +201,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                     }
                     EndpointType::InterruptOut => {
                         let pcap_meta = EndpointPcapMeta::interrupt_out(
-                            Self::pcap_usb_type(device.as_ref()),
+                            pcap_usb_type,
                             request.slot_id,
                             request.endpoint_id,
                         );
@@ -214,14 +221,17 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                     EndpointType::Unsupported => unreachable!(
                         "the slot should early-reject configure endpoint commands with unsupported endpoint types"
                     ),
-                },
+                    }
+                }
                 // unlikely edge case: The device was very recently detached, we are now handling an address device/configure endpoint command
                 // the endpoint does not depend on the real device, so we need the address device/configure endpoint to succeed (while also not
                 // creating an invalid state)
                 None => {
                     debug!("Could not get real device, using dummy endpoint handle");
                     let hotplug_endpoint_handle = HotplugEndpointHandleImpl::dummy(
-                        request.slot_id, request.endpoint_id, self.event_sender.clone()
+                        request.slot_id,
+                        request.endpoint_id,
+                        self.event_sender.clone(),
                     );
 
                     EndpointWorker::launch(
@@ -242,14 +252,6 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             .recv()
             .await
             .ok_or_else(|| anyhow!("channel should never close"))
-    }
-
-    fn pcap_usb_type(device: &CRD) -> u16 {
-        match device.realdevice_ref().speed() {
-            Some(speed) if speed.is_usb2_speed() => 2,
-            Some(_) => 3,
-            None => 0,
-        }
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/device/xhci/endpoint_launcher.rs
+++ b/src/device/xhci/endpoint_launcher.rs
@@ -9,6 +9,7 @@ use tracing::{debug, info};
 use crate::{
     device::{
         bus::BusDeviceRef,
+        pcap::EndpointPcapMeta,
         xhci::{
             endpoint::{EndpointSender, EndpointWorker},
             endpoint_handle::{
@@ -116,46 +117,121 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             debug!("endpoint context specifies endpoint type {endpoint_type:?}");
 
             let endpoint_sender = match device {
-                Some(device) => match endpoint_type {
+                Some(device) => {
+                    let pcap_usb_type = match device.realdevice_ref().speed() {
+                        Some(speed) if speed.is_usb2_speed() => 2,
+                        Some(_) => 3,
+                        None => 0,
+                    };
+
+                    match endpoint_type {
                     EndpointType::Control => {
+                        let pcap_meta = EndpointPcapMeta::control(
+                            pcap_usb_type,
+                            request.slot_id,
+                            request.endpoint_id,
+                        );
                         let real_endpoint = device.realdevice_ref().control_endpoint_handle();
-                        self.launch_helper(ControlEndpointHandle::new, request.slot_id, request.endpoint_id, real_endpoint, request.endpoint_context, device.detach_token())
+                        self.launch_helper(
+                            ControlEndpointHandle::new,
+                            request.slot_id,
+                            request.endpoint_id,
+                            pcap_meta,
+                            real_endpoint,
+                            request.endpoint_context,
+                            device.detach_token(),
+                        )
                     }
                     EndpointType::BulkIn => {
+                        let pcap_meta = EndpointPcapMeta::bulk_in(
+                            pcap_usb_type,
+                            request.slot_id,
+                            request.endpoint_id,
+                        );
                         let real_endpoint = device
                             .realdevice_ref()
                             .bulk_in_endpoint_handle(request.endpoint_id);
-                        self.launch_helper(InEndpointHandle::new, request.slot_id, request.endpoint_id, real_endpoint, request.endpoint_context, device.detach_token())
+                        self.launch_helper(
+                            InEndpointHandle::new,
+                            request.slot_id,
+                            request.endpoint_id,
+                            pcap_meta,
+                            real_endpoint,
+                            request.endpoint_context,
+                            device.detach_token(),
+                        )
                     }
                     EndpointType::BulkOut => {
+                        let pcap_meta = EndpointPcapMeta::bulk_out(
+                            pcap_usb_type,
+                            request.slot_id,
+                            request.endpoint_id,
+                        );
                         let real_endpoint = device
                             .realdevice_ref()
                             .bulk_out_endpoint_handle(request.endpoint_id);
-                        self.launch_helper(OutEndpointHandle::new, request.slot_id, request.endpoint_id, real_endpoint, request.endpoint_context, device.detach_token())
+                        self.launch_helper(
+                            OutEndpointHandle::new,
+                            request.slot_id,
+                            request.endpoint_id,
+                            pcap_meta,
+                            real_endpoint,
+                            request.endpoint_context,
+                            device.detach_token(),
+                        )
                     }
                     EndpointType::InterruptIn => {
+                        let pcap_meta = EndpointPcapMeta::interrupt_in(
+                            pcap_usb_type,
+                            request.slot_id,
+                            request.endpoint_id,
+                        );
                         let real_endpoint = device
                             .realdevice_ref()
                             .interrupt_in_endpoint_handle(request.endpoint_id);
-                        self.launch_helper(InEndpointHandle::new, request.slot_id, request.endpoint_id, real_endpoint, request.endpoint_context, device.detach_token())
+                        self.launch_helper(
+                            InEndpointHandle::new,
+                            request.slot_id,
+                            request.endpoint_id,
+                            pcap_meta,
+                            real_endpoint,
+                            request.endpoint_context,
+                            device.detach_token(),
+                        )
                     }
                     EndpointType::InterruptOut => {
+                        let pcap_meta = EndpointPcapMeta::interrupt_out(
+                            pcap_usb_type,
+                            request.slot_id,
+                            request.endpoint_id,
+                        );
                         let real_endpoint = device
                             .realdevice_ref()
                             .interrupt_out_endpoint_handle(request.endpoint_id);
-                        self.launch_helper(OutEndpointHandle::new, request.slot_id, request.endpoint_id, real_endpoint, request.endpoint_context, device.detach_token())
+                        self.launch_helper(
+                            OutEndpointHandle::new,
+                            request.slot_id,
+                            request.endpoint_id,
+                            pcap_meta,
+                            real_endpoint,
+                            request.endpoint_context,
+                            device.detach_token(),
+                        )
                     }
                     EndpointType::Unsupported => unreachable!(
                         "the slot should early-reject configure endpoint commands with unsupported endpoint types"
                     ),
-                },
+                    }
+                }
                 // unlikely edge case: The device was very recently detached, we are now handling an address device/configure endpoint command
                 // the endpoint does not depend on the real device, so we need the address device/configure endpoint to succeed (while also not
                 // creating an invalid state)
                 None => {
                     debug!("Could not get real device, using dummy endpoint handle");
                     let hotplug_endpoint_handle = HotplugEndpointHandleImpl::dummy(
-                        request.slot_id, request.endpoint_id, self.event_sender.clone()
+                        request.slot_id,
+                        request.endpoint_id,
+                        self.event_sender.clone(),
                     );
 
                     EndpointWorker::launch(
@@ -178,22 +254,26 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             .ok_or_else(|| anyhow!("channel should never close"))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn launch_helper<RealEndpoint, Endpoint, EndpointConstructor>(
         &self,
         constructor: EndpointConstructor,
         slot_id: u8,
         endpoint_id: u8,
+        pcap_meta: EndpointPcapMeta,
         real_endpoint: RealEndpoint,
         endpoint_context: EndpointContext,
         detach_token: CancellationToken,
     ) -> EndpointSender
     where
         Endpoint: EndpointHandle,
-        EndpointConstructor: FnOnce(u8, u8, RealEndpoint, BusDeviceRef, EventSender) -> Endpoint,
+        EndpointConstructor:
+            FnOnce(u8, u8, EndpointPcapMeta, RealEndpoint, BusDeviceRef, EventSender) -> Endpoint,
     {
         let endpoint_handle = constructor(
             slot_id,
             endpoint_id,
+            pcap_meta,
             real_endpoint,
             self.dma_bus.clone(),
             self.event_sender.clone(),

--- a/src/device/xhci/endpoint_launcher.rs
+++ b/src/device/xhci/endpoint_launcher.rs
@@ -126,7 +126,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
 
             let endpoint_sender = match device {
                 Some(device) => {
-                    let pcap_usb_type = match device.realdevice_ref().speed() {
+                    let pcap_usb_bus_number = match device.realdevice_ref().speed() {
                         Some(speed) if speed.is_usb2_speed() => 2,
                         Some(_) => 3,
                         None => 0,
@@ -141,7 +141,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                     match endpoint_type {
                     EndpointType::Control => {
                         let pcap_meta = EndpointPcapMeta::control(
-                            pcap_usb_type,
+                            pcap_usb_bus_number,
                             request.slot_id,
                             request.endpoint_id,
                         );
@@ -155,7 +155,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                     }
                     EndpointType::BulkIn => {
                         let pcap_meta = EndpointPcapMeta::bulk(
-                            pcap_usb_type,
+                            pcap_usb_bus_number,
                             request.slot_id,
                             request.endpoint_id,
                         );
@@ -171,7 +171,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                     }
                     EndpointType::BulkOut => {
                         let pcap_meta = EndpointPcapMeta::bulk(
-                            pcap_usb_type,
+                            pcap_usb_bus_number,
                             request.slot_id,
                             request.endpoint_id,
                         );
@@ -187,7 +187,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                     }
                     EndpointType::InterruptIn => {
                         let pcap_meta = EndpointPcapMeta::interrupt(
-                            pcap_usb_type,
+                            pcap_usb_bus_number,
                             request.slot_id,
                             request.endpoint_id,
                         );
@@ -203,7 +203,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                     }
                     EndpointType::InterruptOut => {
                         let pcap_meta = EndpointPcapMeta::interrupt(
-                            pcap_usb_type,
+                            pcap_usb_bus_number,
                             request.slot_id,
                             request.endpoint_id,
                         );

--- a/src/device/xhci/endpoint_launcher.rs
+++ b/src/device/xhci/endpoint_launcher.rs
@@ -48,6 +48,14 @@ pub struct LaunchRequester {
     msg_send: mpsc::UnboundedSender<LaunchRequest>,
 }
 
+#[derive(Debug)]
+struct LaunchArgs {
+    slot_id: u8,
+    endpoint_id: u8,
+    endpoint_context: EndpointContext,
+    detach_token: CancellationToken,
+}
+
 impl LaunchRequester {
     pub async fn request_launch(
         &self,
@@ -123,6 +131,12 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                         Some(_) => 3,
                         None => 0,
                     };
+                    let launch_args = LaunchArgs {
+                        slot_id: request.slot_id,
+                        endpoint_id: request.endpoint_id,
+                        endpoint_context: request.endpoint_context,
+                        detach_token: device.detach_token(),
+                    };
 
                     match endpoint_type {
                     EndpointType::Control => {
@@ -134,12 +148,9 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                         let real_endpoint = device.realdevice_ref().control_endpoint_handle();
                         self.launch_helper(
                             ControlEndpointHandle::new,
-                            request.slot_id,
-                            request.endpoint_id,
+                            launch_args,
                             pcap_meta,
                             real_endpoint,
-                            request.endpoint_context,
-                            device.detach_token(),
                         )
                     }
                     EndpointType::BulkIn => {
@@ -153,12 +164,9 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                             .bulk_in_endpoint_handle(request.endpoint_id);
                         self.launch_helper(
                             InEndpointHandle::new,
-                            request.slot_id,
-                            request.endpoint_id,
+                            launch_args,
                             pcap_meta,
                             real_endpoint,
-                            request.endpoint_context,
-                            device.detach_token(),
                         )
                     }
                     EndpointType::BulkOut => {
@@ -172,12 +180,9 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                             .bulk_out_endpoint_handle(request.endpoint_id);
                         self.launch_helper(
                             OutEndpointHandle::new,
-                            request.slot_id,
-                            request.endpoint_id,
+                            launch_args,
                             pcap_meta,
                             real_endpoint,
-                            request.endpoint_context,
-                            device.detach_token(),
                         )
                     }
                     EndpointType::InterruptIn => {
@@ -191,12 +196,9 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                             .interrupt_in_endpoint_handle(request.endpoint_id);
                         self.launch_helper(
                             InEndpointHandle::new,
-                            request.slot_id,
-                            request.endpoint_id,
+                            launch_args,
                             pcap_meta,
                             real_endpoint,
-                            request.endpoint_context,
-                            device.detach_token(),
                         )
                     }
                     EndpointType::InterruptOut => {
@@ -210,12 +212,9 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
                             .interrupt_out_endpoint_handle(request.endpoint_id);
                         self.launch_helper(
                             OutEndpointHandle::new,
-                            request.slot_id,
-                            request.endpoint_id,
+                            launch_args,
                             pcap_meta,
                             real_endpoint,
-                            request.endpoint_context,
-                            device.detach_token(),
                         )
                     }
                     EndpointType::Unsupported => unreachable!(
@@ -254,16 +253,12 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             .ok_or_else(|| anyhow!("channel should never close"))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn launch_helper<RealEndpoint, Endpoint, EndpointConstructor>(
         &self,
         constructor: EndpointConstructor,
-        slot_id: u8,
-        endpoint_id: u8,
+        launch_args: LaunchArgs,
         pcap_meta: EndpointPcapMeta,
         real_endpoint: RealEndpoint,
-        endpoint_context: EndpointContext,
-        detach_token: CancellationToken,
     ) -> EndpointSender
     where
         Endpoint: EndpointHandle,
@@ -271,19 +266,19 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             FnOnce(u8, u8, EndpointPcapMeta, RealEndpoint, BusDeviceRef, EventSender) -> Endpoint,
     {
         let endpoint_handle = constructor(
-            slot_id,
-            endpoint_id,
+            launch_args.slot_id,
+            launch_args.endpoint_id,
             pcap_meta,
             real_endpoint,
             self.dma_bus.clone(),
             self.event_sender.clone(),
         );
         let hotplug_endpoint_handle = HotplugEndpointHandleImpl::new(
-            slot_id,
-            endpoint_id,
+            launch_args.slot_id,
+            launch_args.endpoint_id,
             endpoint_handle,
             self.event_sender.clone(),
-            detach_token,
+            launch_args.detach_token,
             &self.async_runtime,
         );
 
@@ -291,7 +286,7 @@ impl<CRD: CompleteRealDevice> EndpointLauncher<CRD> {
             &self.async_runtime,
             self.dma_bus.clone(),
             hotplug_endpoint_handle,
-            endpoint_context,
+            launch_args.endpoint_context,
         )
     }
 }

--- a/src/device/xhci/nusb.rs
+++ b/src/device/xhci/nusb.rs
@@ -82,13 +82,12 @@ impl NusbDeviceWrapper {
 }
 
 const fn endpoint_id_to_address(endpoint_id: u8) -> u8 {
-    let endpoint_number = endpoint_id / 2;
-    let is_out_endpoint = endpoint_id.is_multiple_of(2);
-
-    match is_out_endpoint {
-        true => endpoint_number,
-        false => 0x80 | endpoint_number,
-    }
+    // NOTE: This only applies to normal endpoints!
+    // `endpoint_id / 2` yields the USB endpoint number, while the low bit of the
+    // xHCI endpoint id distinguishes OUT (even) from IN (odd). Rotating right by
+    // one moves that direction bit into the USB IN position (0x80) and leaves the
+    // endpoint number in the low bits.
+    endpoint_id.rotate_right(1)
 }
 
 #[derive(Debug)]

--- a/src/device/xhci/slot_manager.rs
+++ b/src/device/xhci/slot_manager.rs
@@ -648,7 +648,7 @@ impl Slot {
 /// An endpoint context has a size of 32 bytes, lies in guest memory, and
 /// contains information about an endpoint, most importantly for us the dequeue
 /// pointer and cycle state of the associated transfer ring.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EndpointContext {
     /// The address of the endpoint context in guest memory.
     address: u64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use anyhow::{Context, Result};
 use async_runtime::init_runtime;
 use clap::Parser;
 use cli::Cli;
+use device::pcap::UsbPcapManager;
 use hotplug_server::run_hotplug_server;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
@@ -39,6 +40,8 @@ fn main() -> Result<()> {
 
     // Log messages from the log crate as well.
     tracing_log::LogTracer::init()?;
+
+    UsbPcapManager::init(args.pcap_path.clone());
 
     init_runtime().context("Failed to initialize async runtime")?;
     let runtime = runtime();


### PR DESCRIPTION
As the project has grown more complex, it has become increasingly hard to pinpoint issues by manually scanning logs line by line. Adding PCAP capture support allows us to record USB transfer traffic in a parseable format and use tools like Wireshark to filter and isolate the exact signals we care about, making it much faster to locate relevant events and diagnose problems.
All PCAP record structures follow the official USB PCAP specification.([PCAP Capture File Format](https://datatracker.ietf.org/doc/id/draft-gharris-opsawg-pcap-00.html#name-packet-record) and [Packet structure](https://www.tcpdump.org/linktypes/LINKTYPE_USB_LINUX.html))

# Design
## Structure
The implementation of PCAP packets' structure is split into three parts:

- **meta.rs** defines the USB metadata attached to each recorded event and keeps call sites independent from PCAP layout details.

- **packet.rs** builds PCAP records and Linux USB link-layer headers from metadata and payload bytes, and handles writing the resulting bytes to the output file.

- **mod.rs** provides the public entry points that connect transport-side USB events to the serialization layer without exposing packet-format internals upstream.

## Bus number and Device address in packet
The capture output is meant to describe USB traffic as seen by this virtual xHCI path, not to reproduce host-side topology identifiers. If host-side bus and device numbering is needed for debugging, that can be captured separately on the host with usbmon.

The recorded bus number now represents the USB generation of the attached device, using 2 for USB 2.x and 3 for USB 3.x. The recorded device number now uses the slot id assigned by the virtual xHCI controller. This makes the dump better match the virtual device context carried through this stack.

## Error mapping
In the current implementation, transfer-side failures are grouped into three categories: Disconnect, Stall, and TransactionError. The PCAP status mapping follows Linux USB error semantics so the recorded error values stay close to the meaning that host-side tooling and developers would normally expect.

Disconnect is mapped to -ENODEV because it indicates that the target device is no longer present while the transfer is being processed. Stall is mapped to -EPIPE because a USB STALL reflects an endpoint-side reject or halt condition, which Linux conventionally reports as EPIPE for USB transfers. TransactionError is mapped to -EPROTO because it represents a protocol- or transaction-level transfer failure rather than an explicit device removal or endpoint stall.

This mapping keeps the PCAP error records readable and consistent with common Linux USB debugging conventions, while still reflecting the transfer error model used internally by the project.

# Usage
Add PCAP option `--pcap-path` when startup `usbvfiod`. The `PCAP` file will be stored in target path.

An example Wireshark view of a captured PCAP is shown in the figure below.
<img width="1181" height="898" alt="image" src="https://github.com/user-attachments/assets/5992e111-50a1-4ed6-8fd0-f637d81e80ef" />

# Limitation
Isochronous transfers are not implemented in the project yet, so PCAP currently captures only control, bulk, and interrupt traffic. 
