### PR TITLE
Rework USB 2 port enable flow

### DIFF
--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -332,6 +332,9 @@ pub mod xhci {
             pub const CRR: u64 = 0x8;
         }
 
+        /// See xhci specification chapter 5.4.8
+        ///
+        /// Bitmask of the specific field in the portsc register.
         pub mod portsc {
             pub const CCS: u64 = 0x1;
             pub const PED: u64 = 0x2;
@@ -355,6 +358,14 @@ pub mod xhci {
             pub const WOE: u64 = 0x8000000;
             pub const DR: u64 = 0x40000000;
             pub const WPR: u64 = 0x80000000;
+
+            /// Some values including their offset of some portsc fields when
+            /// the field is larger than one bit.
+            pub mod value {
+                pub const PLS_U0: u64 = 0x0;
+                pub const PLS_RXDETECT: u64 = 0xa0;
+                pub const PLS_POLLING: u64 = 0xe0;
+            }
         }
 
         pub mod usbsts {

--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -244,9 +244,13 @@ pub mod xhci {
 
         /// Extended Capabilities
         pub const SUPPORTED_PROTOCOLS: u64 = 0x20;
+        pub const SUPPORTED_PROTOCOLS_STRING: u64 = 0x24;
         pub const SUPPORTED_PROTOCOLS_CONFIG: u64 = 0x28;
+        pub const SUPPORTED_PROTOCOLS_CONFIG_RESERVED: u64 = 0x2c;
         pub const SUPPORTED_PROTOCOLS_USB2: u64 = 0x30;
+        pub const SUPPORTED_PROTOCOLS_USB2_STRING: u64 = 0x34;
         pub const SUPPORTED_PROTOCOLS_USB2_CONFIG: u64 = 0x38;
+        pub const SUPPORTED_PROTOCOLS_USB2_CONFIG_RESERVED: u64 = 0x3c;
 
         /// Operational Register Offsets
         pub const USBCMD: u64 = super::OP_BASE;
@@ -293,6 +297,8 @@ pub mod xhci {
             (super::MAX_PORTS << 24) | (super::MAX_INTRS << 8) | super::MAX_SLOTS;
         pub const HCSPARAMS2: u64 = super::MAX_ERST_SIZE_EXP << 4;
         pub const HCCPARAMS1: u64 = super::offset::SUPPORTED_PROTOCOLS << 14;
+
+        pub const USB_STRING: u64 = 0x20425355;
 
         pub mod supported_protocols {
             const ID: u64 = 2;

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -185,9 +185,13 @@ impl<CRD: CompleteRealDevice> PciDevice for XhciController<CRD> {
 
             // xHC Extended Capability ("Supported Protocols Capability")
             offset::SUPPORTED_PROTOCOLS => capability::supported_protocols::CAP_INFO,
+            offset::SUPPORTED_PROTOCOLS_STRING => capability::USB_STRING,
             offset::SUPPORTED_PROTOCOLS_CONFIG => capability::supported_protocols::CONFIG,
+            offset::SUPPORTED_PROTOCOLS_CONFIG_RESERVED => 0,
             offset::SUPPORTED_PROTOCOLS_USB2 => capability::supported_protocols_usb2::CAP_INFO,
+            offset::SUPPORTED_PROTOCOLS_USB2_STRING => capability::USB_STRING,
             offset::SUPPORTED_PROTOCOLS_USB2_CONFIG => capability::supported_protocols_usb2::CONFIG,
+            offset::SUPPORTED_PROTOCOLS_USB2_CONFIG_RESERVED => 0,
 
             // xHC Operational Registers
             offset::USBCMD => 0,

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -159,7 +159,9 @@ impl<CRD: CompleteRealDevice> PciDevice for XhciController<CRD> {
                 let port_index = get_portsc_index(addr).unwrap();
                 // port ids start at 1, so we have to convert the MMIO address offset to the id
                 let port_id = port_index + 1;
-                self.port_array.write_portsc(port_id, value);
+                self.port_array
+                    .write_portsc(port_id, value)
+                    .expect("event_sender should be alive");
             }
             addr => {
                 todo!("unknown write {}", addr);

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -219,6 +219,7 @@ impl<CRD: CompleteRealDevice> PciDevice for XhciController<CRD> {
             offset::DOORBELL_CONTROLLER => 0, // kernel reads the doorbell after write
             // Device Doorbell Registers (DOORBELL_DEVICE)
             offset::DOORBELL_DEVICE..offset::DOORBELL_DEVICE_END => 0,
+            offset::MFINDEX => 0x0,
 
             // Port Status and Control Register (PORTSC)
             addr if get_portsc_index(addr).is_some() => {

--- a/src/device/xhci/port.rs
+++ b/src/device/xhci/port.rs
@@ -31,8 +31,14 @@ pub struct PortArray<CRD: CompleteRealDevice> {
 
 impl<CRD: CompleteRealDevice> PortArray<CRD> {
     pub fn new(event_sender: EventSender, async_runtime: runtime::Handle) -> Self {
-        let portsc: Arc<OneIndexed<PortscRegister, { MAX_PORTS as usize }>> =
-            Arc::new(array::from_fn(|_| PortscRegister::default()).into());
+        let portsc: Arc<OneIndexed<PortscRegister, { MAX_PORTS as usize }>> = Arc::new(
+            array::from_fn(|index| {
+                // SAFETY: port_id is capped at 255 according to spec
+                let port_id = index as u8 + 1;
+                PortscRegister::new(event_sender.clone(), Self::port_version(port_id), port_id)
+            })
+            .into(),
+        );
 
         let (msg_sender, msg_recv) = mpsc::unbounded_channel();
 
@@ -50,8 +56,8 @@ impl<CRD: CompleteRealDevice> PortArray<CRD> {
         Self { portsc, msg_sender }
     }
 
-    pub fn write_portsc(&self, port_id: usize, value: u64) {
-        self.portsc[port_id].write(value);
+    pub fn write_portsc(&self, port_id: usize, value: u64) -> anyhow::Result<()> {
+        self.portsc[port_id].write(value)
     }
 
     pub fn read_portsc(&self, port_id: usize) -> u64 {
@@ -67,6 +73,14 @@ impl<CRD: CompleteRealDevice> PortArray<CRD> {
     pub fn create_device_retriever(&self) -> DeviceRetriever<CRD> {
         DeviceRetriever {
             msg_send: self.msg_sender.clone(),
+        }
+    }
+
+    fn port_version(port_id: u8) -> UsbVersion {
+        match port_id as u64 {
+            1..=NUM_USB3_PORTS => UsbVersion::USB3,
+            id if id > NUM_USB3_PORTS && id <= MAX_PORTS => UsbVersion::USB2,
+            id => panic!("asked for port version of non-existent port id {id}"),
         }
     }
 }
@@ -145,7 +159,7 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
         let available_port_id = match (1..=MAX_PORTS as usize)
                 .find(|&i| {
                     self.devices[i].is_none()
-                        && Self::port_version(i as u64) == version
+                        && self.portsc[i].usb_version() == version
                 }) // filter USB2/3
                 {
                     Some(port) => port,
@@ -160,15 +174,26 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
         ));
 
         self.devices[available_port_id] = Some(Arc::new(device));
-        self.portsc[available_port_id].set(
-            portsc::CCS
-                | portsc::PED
-                | portsc::PP
-                | portsc::CSC
-                | portsc::PEC
-                | portsc::PRC
-                | (speed as u64) << 10,
-        );
+
+        let new_portsc = match version {
+            UsbVersion::USB3 => {
+                portsc::CCS
+                    | portsc::PED
+                    | portsc::PP
+                    | portsc::CSC
+                    | portsc::PEC
+                    | portsc::PRC
+                    | (speed as u64) << 10
+            }
+            UsbVersion::USB2 => {
+                portsc::CCS
+                    | portsc::value::PLS_POLLING
+                    | portsc::PP
+                    | (speed as u64) << 10
+                    | portsc::CSC
+            }
+        };
+        self.portsc[available_port_id].set(new_portsc);
 
         info!(
             "Attached {speed} device {identifier:?} to port {available_port_id} ({version:?} port)"
@@ -178,14 +203,6 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
         self.event_sender.send(event)?;
 
         Ok(Response::SuccessfulOperation)
-    }
-
-    fn port_version(port_id: u64) -> UsbVersion {
-        match port_id {
-            1..=NUM_USB3_PORTS => UsbVersion::USB3,
-            id if id > NUM_USB3_PORTS && id <= MAX_PORTS => UsbVersion::USB2,
-            id => panic!("asked for port version of non-existent port id {id}"),
-        }
     }
 
     fn attached_devices(&self) -> Vec<CRD::ID> {
@@ -259,7 +276,7 @@ async fn detach_listener<CRD: CompleteRealDevice>(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum UsbVersion {
+pub enum UsbVersion {
     USB2,
     USB3,
 }
@@ -348,45 +365,5 @@ impl<CRD: CompleteRealDevice> DeviceRetriever<CRD> {
         let device = recv.await?;
 
         Ok(device)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn portsc_read_write() {
-        let reg = PortscRegister::default();
-        reg.set(0x00260203);
-        assert_eq!(reg.read(), 0x00260203);
-
-        reg.write(0x0);
-        assert_eq!(
-            reg.read(),
-            0x00260203,
-            "writing 0 should affect neither the read-only nor the RW1C bits."
-        );
-
-        reg.write(0x00200000);
-        assert_eq!(
-            reg.read(),
-            0x00060203,
-            "writing 1 to bit 21 should clear the bit."
-        );
-
-        reg.write(0x00040000);
-        assert_eq!(
-            reg.read(),
-            0x00020203,
-            "writing 1 to bit 18 should clear the bit."
-        );
-
-        reg.write(0x00020000);
-        assert_eq!(
-            reg.read(),
-            0x00000203,
-            "writing 1 to bit 17 should clear the bit."
-        );
     }
 }

--- a/src/device/xhci/registers.rs
+++ b/src/device/xhci/registers.rs
@@ -4,37 +4,53 @@ use std::sync::{
 };
 
 use tokio::sync::Notify;
+use tracing::trace;
 
-use crate::device::pci::constants::xhci::{
-    operational::{portsc, usbsts},
-    MAX_SLOTS,
+use crate::device::{
+    pci::constants::xhci::{
+        operational::{portsc, usbsts},
+        MAX_SLOTS,
+    },
+    xhci::{interrupter::EventSender, port::UsbVersion, trb::EventTrb},
 };
 
-/// A simple PORTSC register implementation supporting RW1C bits.
+/// A somewhat simple PORTSC register implementation supporting RW1C bits and
+/// handling custom port reset logic.
 ///
 /// The PORTSC register requires us to initially set some bits and
 /// later react to 1-to-clear writes (RW1C) to get a device to show up.
-/// Perhaps later we need more fine-grained access to the bits or state
-/// handling, but we can use the simplistic implementation for now.
+/// Additionally the PR bit is handled specific to this implementation to avoid
+/// an actual reset. Instead we pretend it was successful.
+/// We might need further specific logic or access to the bits or state
+/// handling later, for now this implementation is enough.
 #[derive(Debug)]
 pub struct PortscRegister {
     value: AtomicU64,
+    event_sender: EventSender,
+    usb_version: UsbVersion,
+    port_id: u8,
 }
 
 const BITMASK_RW1C: u64 = 0x00260000;
 
-impl Default for PortscRegister {
-    fn default() -> Self {
+impl PortscRegister {
+    pub const fn new(event_sender: EventSender, usb_version: UsbVersion, port_id: u8) -> Self {
         Self {
-            value: AtomicU64::new(portsc::PP),
+            value: AtomicU64::new(portsc::PP | portsc::value::PLS_RXDETECT),
+            event_sender,
+            usb_version,
+            port_id,
         }
     }
-}
 
-impl PortscRegister {
+    /// Write `value` to the register by overwriting the previously stored one.
     pub fn set(&self, value: u64) {
         self.value
             .store(value, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub const fn usb_version(&self) -> UsbVersion {
+        self.usb_version
     }
 
     /// Read the current register value.
@@ -47,18 +63,64 @@ impl PortscRegister {
     /// Update the current register value.
     ///
     /// This function should be called when an MMIO write happens.
-    /// RW1C bits are updates according to RW1C semantics, all
-    /// other bits are treated as read-only.
-    pub fn write(&self, new_value: u64) {
-        let _ = self.value.fetch_update(
+    /// RW1C bits are updates according to RW1C semantics.
+    /// PR bit is handled by a custom logic path.
+    /// All other bits are treated as read-only.
+    pub fn write(&self, new_value: u64) -> anyhow::Result<()> {
+        let bits_to_clear = new_value & BITMASK_RW1C;
+        let port_reset_bit = new_value & portsc::PR != 0;
+
+        match self.value.fetch_update(
             std::sync::atomic::Ordering::Relaxed,
             std::sync::atomic::Ordering::Relaxed,
             |reg| {
-                let bits_to_clear = new_value & BITMASK_RW1C;
-                let new_value = reg & !bits_to_clear;
-                Some(new_value)
+                let mut new_reg = reg & !bits_to_clear;
+
+                if port_reset_bit {
+                    Self::port_reset(&mut new_reg, self.usb_version);
+                }
+
+                Some(new_reg)
             },
-        );
+        ) {
+            Ok(_) => {
+                if port_reset_bit {
+                    let event = EventTrb::new_port_status_change_event_trb(self.port_id);
+                    self.event_sender.send(event)?;
+                }
+                Ok(())
+            }
+            Err(_) => unreachable!("update function never returns None"),
+        }
+    }
+
+    fn port_reset(register: &mut u64, usb_version: UsbVersion) {
+        match usb_version {
+            UsbVersion::USB2 => {
+                trace!("driver attempted to write portsc::PR on USB 2");
+                let portsc_update_mask = portsc::PRC | portsc::PED | portsc::PLS;
+                Self::update_with_mask(
+                    register,
+                    portsc::value::PLS_U0 | portsc::PED | portsc::PRC,
+                    portsc_update_mask,
+                );
+            }
+            UsbVersion::USB3 => {
+                Self::update_with_mask(register, portsc::PRC, portsc::PRC);
+            }
+        }
+    }
+
+    /// Update the masked bits with the given value.
+    ///
+    /// This function is absolute and does not respect RW rules imposed for
+    /// driver access. It shall only be called as part of internal controller
+    /// logic.
+    /// Set bits in `value` not set in `mask` are silently dropped.
+    const fn update_with_mask(register: &mut u64, value: u64, mask: u64) {
+        let register_clear = *register & !mask;
+        let value_checked = value & mask;
+        *register = value_checked | register_clear;
     }
 }
 
@@ -187,36 +249,46 @@ impl ErstbaRegister {
 
 #[cfg(test)]
 mod tests {
+    use crate::device::xhci::interrupter::Interrupter;
+    use crate::dynamic_bus::DynamicBus;
+    use crate::{init_runtime, runtime};
+
     use super::*;
 
     #[test]
     fn portsc_read_write() {
-        let reg = PortscRegister::default();
+        // TODO this is conflicting with other tests using runtime (currently only this one)
+        init_runtime().expect("Failed to initialize async runtime");
+        let async_runtime = runtime();
+        let dma_bus = Arc::new(DynamicBus::new());
+        let interrupter = Interrupter::new(dma_bus, async_runtime);
+        let reg = PortscRegister::new(interrupter.create_event_sender(), UsbVersion::USB3, 1);
+
         reg.set(0x00260203);
         assert_eq!(reg.read(), 0x00260203);
 
-        reg.write(0x0);
+        reg.write(0x0).unwrap();
         assert_eq!(
             reg.read(),
             0x00260203,
             "writing 0 should affect neither the read-only nor the RW1C bits."
         );
 
-        reg.write(0x00200000);
+        reg.write(0x00200000).unwrap();
         assert_eq!(
             reg.read(),
             0x00060203,
             "writing 1 to bit 21 should clear the bit."
         );
 
-        reg.write(0x00040000);
+        reg.write(0x00040000).unwrap();
         assert_eq!(
             reg.read(),
             0x00020203,
             "writing 1 to bit 18 should clear the bit."
         );
 
-        reg.write(0x00020000);
+        reg.write(0x00020000).unwrap();
         assert_eq!(
             reg.read(),
             0x00000203,

--- a/src/xhci_backend.rs
+++ b/src/xhci_backend.rs
@@ -217,8 +217,6 @@ impl<CRD: CompleteRealDevice> ServerBackend for XhciBackend<CRD> {
         offset: u64,
         data: &mut [u8],
     ) -> Result<(), std::io::Error> {
-        trace!("read  region {region} offset {offset:#x}+{}", data.len());
-
         let value: u64 = match region {
             VFIO_PCI_CONFIG_REGION_INDEX => self.controller.read_cfg(Request::new(
                 offset,
@@ -238,6 +236,12 @@ impl<CRD: CompleteRealDevice> ServerBackend for XhciBackend<CRD> {
         };
 
         data.copy_from_slice(&value.to_le_bytes()[0..data.len()]);
+
+        trace!(
+            "read region {region} offset {offset:#x}+{} val {:?}",
+            data.len(),
+            data
+        );
 
         Ok(())
     }


### PR DESCRIPTION
These changes are a stepping stone for windows support.
This implements the USB 2.0 port state transitions as mentioned in the spec.