### PR TITLE
Upgrade USBCMD register from bool to u32

### DIFF
--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -339,6 +339,19 @@ pub mod xhci {
             pub const INTE: u64 = 0x4;
         }
 
+        /// See xhci specification chapter 5.4.2
+        pub mod usbsts {
+            pub const HCH: u64 = 0x1;
+            pub const HSE: u64 = 0x4;
+            pub const EINT: u64 = 0x8;
+            pub const PCD: u64 = 0x10;
+            pub const SSS: u64 = 0x100;
+            pub const RSS: u64 = 0x200;
+            pub const SRE: u64 = 0x400;
+            pub const CNR: u64 = 0x800;
+            pub const HCE: u64 = 0x1000;
+        }
+
         /// See xhci specification chapter 5.4.8
         ///
         /// Bitmask of the specific field in the portsc register.
@@ -373,18 +386,6 @@ pub mod xhci {
                 pub const PLS_RXDETECT: u64 = 0xa0;
                 pub const PLS_POLLING: u64 = 0xe0;
             }
-        }
-
-        pub mod usbsts {
-            pub const HCH: u64 = 0x1;
-            pub const HSE: u64 = 0x4;
-            pub const EINT: u64 = 0x8;
-            pub const PCD: u64 = 0x10;
-            pub const SSS: u64 = 0x100;
-            pub const RSS: u64 = 0x200;
-            pub const SRE: u64 = 0x400;
-            pub const CNR: u64 = 0x800;
-            pub const HCE: u64 = 0x1000;
         }
     }
 

--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -332,6 +332,13 @@ pub mod xhci {
             pub const CRR: u64 = 0x8;
         }
 
