### PR TITLE
Allow doorbell while trb processing

### DIFF
--- a/src/device/xhci/endpoint.rs
+++ b/src/device/xhci/endpoint.rs
@@ -140,6 +140,7 @@ impl<EH: HotplugEndpointHandle> EndpointWorker<EH> {
                             self.state = WorkerState::StoppedWithContinuableTrb;
                             completion.send_anyhow(CompletionCode::Success)?;
                         }
+                        EndpointMessage::Doorbell => {}
                         msg => warn!("invalid endpoint action: {msg:?} in state {:?}", self.state),
                     }
                 },

--- a/src/device/xhci/endpoint.rs
+++ b/src/device/xhci/endpoint.rs
@@ -113,25 +113,25 @@ impl<EH: HotplugEndpointHandle> EndpointWorker<EH> {
                         HotplugTrbProcessingResult::Ok => {
                             self.transfer_ring.advance();
                             self.state = WorkerState::LookForTrb;
-                        },
+                        }
                         HotplugTrbProcessingResult::Stall => {
                             self.context.set_state(endpoint_state::HALTED);
                             let (dequeue_pointer, cycle_state) = self.transfer_ring.get_dequeue_pointer();
                             self.context.set_dequeue_pointer_and_cycle_state(dequeue_pointer, cycle_state);
                             self.state = WorkerState::Halted;
-                        },
+                        }
                         HotplugTrbProcessingResult::TransactionError => {
                             self.context.set_state(endpoint_state::HALTED);
                             let (dequeue_pointer, cycle_state) = self.transfer_ring.get_dequeue_pointer();
                             self.context.set_dequeue_pointer_and_cycle_state(dequeue_pointer, cycle_state);
                             self.state = WorkerState::Halted;
-                        },
+                        }
                         HotplugTrbProcessingResult::TrbError => {
                             self.context.set_state(endpoint_state::ERROR);
                             let (dequeue_pointer, cycle_state) = self.transfer_ring.get_dequeue_pointer();
                             self.context.set_dequeue_pointer_and_cycle_state(dequeue_pointer, cycle_state);
                             self.state = WorkerState::Error;
-                        },
+                        }
                     },
                     // cannot use self.next_msg() because the &mut it takes clashes with the self.real_endpoint above
                     msg = self.recv.recv() => match msg.ok_or_else(|| anyhow!(""))? {
@@ -139,7 +139,7 @@ impl<EH: HotplugEndpointHandle> EndpointWorker<EH> {
                             self.context.set_state(endpoint_state::STOPPED);
                             self.state = WorkerState::StoppedWithContinuableTrb;
                             completion.send_anyhow(CompletionCode::Success)?;
-                            },
+                        }
                         msg => warn!("invalid endpoint action: {msg:?} in state {:?}", self.state),
                     }
                 },


### PR DESCRIPTION
@snue encountered the following warning:
```
[  187.247344] usbvfiod[675]: 2026-04-13T09:30:07.931374Z  WARN usbvfiod::device::xhci::endpoint: invalid endpoint action: Doorbell in state WaitForTrbCompletion
```

We print such warnings for every state/message combination that have not encountered yet, so the warnings can appear in legitimate case (as is the case here).

A doorbell tells us to look for new TRBs on the transfer ring. When waiting for a TRB, we will afterwards continue checking the transfer ring for more TRB, anyways; we can ignore the doorbell.

So, this PR adds a explicit acknowledge for doorbells in the WaitForTrbCompletion state.