### PR TITLE
Add nusb feature for async with tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "once_cell",
  "rustix",
  "slab",
+ "tokio",
  "windows-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "4.5.35", features = [
   "usage",
 ], default-features = false }
 memmap2 = "0.9.5"
-nusb = { version = "0.2.0", default-features = false }
+nusb = { version = "0.2.0", default-features = false, features = ["tokio"] }
 thiserror = { version = "2.0.12" }
 tokio = { version = "1.48.0", features = ["full"] }
 tokio-util = "0.7.17"


### PR DESCRIPTION
While testing with Windows, a runtime error about a blocking syscall appeared with a note for adding nusb's tokio features. Since doing so the error did not reappear.