### PR TITLE
Add inital user documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ virtual machines using the [vfio-user
 protocol](https://www.qemu.org/docs/master/interop/vfio-user.html). Other
 VMMs might also work, but are currently not the main target.
 
-This project is still under active development. We are planning to work on this
+This project is under active development. We are planning to work on this
 project in the following order:
 
 1. **Validating our Assumptions** (Done)
@@ -24,14 +24,18 @@ project in the following order:
      endpoints.
 1. **Hotplug Devices** (Done)
    - We enable attach and detach of exposed devices during runtime.
-1. **Stability & Error Recovery** (🚧 **Ongoing** 🚧)
+1. **Stability & Error Recovery** (Done)
    - We seek out points where we currently panic but should not have to panic.
+1. **Windows Guest Support** (🚧 **Ongoing** 🚧)
+   - Enable all features required for the Windows xHCI driver to interact with
+     devices through the controller.
 1. **Everything Beyond**
    - Many topics remain open. We stay flexible regarding upcoming features.
+   - Missing features include isochronous endpoint support, non-Linux Host
+     support, and support for other VMMs than Cloud Hypervisor.
 
-If you want to use this code, please check back later or [get in
-touch](https://cyberus-technology.de/en/contact), if you need
-professional support.
+If you want to use this code in production and need professional support,
+please [get in touch](https://cyberus-technology.de/en/contact).
 
 ## Documentation
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,10 +1,16 @@
 # Documentation
 
+This project offers a vfio-user server that allows you to pass USB devices
+(such as storage drives, keyboards, etc.) from a host system to a Cloud
+Hypervisor virtual machine. For a basic overview of the goals, see the
+[Architecture Overview](./developers/architecture.md).
+
 ## For Users
 
-As the project is **not usable yet**, there is no user
-documentation. Please check back later or [get in
-touch](https://cyberus-technology.de/en/contact), if you need
+- [Setup and Invocation](./users/basic.md)
+- [Security Considerations](./users/security.md)
+
+Please [get in touch](https://cyberus-technology.de/en/contact), if you need
 professional support.
 
 ## For Developers

--- a/docs/users/basic.md
+++ b/docs/users/basic.md
@@ -1,0 +1,91 @@
+# Usage
+
+The package currently offers two binaries:
+* `usbvfiod`: the vfio-user server emulating an xHCI controller
+* `remote`: a utility to control USB host device attachment
+
+The server communicates via two Unix sockets:
+* a `vfio-user` socket for communication between `usbvfiod` and the VMM (Cloud Hypervisor)
+* a `hotplug` socket to attach/detach/list devices exposed by `usbvfiod` from the host (optional)
+
+> [!TODO]
+> Currently, the server creates both sockets. The `vfio-user` standard
+> requires that a server can also accept the `vfio-user` socket as a file
+> descriptor, but we have not yet implemented this functionality.
+
+## Obtaining the Package
+
+The software is available through the [GitHub
+website](https://github.com/cyberus-technology/usbvfiod) as a `nix
+flake`, or can be built from source as `cargo` project. We also
+release versions to [crates.io](https://crates.io/crates/usbvfiod)
+and maintain [a `NixOS`
+package](https://search.nixos.org/packages?channel=unstable&query=usbvfiod).
+
+> [!NOTE]
+> There are currently no other officially maintained distribution packages
+> available.
+
+## Invocation
+
+You can run the server through `nix` directly from GitHub, or install the
+binaries in your system through `cargo install usbvfiod`.
+
+```console
+nix run github:cyberus-technology/usbvfiod#usbvfiod -- \
+  --socket-path /path/to/usbvfiod.sock                 \
+  --hotplug-socket-path /path/to/usb-hotplug.sock
+2026-04-10T07:00:16.353894Z  INFO usbvfiod: We're up!
+```
+
+> [!NOTE]
+> Instead of (or additionally to) providing a `hotplug` socket, you can
+> specify devices to expose on the controller directly with
+> `--device /dev/bus/usb/<BUS>/<DEV>`
+
+Connect the virtual xHCI controller to a Cloud Hypervisor instance through the
+`vfio-user` socket, by adding `--user-device socket=/path/to/usbvfiod.sock` to
+the Cloud Hypervisor command line invocation. The socket must exist (`usbvfiod`
+must be running) before Cloud Hypervisor can attach to it.
+
+Use the `remote` binary to list, attach, and detach devices through the
+`hotplug` socket.
+
+```console
+nix run github:cyberus-technology/usbvfiod#remote -- \
+  --socket /path/to/usb-hotplug.sock                 \
+  --list
+No attached devices
+```
+
+Attach a USB device to the controller through the `hotplug` socket. The 
+example uses a keyboard recognized at `/dev/bus/usb/009/003`.
+
+```
+nix run github:cyberus-technology/usbvfiod#remote -- \
+  --socket /tmp/usb-hotplug.sock                     \
+  --attach /dev/bus/usb/009/003
+Requesting attachment of device 009:003
+2026-04-10T07:01:16.353894Z  INFO usbvfiod::device::xhci::port: Attached Full Speed (12 Mbps) device (9, 3) to port 5 (USB2 port)
+    SuccessfulOperation
+```
+
+Detach the device using the recorded device ID also shown on `--list`.
+
+```console
+nix run github:cyberus-technology/usbvfiod#remote -- \
+  --socket /tmp/usb-hotplug.sock                     \
+  --detach 9 3
+Requesting detach of device 009:003
+2026-04-10T07:02:17.889529Z  INFO usbvfiod::device::xhci::port: Detached device (9, 3) from port 5
+SuccessfulOperation
+```
+
+## Device Access Restrictions
+
+The `usbvfiod` server and `remote` binary do not require elevated privileges.
+Only access to the USB character device nodes is required for the component
+opening the device. You can manage the permissions for specific devices through
+`udev` rules (`TAG+="uaccess"`), or you can invoke the `remote` binary with
+elevated privileges (e.g., `sudo`). The `hotplug` socket must be accessible to
+the `remote` binary.

--- a/docs/users/security.md
+++ b/docs/users/security.md
@@ -1,0 +1,106 @@
+# Security Considerations
+
+USB device passthrough presents some security challenges, as malicious devices
+could potentially compromise system integrity and enable privilege escalation.
+This project was specifically designed with security as a core principle,
+allowing multiple layers of defense to limit the impact of malicious actors.
+The design philosophy prioritizes isolation and privilege separation mechanisms
+to ensure that compromised guest systems cannot easily escape to the host.
+
+## Threat Model
+
+Attackers:
+* Malicious USB devices
+* Malicious Guest VM drivers
+
+Trusted parties:
+* Host processes with socket access
+* Host Kernel USB API
+
+We specifically trust the VMM and utilities calling the `hotplug` socket.
+
+Risks:
+* Leaks from the process address space
+* VM Escapes to the host user space and subsequent privilege escalation
+
+## Design Mitigations
+
+The vfio-user server runs as a separate user-space process. Its operation is
+tightly coupled to the VMM it serves, but it is isolated from the VMM process
+address space and privileges. One process only ever serves one VMM.
+
+The software is written in a memory-safe language, to limit the possibilities
+of bugs leading to code execution. The nature of protocol boundaries to the
+kernel and `vfio-user` client mandates some carefully chosen bindings to uphold
+those guarantees.
+
+### Host and Guest Memory Access
+
+The server has full access to the Guest VM's physical backing memory.
+Guest-controlled DMA (Direct Memory Access) operations of the virtual
+controller are only supported from/to this memory. The Guest VM is generally
+allowed arbitrary modifications to its memory, or to "shoot itself in the
+foot" through the virtual controller. Access to Guest memory regions outside
+the backing memory (i.e., "P2P DMA") is deliberately not supported through the
+`vfio-user` server.
+
+All Host-DMA is gated through the Kernel user-space USB API. No direct control
+over the host USB controller is granted to the server.
+
+### Privilege Separation
+
+The server accepts file descriptors to opened devices through the `hotplug`
+socket. This ensures the server itself does not require the privileges to open
+device nodes, and can run with very low privileges over the whole process
+lifetime.
+
+The provided `remote` utility incurs short-lived processes with the required
+permissions to open a device node and the `hotplug` socket. The Linux Kernel
+user-space USB API is based on file permissions and does not mandate additional
+capabilities.
+
+The VMM is a separate process with its own security boundary. It must be
+granted access to the `vfio-user` socket.
+
+The sockets used for communication must be sufficiently protected from
+malicious or accidental interference. Malformed access may lead to denial of
+service of the virtual controller.
+
+## Hardening Options
+
+The design allows for various orthogonal hardening options.
+
+### Service Sandboxing
+
+The vfio-user server can be run with strict sandboxing to further limit its capabilities:
+* **Process isolation**: Ensure the server runs as a non-root user with minimal group memberships.
+* **User namespace isolation**: Run the server in a dedicated user namespace where it has minimal privileges.
+* **System call filtering**: The `vfio-user` server allowed syscalls can be further restricted, e.g., through [systemd](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#System%20Call%20Filtering).
+* **Memory restrictions**: Limit the server's memory footprint using OS-level `cgroups` or similar mechanisms.
+
+### Limiting Host USB Kernel Drivers
+
+The core USB subsystem drivers must be available in the host, in order to
+support user-space processes as the `vfio-user` server to claim and work
+with the device. This is a tradeoff with full controller pass-through, which
+can omit the whole USB support. No specific USB subsystem drivers (storage,
+network, etc.) are required, though, and can be omitted in the host. This
+avoids the risk of bugs in kernel drivers attaching to malicious devices.
+The Guest VM is responsible for the device support, and must ensure its own
+hardening against such devices.
+
+### Authorizing USB Devices
+
+Unknown USB devices should be ignored by the host until explicitly authorized.
+The Linux kernel can be configured to reject all USB devices by default through
+a command line parameter:
+
+```
+usbcore.authorized_default=0
+```
+
+This kernel parameter prevents any USB device from being automatically
+attached, ensuring that only explicitly authorized devices
+can be used. Devices must then be explicitly enabled through
+the `usbcore.authorized` sysfs interface. See the [Kernel USB
+documentation](https://docs.kernel.org/usb/authorization.html) for details.


### PR DESCRIPTION
This is a starting point for our user documentation. Now that there is a `0.1.0` tag, we should not claim "this project is not yet usable" anymore.

* Move goalpost in README.
* Add basic user documentation to obtain and run the software.
* Add security considerations and threat model description.

It is lacking more complete descriptions of service setup and system integration, but these can come later.