+        /// See xhci specification chapter 5.4.1
+        pub mod usbcmd {
+            pub const RS: u64 = 0x1;
+            pub const HCRST: u64 = 0x2;
+            pub const INTE: u64 = 0x4;
+        }
+
         /// See xhci specification chapter 5.4.8
         ///
         /// Bitmask of the specific field in the portsc register.

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -43,7 +43,7 @@ pub struct XhciController<CRD: CompleteRealDevice> {
 impl<CRD: CompleteRealDevice> XhciController<CRD> {
     pub fn new(dma_bus: BusDeviceRef, async_runtime: runtime::Handle) -> Self {
         let usbcmd = UsbcmdRegister::new();
-        let usbsts = UsbstsRegister::new(usbcmd.running_bit());
+        let usbsts = UsbstsRegister::new(usbcmd.value_reference());
         let interrupter = Interrupter::new(dma_bus.clone(), &async_runtime);
         let port_array = PortArray::new(interrupter.create_event_sender(), async_runtime.clone());
         let ep_launch_requester = EndpointLauncher::start(
@@ -58,7 +58,7 @@ impl<CRD: CompleteRealDevice> XhciController<CRD> {
             &async_runtime,
             interrupter.create_event_sender(),
             slot_manager.create_slot_worker_handle(),
-            usbcmd.running_bit(),
+            usbcmd.value_reference(),
         );
 
         Self {
@@ -202,7 +202,7 @@ impl<CRD: CompleteRealDevice> PciDevice for XhciController<CRD> {
             offset::SUPPORTED_PROTOCOLS_USB2_CONFIG_RESERVED => 0,
 
             // xHC Operational Registers
-            offset::USBCMD => 0,
+            offset::USBCMD => self.usbcmd.read(),
             offset::USBSTS => self.usbsts.read(),
             offset::DNCTL => 2,
             offset::CRCR => self.command_ring.status(),

--- a/src/device/xhci/command_ring.rs
+++ b/src/device/xhci/command_ring.rs
@@ -1,7 +1,7 @@
 //! Implements a XHCI command ring and a worker task that services the ring.
 
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicU32, Ordering},
     Arc,
 };
 
@@ -14,7 +14,7 @@ use tracing::{debug, info, trace, warn};
 
 use crate::device::{
     bus::BusDeviceRef,
-    pci::constants::xhci::operational::crcr,
+    pci::constants::xhci::operational::{crcr, usbcmd},
     xhci::{
         interrupter::EventSender,
         linked_ring::LinkedRing,
@@ -34,7 +34,7 @@ struct CommandWorker {
     state: WorkerState,
     receiver: mpsc::UnboundedReceiver<WorkerMessage>,
     commandring_running: Arc<AtomicBool>,
-    controller_running: Arc<AtomicBool>,
+    usbcmd: Arc<AtomicU32>,
     event_sender: EventSender,
     ring: LinkedRing,
     slot_handle: SlotWorkerHandle,
@@ -71,7 +71,7 @@ impl CommandRing {
         async_runtime: &runtime::Handle,
         event_sender: EventSender,
         slot_handle: SlotWorkerHandle,
-        controller_running: Arc<AtomicBool>,
+        usbcmd: Arc<AtomicU32>,
     ) -> Self {
         let (sender_to_worker, receiver) = mpsc::unbounded_channel();
         let running = Arc::new(AtomicBool::new(false));
@@ -81,7 +81,7 @@ impl CommandRing {
             state: WorkerState::Stopped,
             receiver,
             commandring_running: running.clone(),
-            controller_running,
+            usbcmd,
             event_sender,
             ring,
             slot_handle,
@@ -171,7 +171,9 @@ impl CommandWorker {
                         self.ring.set_dequeue_pointer(dp, cs);
                     }
                     WorkerMessage::Doorbell => {
-                        if self.controller_running.load(Ordering::Relaxed) {
+                        let controller_running =
+                            (self.usbcmd.load(Ordering::Relaxed) as u64 & usbcmd::RS) == usbcmd::RS;
+                        if controller_running {
                             self.commandring_running.store(true, Ordering::Relaxed);
                             self.state = WorkerState::LookingForNewCommand;
                         } else {
@@ -206,7 +208,9 @@ impl CommandWorker {
                             msg => warn!("Unexpected message: msg={msg:?}, state={:?}", self.state),
                         }
                     }
-                    if !self.controller_running.load(Ordering::Relaxed) {
+                    let controller_stopped =
+                        (self.usbcmd.load(Ordering::Relaxed) & usbcmd::RS as u32) == 0;
+                    if controller_stopped {
                         trace!("Detected controller is not running; moving command ring to stopped state");
                         self.state = WorkerState::Stopped;
                         continue;

--- a/src/device/xhci/registers.rs
+++ b/src/device/xhci/registers.rs
@@ -1,14 +1,14 @@
 use std::sync::{
-    atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+    atomic::{AtomicU32, AtomicU64, Ordering},
     Arc,
 };
 
 use tokio::sync::Notify;
-use tracing::trace;
+use tracing::{info, trace, warn};
 
 use crate::device::{
     pci::constants::xhci::{
-        operational::{portsc, usbsts},
+        operational::{portsc, usbcmd, usbsts},
         MAX_SLOTS,
     },
     xhci::{interrupter::EventSender, port::UsbVersion, trb::EventTrb},
@@ -179,43 +179,62 @@ impl DcbaapRegister {
     }
 }
 
+/// USB Command Register (chapter 5.4.1)
 #[derive(Debug)]
 pub struct UsbcmdRegister {
-    running: Arc<AtomicBool>,
+    value: Arc<AtomicU32>,
 }
 
 impl UsbcmdRegister {
     pub fn new() -> Self {
-        let running = Arc::new(AtomicBool::new(false));
-
-        Self { running }
+        Self {
+            value: Arc::new(AtomicU32::new(0)),
+        }
     }
 
+    pub fn read(&self) -> u64 {
+        self.value.load(std::sync::atomic::Ordering::Relaxed).into()
+    }
+
+    /// A simple write with a very limited list of allowed bits (RsvdP is also not written).
     pub fn write(&self, value: u64) {
-        self.running.store(value & 0x1 != 0, Ordering::Relaxed);
+        // Currently writable bits ...
+        const BITMASK_PRESERVED: u64 = usbcmd::RS | usbcmd::INTE;
+        // ... ignoring any other bits and printing a warning when attempted.
+        if value & usbcmd::HCRST == usbcmd::HCRST {
+            info!("Host Controller Reset attempted; no action");
+        }
+        if value & !(BITMASK_PRESERVED | usbcmd::HCRST) != 0 {
+            warn!(
+                "received at least one bit that is ignored for USBCMD: {}",
+                value & !BITMASK_PRESERVED
+            );
+        }
+
+        let value = value & BITMASK_PRESERVED;
+        // SAFETY: USBCMD is defined as 32 bit and the masks used above enforce it.
+        self.value
+            .store(value.try_into().unwrap(), Ordering::Relaxed);
     }
 
-    pub fn running_bit(&self) -> Arc<AtomicBool> {
-        self.running.clone()
+    pub fn value_reference(&self) -> Arc<AtomicU32> {
+        self.value.clone()
     }
 }
 
 #[derive(Debug)]
 pub struct UsbstsRegister {
-    running: Arc<AtomicBool>,
+    usbcmd: Arc<AtomicU32>,
 }
 
 impl UsbstsRegister {
-    pub const fn new(running: Arc<AtomicBool>) -> Self {
-        Self { running }
+    pub const fn new(usbcmd: Arc<AtomicU32>) -> Self {
+        Self { usbcmd }
     }
 
     pub fn read(&self) -> u64 {
-        let hch = if self.running.load(Ordering::Relaxed) {
-            0
-        } else {
-            usbsts::HCH
-        };
+        let is_running = (self.usbcmd.load(Ordering::Relaxed) as u64 & usbcmd::RS) == usbcmd::RS;
+        let hch = if is_running { 0 } else { usbsts::HCH };
         hch | usbsts::EINT | usbsts::PCD
     }
 }

--- a/src/device/xhci/registers.rs
+++ b/src/device/xhci/registers.rs
@@ -333,4 +333,26 @@ mod tests {
             "writing 1 to bit 17 should clear the bit."
         );
     }
+
+    #[test]
+    fn usbcmd_read_write() {
+        let reg = UsbcmdRegister::new();
+
+        reg.write(0x5);
+        assert_eq!(reg.read(), 0x5, "Writing to allowed bits should work.");
+
+        reg.write(0xd);
+        assert_eq!(
+            reg.read(),
+            0x5,
+            "Writing any bit besides the allowed ones should be ignored."
+        );
+
+        reg.write(0x1);
+        assert_eq!(
+            reg.read(),
+            0x1,
+            "Not writing to allowed and already set bit 2 should clear it."
+        );
+    }
 }


### PR DESCRIPTION
We previously never had to remember any values of USBCMD except the bit 0 with Run/Stop state. With windows as guest after an error occurs we did not properly provide the USBCMD state and the driver did not clean up as expected (instead assumed a stopped xHC and acted according to that).
This is, as of right now, likely only relevant for debugging, when something else already did not work and system software attempts some recovery.