### PR TITLE
Implement event data trb handling

### DIFF
--- a/src/device/pcap/mod.rs
+++ b/src/device/pcap/mod.rs
@@ -17,12 +17,7 @@ pub fn control_submission(base: EndpointPcapMeta, req: &UsbRequest) {
     } else {
         UsbDirection::DeviceToHost
     };
-    packet::log_control_submission(
-        base,
-        control_direction,
-        req,
-        req.data.as_deref().unwrap_or(&[]),
-    );
+    packet::log_control_submission(base, control_direction, req, &req.data);
 }
 
 pub fn control_completion_in(base: EndpointPcapMeta, urb_id: u64, data: &[u8]) {
@@ -52,7 +47,7 @@ pub fn control_in_error(
         UsbEventType::Error,
         meta::control_error_status(error),
         Some(packet::build_setup_bytes(req)),
-        req.data.as_deref().unwrap_or(&[]),
+        &req.data,
     );
 }
 
@@ -68,7 +63,7 @@ pub fn control_out_error(
         UsbEventType::Error,
         meta::control_error_status(error),
         Some(packet::build_setup_bytes(req)),
-        req.data.as_deref().unwrap_or(&[]),
+        &req.data,
     );
 }
 

--- a/src/device/pci/constants.rs
+++ b/src/device/pci/constants.rs
@@ -291,12 +291,13 @@ pub mod xhci {
 
     /// Constants for the capability register.
     pub mod capability {
+
         /// We only emulate version 1.0.0 of the XHCI spec for simplicity.
         pub const HCIVERSION: u64 = 0x100;
         pub const HCSPARAMS1: u64 =
             (super::MAX_PORTS << 24) | (super::MAX_INTRS << 8) | super::MAX_SLOTS;
         pub const HCSPARAMS2: u64 = super::MAX_ERST_SIZE_EXP << 4;
-        pub const HCCPARAMS1: u64 = super::offset::SUPPORTED_PROTOCOLS << 14;
+        pub const HCCPARAMS1: u64 = hccparams1::PAE | super::offset::SUPPORTED_PROTOCOLS << 14;
 
         pub const USB_STRING: u64 = 0x20425355;
 
@@ -319,6 +320,12 @@ pub mod xhci {
             pub const CAP_INFO: u64 = ID | (MAJOR << 24) | (MINOR << 16) | (NEXT << 8);
             pub const CONFIG: u64 =
                 (super::super::NUM_USB3_PORTS + 1) | (super::super::NUM_USB2_PORTS << 8);
+        }
+
+        // See xhci specification chapter 5.3.6
+        pub mod hccparams1 {
+            // Parse all Event Data TRB while advancing to the next TD after a Short Packet.
+            pub const PAE: u64 = 0x100;
         }
     }
 

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -1,14 +1,14 @@
 use std::{
+    cmp::min,
     fmt::Debug,
     future::Future,
     mem::{self},
-    ops::ControlFlow,
     pin::Pin,
 };
 
 use anyhow::anyhow;
 use replace_with::replace_with_or_abort;
-use tracing::{debug, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::device::{
     bus::BusDeviceRef,
@@ -22,8 +22,8 @@ use crate::device::{
             RealOutEndpointHandle,
         },
         trb::{
-            CompletionCode, EventDataTrb, EventTrb, NormalTrb, RawTrb, TransferTrb,
-            TransferTrbVariant,
+            CompletionCode, DataStageTrb, EventDataTrb, EventTrb, NormalTrb, RawTrb, SetupStageTrb,
+            StatusStageTrb, TransferTrb, TransferTrbVariant, TrbDmaInfo,
         },
         usbrequest::UsbRequest,
     },
@@ -79,16 +79,77 @@ impl BaseEndpointHandle for DummyEndpointHandle {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct ControlTransferState {
+    /// upcoming or current stage/TD of a control transfer to be handled
+    pub state: ControlTransferStage,
+    /// holding the UsbRequest and all associated data
+    pub data: ControlTransferData,
+}
+impl ControlTransferState {
+    const fn new(data: ControlTransferData) -> Self {
+        Self {
+            state: ControlTransferStage::ExpectSetupStageTrb,
+            data,
+        }
+    }
+}
+
+fn interrupt_on_completion(
+    address: u64,
+    completion_code: CompletionCode,
+    event_data: bool,
+    endpoint_id: u8,
+    slot_id: u8,
+    event_sender: &EventSender,
+) -> anyhow::Result<()> {
+    trace!("interrupt_on_completion triggered for address {}", address);
+    let event = EventTrb::new_transfer_event_trb(
+        address,
+        0,
+        completion_code,
+        event_data,
+        endpoint_id,
+        slot_id,
+    );
+
+    event_sender.send(event)?;
+    Ok(())
+}
+
+// Track how far we are with parsing the Control Transfer (chain of TRB).
+#[derive(Debug, PartialEq, Eq)]
+pub enum ControlTransferStage {
+    /// Nothing happened yet. Awaiting a Setup Stage Trb and dropping any other
+    /// Trb (they will not reach the hardware device).
+    ExpectSetupStageTrb,
+    /// Either collect data if a Data Stage Trb is received or skip the Data
+    /// Stage TD altogether if a Status Stage Trb is received.
+    MaybeDataStageTrb,
+    MoreData,
+    /// Finished processing the Data Stage if there was one.
+    ExpectStatusStageTrb,
+}
+/// The state machine provides the information partially as ControlSubmissionState::AwaitingControlIn(TransferTrb).
+/// Track state between us and the guest for building the current control request.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ControlTransferData {
+    In(UsbRequest),
+    Out(UsbRequest),
+}
+
 #[derive(Debug)]
 pub struct ControlEndpointHandle<RCEH: RealControlEndpointHandle> {
     slot_id: u8,
     endpoint_id: u8,
     pcap_meta: EndpointPcapMeta,
     real_ep: RCEH,
-    trb_parser: ControlRequestParser,
     dma_bus: BusDeviceRef,
     event_sender: EventSender,
+    /// referring to usbvfiod to hardware communication
     submission_state: ControlSubmissionState,
+    /// referring to usbvfiod to guest communication
+    transfer_state: ControlTransferState,
 }
 
 impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
@@ -105,24 +166,303 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
             endpoint_id,
             pcap_meta,
             real_ep,
-            trb_parser: ControlRequestParser::new(dma_bus.clone()),
             dma_bus,
             event_sender,
             submission_state: ControlSubmissionState::NoTrbSubmitted,
+            transfer_state: ControlTransferState::new(ControlTransferData::In(
+                UsbRequest::default(),
+            )),
+        }
+    }
+
+    fn handle_setup_stage_trb(&mut self, address: u64, trb: SetupStageTrb) -> anyhow::Result<()> {
+        let usb_request = UsbRequest {
+            address,
+            request_type: trb.request_type,
+            request: trb.request,
+            value: trb.value,
+            index: trb.index,
+            length: trb.length,
+            data_pointer: None,
+            data: vec![],
+        };
+
+        if trb.request_type & 0x80 != 0 {
+            trace!("SetupStage TRB with ControlIn");
+
+            self.transfer_state =
+                ControlTransferState::new(ControlTransferData::In(usb_request.clone()));
+
+            self.real_ep.submit_control_request(usb_request.clone())?;
+            pcap::control_submission(self.pcap_meta, &usb_request);
+
+            self.submission_state = ControlSubmissionState::AwaitingControlIn(
+                address,
+                TransferTrbVariant::SetupStage(trb),
+            );
+        } else {
+            trace!("SetupStage TRB with ControlOut");
+
+            self.transfer_state = ControlTransferState::new(ControlTransferData::Out(usb_request));
+
+            // actual hardware request happens in status stage after consuming the data stage td
+
+            if trb.interrupt_on_completion {
+                interrupt_on_completion(
+                    address,
+                    CompletionCode::Success,
+                    false,
+                    self.endpoint_id,
+                    self.slot_id,
+                    &self.event_sender,
+                )?;
+            }
+
+            self.transfer_state.state = ControlTransferStage::MaybeDataStageTrb;
+            self.submission_state = ControlSubmissionState::ParserConsumedTrb(
+                address,
+                TransferTrbVariant::SetupStage(trb),
+            );
+        }
+
+        Ok(())
+    }
+
+    fn handle_setup_stage_hardware_response(
+        &mut self,
+        address: u64,
+        trb: SetupStageTrb,
+        hardware_data: &mut Vec<u8>,
+    ) -> anyhow::Result<()> {
+        match &mut self.transfer_state.data {
+            // collect hardware data
+            ControlTransferData::In(request) => {
+                trace!("control in data {:?}", hardware_data);
+
+                pcap::control_completion_in(self.pcap_meta, request.address, hardware_data);
+
+                request.data.append(hardware_data);
+
+                request.data.resize(trb.length as usize, 0);
+
+                if trb.interrupt_on_completion {
+                    interrupt_on_completion(
+                        address,
+                        CompletionCode::Success,
+                        false,
+                        self.endpoint_id,
+                        self.slot_id,
+                        &self.event_sender,
+                    )?;
+                }
+
+                self.transfer_state.state = ControlTransferStage::MaybeDataStageTrb;
+            }
+            ControlTransferData::Out(_) => {
+                unreachable!("internal error: ControlOut SetupTrb have insufficient information to do the Hardware request; a submission state to arrive here should never be used");
+            }
+        }
+        Ok(())
+    }
+
+    fn transfer_data_slices<T: TrbDmaInfo>(&mut self, address: u64, trb: &T) {
+        let data_pointer = trb.data_pointer();
+        let immediate_data = trb.has_immediate_data();
+
+        let transfer_length = if immediate_data {
+            min(8, trb.transfer_length())
+        } else {
+            trb.transfer_length()
+        };
+
+        match &mut self.transfer_state.data {
+            ControlTransferData::In(usb_request) => {
+                trace!("DMA for ControlIn");
+
+                // From xhci specification chapter 4.11.2.2:
+                //
+                // System software is responsible for ensuring that the total data length defined by a
+                // Data Stage TD (i.e. the sum of the Length fields of the Data Stage TRB and all Normal
+                // TRBs) is equal to wLength. Note that communicating with some non-compliant
+                // devices may require violating this rule.
+                if usb_request.data.len() < transfer_length as usize {
+                    self.transfer_state.state = ControlTransferStage::ExpectStatusStageTrb;
+                    self.submission_state = ControlSubmissionState::ParserError(address);
+                    return;
+                }
+
+                let byte_slice: Vec<u8> = usb_request
+                    .data
+                    .drain(0..transfer_length as usize)
+                    .collect();
+
+                trace!(
+                    "DataStage TRB len: {} slice: {:?}",
+                    byte_slice.len(),
+                    byte_slice
+                );
+                self.dma_bus.write_bulk(data_pointer, &byte_slice);
+            }
+            ControlTransferData::Out(usb_request) => {
+                trace!("DMA for ControlOut");
+
+                if immediate_data {
+                    // Only event data should follow when immediate data is used here
+                    // but we do not check for that and allow multiple immediate data
+                    // TRB in the data stage TD.
+
+                    usb_request.data.append(
+                        &mut data_pointer.to_le_bytes()[..transfer_length as usize].to_vec(),
+                    );
+                } else {
+                    let mut tmp = vec![0u8; transfer_length as usize];
+                    self.dma_bus.read_bulk(data_pointer, &mut tmp);
+
+                    usb_request.data.append(&mut tmp);
+                }
+            }
+        }
+    }
+
+    fn handle_data_stage_trb(&mut self, address: u64, trb: DataStageTrb) -> anyhow::Result<()> {
+        trace!("DataStage TRB");
+
+        self.transfer_data_slices(address, &trb);
+
+        if trb.interrupt_on_completion {
+            interrupt_on_completion(
+                address,
+                CompletionCode::Success,
+                false,
+                self.endpoint_id,
+                self.slot_id,
+                &self.event_sender,
+            )?;
+        }
+
+        if trb.chain {
+            self.transfer_state.state = ControlTransferStage::MoreData;
+        } else {
+            self.transfer_state.state = ControlTransferStage::ExpectStatusStageTrb;
+        }
+
+        self.submission_state =
+            ControlSubmissionState::ParserConsumedTrb(address, TransferTrbVariant::DataStage(trb));
+        Ok(())
+    }
+
+    fn handle_normal_trb(&mut self, address: u64, trb: NormalTrb) -> anyhow::Result<()> {
+        trace!("Normal TRB");
+
+        self.transfer_data_slices(address, &trb);
+
+        if trb.interrupt_on_completion {
+            interrupt_on_completion(
+                address,
+                CompletionCode::Success,
+                false,
+                self.endpoint_id,
+                self.slot_id,
+                &self.event_sender,
+            )?;
+        }
+
+        if !trb.chain {
+            self.transfer_state.state = ControlTransferStage::ExpectStatusStageTrb;
+        }
+
+        self.submission_state =
+            ControlSubmissionState::ParserConsumedTrb(address, TransferTrbVariant::Normal(trb));
+        Ok(())
+    }
+
+    fn handle_status_stage_trb(&mut self, address: u64, trb: StatusStageTrb) -> anyhow::Result<()> {
+        match &mut self.transfer_state.data {
+            ControlTransferData::In(_) => {
+                trace!("StatusStage TRB with ControlIn");
+
+                if trb.interrupt_on_completion {
+                    interrupt_on_completion(
+                        address,
+                        CompletionCode::Success,
+                        false,
+                        self.endpoint_id,
+                        self.slot_id,
+                        &self.event_sender,
+                    )?;
+                }
+
+                if !trb.chain {
+                    self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
+                }
+                self.submission_state = ControlSubmissionState::ParserConsumedTrb(
+                    address,
+                    TransferTrbVariant::StatusStage(trb),
+                );
+            }
+            ControlTransferData::Out(usb_request_out) => {
+                trace!("StatusStage TRB with ControlOut");
+
+                self.real_ep
+                    .submit_control_request(usb_request_out.clone())?;
+                pcap::control_submission(self.pcap_meta, usb_request_out);
+
+                self.submission_state = ControlSubmissionState::AwaitingControlOut(
+                    address,
+                    TransferTrbVariant::StatusStage(trb),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_status_stage_hardware_response(
+        &mut self,
+        address: u64,
+        trb: StatusStageTrb,
+    ) -> anyhow::Result<()> {
+        match &mut self.transfer_state.data {
+            ControlTransferData::In(_) => {
+                unreachable!("internal error: ControlIn requests do the Hardware request in the SetupStage; a submission state to arrive here should never be used");
+            }
+            ControlTransferData::Out(usb_request) => {
+                trace!("StatusStage TRB with ControlOut");
+
+                pcap::control_completion_out(
+                    self.pcap_meta,
+                    usb_request.address,
+                    u32::from(usb_request.length),
+                );
+
+                if !trb.chain {
+                    self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
+                }
+
+                if trb.interrupt_on_completion {
+                    interrupt_on_completion(
+                        address,
+                        CompletionCode::Success,
+                        false,
+                        self.endpoint_id,
+                        self.slot_id,
+                        &self.event_sender,
+                    )?;
+                }
+                Ok(())
+            }
         }
     }
 }
 
-#[derive(Debug, Default)]
+/// Track communication between us and the host hardware.
+#[derive(Debug, Default, Clone)]
 enum ControlSubmissionState {
     #[default]
     NoTrbSubmitted,
-    ParserConsumedTrb,
-    // store address of trb that failed to parse.
-    // needs to be specified inside the transfer event indicating the error.
+    ParserConsumedTrb(u64, TransferTrbVariant),
     ParserError(u64),
-    AwaitingControlIn(UsbRequest),
-    AwaitingControlOut(UsbRequest),
+    AwaitingControlIn(u64, TransferTrbVariant),
+    AwaitingControlOut(u64, TransferTrbVariant),
 }
 
 impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<RCEH> {
@@ -130,28 +470,91 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
         Pin<Box<dyn Future<Output = anyhow::Result<TrbProcessingResult>> + Send + 'a>>;
 
     fn submit_trb(&mut self, trb: RawTrb) -> anyhow::Result<()> {
-        let trb_address = trb.address;
-        if let ControlFlow::Break(res) = self.trb_parser.trb(trb) {
-            match res {
-                Ok(request) => {
-                    let request_copy = request.clone_without_data();
-                    let is_out_request = request.request_type & 0x80 == 0;
+        let variant = TransferTrbVariant::parse(trb.buffer);
 
-                    pcap::control_submission(self.pcap_meta, &request);
+        if let TransferTrbVariant::Unrecognized(_, _) = &variant {
+            // logging this is happening in next_completion()
+            self.submission_state = ControlSubmissionState::ParserError(trb.address);
+        }
 
-                    self.real_ep.submit_control_request(request)?;
-
-                    self.submission_state = match is_out_request {
-                        true => ControlSubmissionState::AwaitingControlOut(request_copy),
-                        false => ControlSubmissionState::AwaitingControlIn(request_copy),
-                    };
+        match &self.transfer_state.state {
+            ControlTransferStage::ExpectSetupStageTrb => match variant {
+                TransferTrbVariant::SetupStage(setup_stage) => {
+                    self.handle_setup_stage_trb(trb.address, setup_stage)?;
                 }
-                Err(_) => {
-                    self.submission_state = ControlSubmissionState::ParserError(trb_address);
+                other_trb => {
+                    info!(
+                        "invalid control transfer sequence; expected Setup Stage Trb, got: {:?}",
+                        other_trb
+                    );
+                    self.submission_state =
+                        ControlSubmissionState::ParserConsumedTrb(trb.address, other_trb);
                 }
-            }
-        } else {
-            self.submission_state = ControlSubmissionState::ParserConsumedTrb;
+            },
+            ControlTransferStage::MaybeDataStageTrb => match variant {
+                TransferTrbVariant::SetupStage(setup_stage) => {
+                    info!(
+                        "received Setup Stage TRB abort ongoing control transfer in favour of this new one"
+                    );
+                    self.handle_setup_stage_trb(trb.address, setup_stage)?;
+                }
+                TransferTrbVariant::DataStage(data_stage) => {
+                    self.handle_data_stage_trb(trb.address, data_stage)?;
+                }
+                TransferTrbVariant::StatusStage(status_stage) => {
+                    self.handle_status_stage_trb(trb.address, status_stage)?;
+                }
+                other_trb => {
+                    info!(
+                        "invalid control transfer sequence; expected Setup, Data or Status Stage Trb, got: {:?}",
+                        other_trb
+                    );
+                    self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
+                    self.submission_state =
+                        ControlSubmissionState::ParserConsumedTrb(trb.address, other_trb);
+                }
+            },
+            ControlTransferStage::MoreData => match variant {
+                TransferTrbVariant::SetupStage(setup_stage) => {
+                    info!(
+                        "received Setup Stage TRB abort ongoing control transfer in favour of this new one"
+                    );
+                    self.handle_setup_stage_trb(trb.address, setup_stage)?;
+                }
+                TransferTrbVariant::Normal(normal) => {
+                    self.handle_normal_trb(trb.address, normal)?;
+                }
+                other_trb => {
+                    info!(
+                        "invalid control transfer sequence; expected Setup Stage, Normal or Event Data Trb, got: {:?}",
+                        other_trb
+                    );
+                    self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
+                    self.submission_state =
+                        ControlSubmissionState::ParserConsumedTrb(trb.address, other_trb);
+                }
+            },
+
+            ControlTransferStage::ExpectStatusStageTrb => match variant {
+                TransferTrbVariant::SetupStage(setup_stage) => {
+                    info!(
+                        "received Setup Stage TRB abort ongoing control transfer in favour of this new one"
+                    );
+                    self.handle_setup_stage_trb(trb.address, setup_stage)?;
+                }
+                TransferTrbVariant::StatusStage(status_stage) => {
+                    self.handle_status_stage_trb(trb.address, status_stage)?;
+                }
+                other_trb => {
+                    info!(
+                        "invalid control transfer sequence; expected Setup or Status Stage Trb, got: {:?}",
+                        other_trb
+                    );
+                    self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
+                    self.submission_state =
+                        ControlSubmissionState::ParserConsumedTrb(trb.address, other_trb);
+                }
+            },
         }
 
         Ok(())
@@ -159,12 +562,19 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
 
     fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_> {
         Box::pin(async {
-            let result = match self.submission_state {
-                ControlSubmissionState::ParserConsumedTrb => TrbProcessingResult::Ok,
-                ControlSubmissionState::ParserError(trb_address) => {
-                    pcap::trb_error(self.pcap_meta, trb_address);
+            let result = match self.submission_state.clone() {
+                ControlSubmissionState::ParserConsumedTrb(address, variant) => {
+                    trace!("consumed trb from address: {} as: {:?}", address, variant);
+                    TrbProcessingResult::Ok
+                }
+                ControlSubmissionState::ParserError(address) => {
+                    info!(
+                        "Failed to parse Transfer Trb on Control Endpoint. slot {}",
+                        self.slot_id
+                    );
+                    pcap::trb_error(self.pcap_meta, address);
                     let event = EventTrb::new_transfer_event_trb(
-                        trb_address,
+                        address,
                         0,
                         CompletionCode::TrbError,
                         false,
@@ -174,67 +584,57 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                     self.event_sender.send(event)?;
                     TrbProcessingResult::TrbError
                 }
-                ControlSubmissionState::AwaitingControlIn(ref usb_request) => {
+                ControlSubmissionState::AwaitingControlIn(address, variant) => {
                     let processing_result = self.real_ep.next_completion().await?;
                     match processing_result {
-                        ControlRequestProcessingResult::SuccessfulControlIn(data) => {
-                            debug!("got data from control in: {data:?}");
-                            pcap::control_completion_in(self.pcap_meta, usb_request.address, &data);
-                            if let Some(data_pointer) = usb_request.data_pointer {
-                                debug!("writing data to {data_pointer}");
-                                self.dma_bus.write_bulk(data_pointer, &data);
-                            }
-
-                            let event = EventTrb::new_transfer_event_trb(
-                                usb_request.address,
-                                0,
-                                CompletionCode::Success,
-                                false,
-                                self.endpoint_id,
-                                self.slot_id,
-                            );
-                            self.event_sender.send(event)?;
-
+                        ControlRequestProcessingResult::SuccessfulControlIn(mut data) => {
+                            let trb = match variant {
+                                TransferTrbVariant::SetupStage(setup_stage) => setup_stage,
+                                _ => unreachable!("internal error: never set this ControlSubmissionState besides with a SetupStage."),
+                            };
+                            self.handle_setup_stage_hardware_response(address, trb, &mut data)?;
                             TrbProcessingResult::Ok
                         }
-                        ControlRequestProcessingResult::SuccessfulControlOut => unreachable!(),
+                        ControlRequestProcessingResult::SuccessfulControlOut => unreachable!(
+                            "internal error: never set AwaitingControlIn and received a SuccessfulControlOut."
+                        ),
                         processing_error => {
+                            let usb_request = match &self.transfer_state.data {
+                                ControlTransferData::In(usb_request) => usb_request,
+                                _ => unreachable!("internal error: never set AwaitingControlIn without a UsbRequest containing a ControlIn"),
+                            };
                             pcap::control_in_error(self.pcap_meta, usb_request, &processing_error);
-                            self.handle_processing_error(processing_error, usb_request.address)?
+                            self.handle_processing_error(processing_error, address)?
                         }
                     }
                 }
-                ControlSubmissionState::AwaitingControlOut(ref usb_request) => {
+                ControlSubmissionState::AwaitingControlOut(address, variant) => {
                     let processing_result = self.real_ep.next_completion().await?;
                     match processing_result {
                         ControlRequestProcessingResult::SuccessfulControlIn(_) => {
-                            unreachable!()
+                            unreachable!("internal error: never set AwaitingControlOut and receive a SuccessfulControlIn.")
                         }
                         ControlRequestProcessingResult::SuccessfulControlOut => {
-                            pcap::control_completion_out(
-                                self.pcap_meta,
-                                usb_request.address,
-                                u32::from(usb_request.length),
-                            );
-                            let event = EventTrb::new_transfer_event_trb(
-                                usb_request.address,
-                                0,
-                                CompletionCode::Success,
-                                false,
-                                self.endpoint_id,
-                                self.slot_id,
-                            );
-                            self.event_sender.send(event)?;
-
+                            let trb = match variant {
+                                TransferTrbVariant::StatusStage(status_stage) => status_stage,
+                                _ => unreachable!("internal error: never set this ControlSubmissionState besides with a StatusStage."),
+                            };
+                            self.handle_status_stage_hardware_response(address, trb)?;
                             TrbProcessingResult::Ok
                         }
                         processing_error => {
+                            let usb_request = match &self.transfer_state.data {
+                                ControlTransferData::Out(usb_request) => usb_request,
+                                _ => unreachable!("internal error: never set AwaitingControlOut without a UsbRequest containing a ControlOut"),
+                            };
                             pcap::control_out_error(self.pcap_meta, usb_request, &processing_error);
-                            self.handle_processing_error(processing_error, usb_request.address)?
+                            self.handle_processing_error(processing_error, address)?
                         }
                     }
                 }
-                ControlSubmissionState::NoTrbSubmitted => unreachable!(),
+                ControlSubmissionState::NoTrbSubmitted => {
+                    unreachable!("internal error: Always set a different ControlSubmissionState in submit_trb().")
+                }
             };
             self.submission_state = ControlSubmissionState::NoTrbSubmitted;
 
@@ -301,103 +701,17 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
                 TrbProcessingResult::TransactionError(None)
             }
             ControlRequestProcessingResult::SuccessfulControlIn(_) => {
-                panic!("SuccessfulControlIn should be handled elsewhere")
+                unreachable!(
+                    "internal error: Don't try processing an error with a successful ControlRequestProcessingResult."
+                )
             }
             ControlRequestProcessingResult::SuccessfulControlOut => {
-                panic!("SuccessfulControlOut should be handled elsewhere")
+                unreachable!(
+                    "internal error: Don't try processing an error with a successful ControlRequestProcessingResult."
+                )
             }
         };
         Ok(mapped)
-    }
-}
-
-#[derive(Debug)]
-struct ControlRequestParser {
-    state: ControlRequestParserState,
-    dma_bus: BusDeviceRef,
-    request_builder: UsbRequest,
-}
-
-impl ControlRequestParser {
-    fn new(dma_bus: BusDeviceRef) -> Self {
-        Self {
-            state: ControlRequestParserState::Initial,
-            dma_bus,
-            request_builder: Default::default(),
-        }
-    }
-}
-
-#[derive(Debug)]
-enum ControlRequestParserState {
-    Initial,
-    SetupStageConsumed,
-    DataStageConsumed,
-}
-
-impl ControlRequestParser {
-    fn trb(&mut self, trb: RawTrb) -> ControlFlow<Result<UsbRequest, ()>> {
-        let transfer_trb = TransferTrbVariant::parse(trb.buffer);
-
-        loop {
-            match &self.state {
-                ControlRequestParserState::Initial => match transfer_trb {
-                    TransferTrbVariant::SetupStage(setup_trb_data) => {
-                        let request = UsbRequest {
-                            address: 0,
-                            request_type: setup_trb_data.request_type,
-                            request: setup_trb_data.request,
-                            value: setup_trb_data.value,
-                            index: setup_trb_data.index,
-                            length: setup_trb_data.length,
-                            data_pointer: None,
-                            data: vec![],
-                        };
-                        self.request_builder = request;
-                        self.state = ControlRequestParserState::SetupStageConsumed;
-                        return ControlFlow::Continue(());
-                    }
-                    _ => return ControlFlow::Break(Err(())),
-                },
-                ControlRequestParserState::SetupStageConsumed => match transfer_trb {
-                    TransferTrbVariant::DataStage(data_trb_data) => {
-                        let data = if data_trb_data.immediate_data {
-                            if self.request_builder.length > 8 {
-                                todo!("using IDT with length > 8");
-                            }
-                            data_trb_data.data_pointer.to_le_bytes()
-                                [..self.request_builder.length as usize]
-                                .to_vec()
-                        } else {
-                            let mut data = vec![0; self.request_builder.length as usize];
-                            self.dma_bus
-                                .read_bulk(data_trb_data.data_pointer, &mut data);
-                            data
-                        };
-
-                        self.request_builder.data = data;
-                        self.request_builder.data_pointer = Some(data_trb_data.data_pointer);
-                        self.state = ControlRequestParserState::DataStageConsumed;
-                        return ControlFlow::Continue(());
-                    }
-                    TransferTrbVariant::StatusStage(_) => {
-                        self.state = ControlRequestParserState::DataStageConsumed;
-                        continue;
-                    }
-                    _ => return ControlFlow::Break(Err(())),
-                },
-                ControlRequestParserState::DataStageConsumed => match transfer_trb {
-                    TransferTrbVariant::StatusStage(_) => {
-                        self.request_builder.address = trb.address;
-                        let request = mem::take(&mut self.request_builder);
-                        self.request_builder = UsbRequest::default();
-                        self.state = ControlRequestParserState::Initial;
-                        return ControlFlow::Break(Ok(request));
-                    }
-                    _ => return ControlFlow::Break(Err(())),
-                },
-            }
-        }
     }
 }
 

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -22,7 +22,7 @@ use crate::device::{
             RealOutEndpointHandle,
         },
         trb::{
-            CompletionCode, EventDataTrbData, EventTrb, NormalTrbData, RawTrb, TransferTrb,
+            CompletionCode, EventDataTrb, EventTrb, NormalTrb, RawTrb, TransferTrb,
             TransferTrbVariant,
         },
         usbrequest::UsbRequest,
@@ -609,8 +609,8 @@ struct SupportedInEndpointTrb {
 
 #[derive(Debug)]
 enum SupportedInEndpointTrbVariant {
-    Normal(NormalTrbData),
-    EventData(EventDataTrbData),
+    Normal(NormalTrb),
+    EventData(EventDataTrb),
 }
 
 impl TryFrom<TransferTrbVariant> for SupportedInEndpointTrbVariant {
@@ -848,7 +848,7 @@ impl<'a> TdProcessingInfo<'a> {
         &mut self,
         addr: u64,
         cs: bool,
-        trb_data: NormalTrbData,
+        trb_data: NormalTrb,
     ) -> anyhow::Result<Option<TrbProcessingResult>> {
         match self.state {
             TdProcessingState::Default => {

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::anyhow;
 use replace_with::replace_with_or_abort;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::device::{
     bus::BusDeviceRef,
@@ -28,6 +28,8 @@ use crate::device::{
         usbrequest::UsbRequest,
     },
 };
+
+pub const MAX_VALUE_U24: u32 = 0xff_ffff;
 
 pub trait EndpointHandle: BaseEndpointHandle {
     type TrbCompletionFuture<'a>: Future<Output = anyhow::Result<TrbProcessingResult>> + Send + 'a;
@@ -79,18 +81,48 @@ impl BaseEndpointHandle for DummyEndpointHandle {
     }
 }
 
+/// Values we will need to handle an incoming Event Data Trb.
+///
+/// When an Event Data is encountered two additional things are needed:
+/// - the EDTLA
+/// - the completion code of the previously handled TRB
+#[derive(Debug, PartialEq, Eq)]
+struct EventDataTrbMetadata {
+    /// a 24 Bit sized counter to track already transmitted bytes of the current TD
+    edtla: u32,
+    previous_completion_code: CompletionCode,
+}
+impl EventDataTrbMetadata {
+    const fn default() -> Self {
+        Self {
+            edtla: 0,
+            previous_completion_code: CompletionCode::Success,
+        }
+    }
+
+    const fn zero(&mut self) {
+        self.edtla = 0;
+    }
+    /// input is 17 Bit
+    const fn add(&mut self, byte_count: u32) {
+        self.edtla = MAX_VALUE_U24 & (self.edtla.wrapping_add(byte_count));
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct ControlTransferState {
     /// upcoming or current stage/TD of a control transfer to be handled
     pub state: ControlTransferStage,
     /// holding the UsbRequest and all associated data
     pub data: ControlTransferData,
+    event_meta: EventDataTrbMetadata,
 }
 impl ControlTransferState {
     const fn new(data: ControlTransferData) -> Self {
         Self {
             state: ControlTransferStage::ExpectSetupStageTrb,
             data,
+            event_meta: EventDataTrbMetadata::default(),
         }
     }
 }
@@ -129,7 +161,11 @@ pub enum ControlTransferStage {
     MoreData,
     /// Finished processing the Data Stage if there was one.
     ExpectStatusStageTrb,
+    /// Status Stage TRB had a chain bit and there will be exactly one
+    /// Event Data Trb to finish the Control Transfer.
+    ExpectFinalEventDataTrb,
 }
+
 /// The state machine provides the information partially as ControlSubmissionState::AwaitingControlIn(TransferTrb).
 /// Track state between us and the guest for building the current control request.
 #[derive(Debug, PartialEq, Eq)]
@@ -245,6 +281,8 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
 
                 request.data.resize(trb.length as usize, 0);
 
+                self.transfer_state.event_meta.previous_completion_code = CompletionCode::Success;
+
                 if trb.interrupt_on_completion {
                     interrupt_on_completion(
                         address,
@@ -287,9 +325,14 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
                 // devices may require violating this rule.
                 if usb_request.data.len() < transfer_length as usize {
                     self.transfer_state.state = ControlTransferStage::ExpectStatusStageTrb;
+                    self.transfer_state.event_meta.zero();
                     self.submission_state = ControlSubmissionState::ParserError(address);
                     return;
                 }
+
+                // All transfers are done but to have the expected value in the
+                // created Events we keep count of pretend transfers.
+                self.transfer_state.event_meta.add(transfer_length);
 
                 let byte_slice: Vec<u8> = usb_request
                     .data
@@ -339,6 +382,8 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
                 &self.event_sender,
             )?;
         }
+
+        self.transfer_state.event_meta.previous_completion_code = CompletionCode::Success;
 
         if trb.chain {
             self.transfer_state.state = ControlTransferStage::MoreData;
@@ -392,9 +437,13 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
                     )?;
                 }
 
-                if !trb.chain {
+                if trb.chain {
+                    self.transfer_state.state = ControlTransferStage::ExpectFinalEventDataTrb;
+                } else {
                     self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
+                    self.transfer_state.event_meta.zero();
                 }
+
                 self.submission_state = ControlSubmissionState::ParserConsumedTrb(
                     address,
                     TransferTrbVariant::StatusStage(trb),
@@ -434,8 +483,11 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
                     u32::from(usb_request.length),
                 );
 
-                if !trb.chain {
+                if trb.chain {
+                    self.transfer_state.state = ControlTransferStage::ExpectFinalEventDataTrb;
+                } else {
                     self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
+                    self.transfer_state.event_meta.zero();
                 }
 
                 if trb.interrupt_on_completion {
@@ -451,6 +503,46 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
                 Ok(())
             }
         }
+    }
+
+    fn handle_event_data_trb(&mut self, address: u64, trb: EventDataTrb) -> anyhow::Result<()> {
+        trace!("EventData TRB");
+
+        if trb.interrupt_on_completion {
+            let event = EventTrb::new_transfer_event_trb(
+                trb.event_data,
+                self.transfer_state.event_meta.edtla,
+                self.transfer_state.event_meta.previous_completion_code,
+                true,
+                self.endpoint_id,
+                self.slot_id,
+            );
+
+            self.event_sender.send(event)?;
+            self.transfer_state.event_meta.zero();
+        }
+
+        if !trb.chain {
+            match self.transfer_state.state {
+                ControlTransferStage::MoreData => {
+                    self.transfer_state.state = ControlTransferStage::ExpectStatusStageTrb;
+                    self.transfer_state.event_meta.zero();
+                }
+                ControlTransferStage::ExpectFinalEventDataTrb => {
+                    self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
+                    self.transfer_state.event_meta.zero();
+                }
+                _ => {
+                    error!("driver did not provide a spec compliant control transfer trb chain");
+                    self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
+                    self.transfer_state.event_meta.zero();
+                }
+            }
+        }
+
+        self.submission_state =
+            ControlSubmissionState::ParserConsumedTrb(address, TransferTrbVariant::EventData(trb));
+        Ok(())
     }
 }
 
@@ -524,6 +616,9 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                 TransferTrbVariant::Normal(normal) => {
                     self.handle_normal_trb(trb.address, normal)?;
                 }
+                TransferTrbVariant::EventData(event_data) => {
+                    self.handle_event_data_trb(trb.address, event_data)?;
+                }
                 other_trb => {
                     info!(
                         "invalid control transfer sequence; expected Setup Stage, Normal or Event Data Trb, got: {:?}",
@@ -548,6 +643,26 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                 other_trb => {
                     info!(
                         "invalid control transfer sequence; expected Setup or Status Stage Trb, got: {:?}",
+                        other_trb
+                    );
+                    self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
+                    self.submission_state =
+                        ControlSubmissionState::ParserConsumedTrb(trb.address, other_trb);
+                }
+            },
+            ControlTransferStage::ExpectFinalEventDataTrb => match variant {
+                TransferTrbVariant::SetupStage(setup_stage) => {
+                    info!(
+                        "received Setup Stage TRB abort ongoing control transfer in favour of this new one"
+                    );
+                    self.handle_setup_stage_trb(trb.address, setup_stage)?;
+                }
+                TransferTrbVariant::EventData(event_data) => {
+                    self.handle_event_data_trb(trb.address, event_data)?;
+                }
+                other_trb => {
+                    info!(
+                        "invalid control transfer sequence; expected Setup Stage or Event Data Trb, got: {:?}",
                         other_trb
                     );
                     self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -351,7 +351,7 @@ impl ControlRequestParser {
                             index: setup_trb_data.index,
                             length: setup_trb_data.length,
                             data_pointer: None,
-                            data: None,
+                            data: vec![],
                         };
                         self.request_builder = request;
                         self.state = ControlRequestParserState::SetupStageConsumed;
@@ -375,7 +375,7 @@ impl ControlRequestParser {
                             data
                         };
 
-                        self.request_builder.data = Some(data);
+                        self.request_builder.data = data;
                         self.request_builder.data_pointer = Some(data_trb_data.data_pointer);
                         self.state = ControlRequestParserState::DataStageConsumed;
                         return ControlFlow::Continue(());

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -149,7 +149,38 @@ fn interrupt_on_completion(
     Ok(())
 }
 
-// Track how far we are with parsing the Control Transfer (chain of TRB).
+/// Track how far we are with parsing the Control Transfer (chain of TRB).
+///
+/// ```mermaid
+/// graph TD;
+///
+///     expect_setup_stage_trb((expect_setup_stage_trb))
+///     maybe_data((maybe_data))
+///     more_data((more_data))
+///     expect_status_stage_trb((expect_status_stage_trb))
+///     expect_event_data_as_final_trb((expect_event_data_as_final_trb))
+///
+///     expect_setup_stage_trb--(received setup_stage_trb)-->maybe_data
+///     expect_setup_stage_trb--(any other trb)-->expect_setup_stage_trb
+///
+///     maybe_data--(received setup_stage_trb)-->maybe_data
+///     maybe_data--(status_stage, with chain)-->expect_event_data_as_final_trb
+///     maybe_data--(status_stage, no chain or any other trb)-->expect_setup_stage_trb
+///     maybe_data--(data_stage, no chain)-->expect_status_stage_trb
+///     maybe_data--(data_stage, with chain)-->more_data
+///
+///     more_data--(received setup_stage_trb)-->maybe_data
+///     more_data--(any other trb)-->expect_setup_stage_trb
+///     more_data--(normal or event_data, with chain)-->more_data
+///     more_data--(normal or event_data, no chain)-->expect_status_stage_trb
+///
+///     expect_status_stage_trb--(received setup_stage)-->maybe_data
+///     expect_status_stage_trb--(status_stage, with chain)-->expect_event_data_as_final_trb
+///     expect_status_stage_trb--(status_stage, no chain or any other trb)-->expect_setup_stage_trb
+///
+///     expect_event_data_as_final_trb--(received setup_stage)-->maybe_data
+///     expect_event_data_as_final_trb--(event_data, no chain or any other trb)-->expect_setup_stage_trb
+/// ```
 #[derive(Debug, PartialEq, Eq)]
 pub enum ControlTransferStage {
     /// Nothing happened yet. Awaiting a Setup Stage Trb and dropping any other

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -1573,7 +1573,7 @@ pub mod tests {
     use crate::device::xhci::endpoint_handle::tests::testutils::{
         MockRealControlEndpointExpectDataPattern, MockRealControlEndpointHardwareError,
         MockRealControlEndpointReadStatic, MockRealInEndpointHardwareError,
-        MockRealInEndpointReadStatic, MockRealOutEndpoint,
+        MockRealInEndpointReadStatic, MockRealOutEndpoint, MockRealOutEndpointHardwareError,
     };
     use crate::device::xhci::interrupter::tests::testutils::MockInterrupter;
     use crate::device::{bus::testutils::TestBusDevice, xhci::trb::testutils::RawTrbBuilder};
@@ -1892,6 +1892,55 @@ pub mod tests {
 
             fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
                 // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+        }
+
+        // mock for bulk out real endpoint consuming `vec![_; 512 + 64]` and then returning a given OutTrbProcessingResult
+        #[derive(Debug)]
+        pub struct MockRealOutEndpointHardwareError {
+            status: OutTrbProcessingResult,
+            byte_count: i32,
+        }
+
+        impl MockRealOutEndpointHardwareError {
+            pub fn new(status: OutTrbProcessingResult) -> Self {
+                Self {
+                    status,
+                    byte_count: 576,
+                }
+            }
+        }
+
+        impl RealOutEndpointHandle for MockRealOutEndpointHardwareError {
+            type TrbCompletionFuture<'a> =
+                Pin<Box<dyn Future<Output = anyhow::Result<OutTrbProcessingResult>> + Send + 'a>>;
+
+            fn submit(&mut self, data: Vec<u8>) -> anyhow::Result<()> {
+                let length: i32 = data.len().try_into().expect("too much data");
+                self.byte_count -= length;
+                Ok(())
+            }
+
+            fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_> {
+                let status = match self.byte_count {
+                    i if i <= 0 => self.status.clone(),
+                    i if i > 0 => OutTrbProcessingResult::Success,
+                    _ => unreachable!(),
+                };
+                Box::pin(async { Ok(status) })
+            }
+        }
+
+        impl BaseEndpointHandle for MockRealOutEndpointHardwareError {
+            type CompletionFuture<'a> =
+                Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+            fn cancel(&mut self) -> Self::CompletionFuture<'_> {
+                Box::pin(async { Ok(()) })
+            }
+
+            fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
                 Box::pin(async { Ok(()) })
             }
         }
@@ -2747,6 +2796,106 @@ pub mod tests {
         );
 
         // no event for the third normal Trb because we (in theory) have yet to touch it
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn normal_out_returns_hardware_stall() {
+        const SLOT_ID: u8 = 1;
+        const ENDPOINT_ID: u8 = 1;
+
+        let pcap_usb_bus_number = 1;
+        let pcap_meta = EndpointPcapMeta::bulk(pcap_usb_bus_number, SLOT_ID, ENDPOINT_ID);
+
+        let real_ep = MockRealOutEndpointHardwareError::new(OutTrbProcessingResult::Stall);
+
+        let dma_bus = Arc::new(DynamicBus::new());
+        let dma_backing = vec![99; 2048];
+        dma_bus
+            .add(0x0, Arc::new(TestBusDevice::new(&dma_backing[..])))
+            .expect("Adding Memory to the DynamicBus should never fail.");
+
+        let (event_sender, mut interrupter) = MockInterrupter::new();
+
+        let mut bulk_out_endpoint = OutEndpointHandle::new(
+            SLOT_ID,
+            ENDPOINT_ID,
+            pcap_meta,
+            real_ep,
+            dma_bus,
+            event_sender,
+        );
+
+        let normal_1 = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .with_trb_transfer_length(512)
+            .with_interrupt_on_completion()
+            .with_chain()
+            .build();
+        let normal_2 = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .with_trb_transfer_length(512)
+            .with_interrupt_on_completion()
+            .build();
+
+        bulk_out_endpoint
+            .submit_trb(normal_1)
+            .expect("this mock hardware request should never fail");
+
+        let completion = bulk_out_endpoint.next_completion().await.ok();
+
+        // stall information is only included for td aggregation
+        assert_eq!(completion, Some(TrbProcessingResult::Ok));
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                FIRST_ADDRESS,
+                0, // these bytes are fully consumed
+                CompletionCode::Success,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
+
+        assert!(interrupter.is_empty());
+
+        bulk_out_endpoint
+            .submit_trb(normal_2)
+            .expect("this mock hardware request should never fail");
+
+        let completion = bulk_out_endpoint.next_completion().await.ok();
+
+        assert_eq!(completion, Some(TrbProcessingResult::Stall(None)));
+
+        // In theory we can not know how much of the transfer concluded successfully
+        //
+        // xhci specification: Table 6-38: Offset 08h – Transfer Event TRB Field Definitions
+        // ```
+        // TRB Transfer Length. This field shall reflect the residual number of bytes not transferred.
+        //
+        // For an OUT, this field shall indicate the value of the Length field
+        // of the Transfer TRB, minus the data bytes that were successfully
+        // transmitted. A successful OUT transfer shall return a Length of ‘0’.
+        // ```
+        //
+        // With the current mock a length field of 448 would be expected
+        // according to the specification citation.
+        //
+        // We currently return a hard coded 0 and this test is working with that.
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                SECOND_ADDRESS,
+                0,
+                CompletionCode::StallError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
 
         assert!(interrupter.is_empty());
     }

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -23,7 +23,7 @@ use crate::device::{
         },
         trb::{
             CompletionCode, DataStageTrb, EventDataTrb, EventTrb, NormalTrb, RawTrb, SetupStageTrb,
-            StatusStageTrb, TransferTrb, TransferTrbVariant, TrbDmaInfo,
+            StatusStageTrb, TransferTrbVariant, TrbDmaInfo,
         },
         usbrequest::UsbRequest,
     },
@@ -394,6 +394,11 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
 
                     usb_request.data.append(&mut tmp);
                 }
+
+                // No hardware transfer happened yet but we have to track from
+                // the guest "successful transmitted" byte count for maybe
+                // created Events to show the expected edtla.
+                self.transfer_state.event_meta.add(transfer_length);
             }
         }
     }
@@ -861,6 +866,41 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
     }
 }
 
+fn handle_event_data_trb_normal_ep(
+    event_data_trb: &EventDataTrb,
+    event_meta: &mut EventDataTrbMetadata,
+    endpoint_id: u8,
+    slot_id: u8,
+    event_sender: &EventSender,
+) -> anyhow::Result<()> {
+    trace!("EventData TRB on Normal Ep");
+
+    if event_data_trb.interrupt_on_completion {
+        let event = EventTrb::new_transfer_event_trb(
+            event_data_trb.event_data,
+            event_meta.edtla,
+            event_meta.previous_completion_code,
+            true,
+            endpoint_id,
+            slot_id,
+        );
+        event_sender.send(event)?;
+    }
+
+    event_meta.zero();
+
+    Ok(())
+}
+
+#[derive(Debug, Default, Clone)]
+enum NormalSubmissionState {
+    #[default]
+    NoTrbSubmitted,
+    UnsupportedTrbType(RawTrb),
+    AwaitingRealTransfer(u64, NormalTrb),
+    ConsumedEventDataTrb,
+}
+
 #[derive(Debug)]
 pub struct OutEndpointHandle<ROEH: RealOutEndpointHandle> {
     slot_id: u8,
@@ -870,6 +910,7 @@ pub struct OutEndpointHandle<ROEH: RealOutEndpointHandle> {
     dma_bus: BusDeviceRef,
     event_sender: EventSender,
     submission_state: NormalSubmissionState,
+    event_meta: EventDataTrbMetadata,
 }
 
 impl<ROEH: RealOutEndpointHandle> OutEndpointHandle<ROEH> {
@@ -889,16 +930,79 @@ impl<ROEH: RealOutEndpointHandle> OutEndpointHandle<ROEH> {
             dma_bus,
             event_sender,
             submission_state: NormalSubmissionState::NoTrbSubmitted,
+            event_meta: EventDataTrbMetadata::default(),
         }
     }
-}
 
-#[derive(Debug, Default)]
-enum NormalSubmissionState {
-    #[default]
-    NoTrbSubmitted,
-    UnsupportedTrbType(RawTrb),
-    AwaitingRealTransfer(TransferTrb),
+    fn handle_normal_trb_pre_hardware(
+        &mut self,
+        address: u64,
+        trb: NormalTrb,
+    ) -> anyhow::Result<()> {
+        trace!("handle_normal_trb_pre_hardware Out");
+
+        if !trb.chain {
+            self.event_meta = EventDataTrbMetadata::default();
+        }
+
+        let data = if trb.immediate_data {
+            if trb.transfer_length > 8 {
+                todo!("using IDT with length > 8");
+            }
+            trb.data_pointer.to_le_bytes()[..trb.transfer_length as usize].to_vec()
+        } else {
+            let mut data = vec![0; trb.transfer_length as usize];
+            self.dma_bus.read_bulk(trb.data_pointer, &mut data);
+            data
+        };
+
+        self.real_ep.submit(data.clone())?;
+        pcap::out_submission(self.pcap_meta, address, &data, trb.transfer_length);
+
+        self.submission_state = NormalSubmissionState::AwaitingRealTransfer(address, trb);
+        self.event_meta.previous_completion_code = CompletionCode::Success;
+
+        Ok(())
+    }
+
+    fn handle_normal_trb_post_hardware(
+        &mut self,
+        address: u64,
+        trb: NormalTrb,
+    ) -> anyhow::Result<()> {
+        trace!("handle_normal_trb_post_hardware Out");
+
+        self.event_meta.add(trb.transfer_length);
+
+        if trb.interrupt_on_completion {
+            interrupt_on_completion(
+                address,
+                CompletionCode::Success,
+                false,
+                self.endpoint_id,
+                self.slot_id,
+                &self.event_sender,
+            )?;
+        }
+
+        pcap::out_completion(self.pcap_meta, address, trb.transfer_length);
+
+        self.event_meta.previous_completion_code = CompletionCode::Success;
+        Ok(())
+    }
+
+    fn handle_event_data_trb(&mut self, trb: EventDataTrb) -> anyhow::Result<()> {
+        handle_event_data_trb_normal_ep(
+            &trb,
+            &mut self.event_meta,
+            self.endpoint_id,
+            self.slot_id,
+            &self.event_sender,
+        )?;
+
+        self.submission_state = NormalSubmissionState::ConsumedEventDataTrb;
+        Ok(())
+    }
 }
 
 impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
@@ -911,32 +1015,12 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
             "submit_trb called twice without calling next_completion"
         );
 
-        let transfer_trb = TransferTrbVariant::parse(trb.buffer);
-        match &transfer_trb {
-            TransferTrbVariant::Normal(normal_data) => {
-                let data = if normal_data.immediate_data {
-                    if normal_data.transfer_length > 8 {
-                        todo!("using IDT with length > 8");
-                    }
-                    normal_data.data_pointer.to_le_bytes()[..normal_data.transfer_length as usize]
-                        .to_vec()
-                } else {
-                    let mut data = vec![0; normal_data.transfer_length as usize];
-                    self.dma_bus.read_bulk(normal_data.data_pointer, &mut data);
-                    data
-                };
-
-                pcap::out_submission(
-                    self.pcap_meta,
-                    trb.address,
-                    &data,
-                    normal_data.transfer_length,
-                );
-                self.real_ep.submit(data)?;
-                self.submission_state = NormalSubmissionState::AwaitingRealTransfer(TransferTrb {
-                    address: trb.address,
-                    variant: transfer_trb,
-                });
+        match TransferTrbVariant::parse(trb.buffer) {
+            TransferTrbVariant::Normal(normal) => {
+                self.handle_normal_trb_pre_hardware(trb.address, normal)?;
+            }
+            TransferTrbVariant::EventData(event_data) => {
+                self.handle_event_data_trb(event_data)?;
             }
             _ => self.submission_state = NormalSubmissionState::UnsupportedTrbType(trb),
         }
@@ -951,7 +1035,15 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
         );
 
         Box::pin(async {
-            let result = match self.submission_state {
+            let result = match &self.submission_state {
+                NormalSubmissionState::ConsumedEventDataTrb => {
+                    trace!(
+                        "Slot {} Endpoint {} Consumed Event Data Trb",
+                        self.slot_id,
+                        self.endpoint_id
+                    );
+                    TrbProcessingResult::Ok
+                }
                 NormalSubmissionState::UnsupportedTrbType(ref trb) => {
                     let transfer_event = EventTrb::new_transfer_event_trb(
                         trb.address,
@@ -965,81 +1057,89 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
 
                     TrbProcessingResult::TrbError
                 }
-                NormalSubmissionState::AwaitingRealTransfer(ref transfer_trb) => {
-                    let (completion_code, processing_result) =
-                        match self.real_ep.next_completion().await? {
-                            OutTrbProcessingResult::Disconnect => {
-                                pcap::out_error(
-                                    self.pcap_meta,
-                                    transfer_trb.address,
-                                    &OutTrbProcessingResult::Disconnect,
-                                    &[],
-                                );
-                                (
-                                    Some(CompletionCode::UsbTransactionError),
-                                    TrbProcessingResult::Disconnect,
-                                )
-                            }
-                            OutTrbProcessingResult::Stall => {
-                                pcap::out_error(
-                                    self.pcap_meta,
-                                    transfer_trb.address,
-                                    &OutTrbProcessingResult::Stall,
-                                    &[],
-                                );
-                                (
-                                    Some(CompletionCode::StallError),
-                                    TrbProcessingResult::Stall(None),
-                                )
-                            }
-                            OutTrbProcessingResult::TransactionError => {
-                                pcap::out_error(
-                                    self.pcap_meta,
-                                    transfer_trb.address,
-                                    &OutTrbProcessingResult::TransactionError,
-                                    &[],
-                                );
-                                (
-                                    Some(CompletionCode::UsbTransactionError),
-                                    TrbProcessingResult::TransactionError(None),
-                                )
-                            }
-                            OutTrbProcessingResult::Success => {
-                                let completion_code =
-                                    if let TransferTrbVariant::Normal(ref normal_data) =
-                                        transfer_trb.variant
-                                    {
-                                        pcap::out_completion(
-                                            self.pcap_meta,
-                                            transfer_trb.address,
-                                            normal_data.transfer_length,
-                                        );
-                                        match normal_data.interrupt_on_completion {
-                                            true => Some(CompletionCode::Success),
-                                            false => None,
-                                        }
-                                    } else {
-                                        unreachable!();
-                                    };
-                                (completion_code, TrbProcessingResult::Ok)
-                            }
-                        };
+                NormalSubmissionState::AwaitingRealTransfer(address, normal) => {
+                    match &self.real_ep.next_completion().await? {
+                        OutTrbProcessingResult::Disconnect => {
+                            info!(
+                                "Device has been disconnected. slot {} ep {}",
+                                self.slot_id, self.endpoint_id
+                            );
+                            pcap::out_error(
+                                self.pcap_meta,
+                                *address,
+                                &OutTrbProcessingResult::Disconnect,
+                                &[],
+                            );
 
-                    if let Some(completion_code) = completion_code {
-                        let transfer_event = EventTrb::new_transfer_event_trb(
-                            transfer_trb.address,
-                            0,
-                            completion_code,
-                            false,
-                            self.endpoint_id,
-                            self.slot_id,
-                        );
-                        self.event_sender.send(transfer_event)?;
+                            let event = EventTrb::new_transfer_event_trb(
+                                *address,
+                                0,
+                                CompletionCode::UsbTransactionError,
+                                false,
+                                self.endpoint_id,
+                                self.slot_id,
+                            );
+                            self.event_sender.send(event)?;
+
+                            TrbProcessingResult::Disconnect
+                        }
+                        OutTrbProcessingResult::Stall => {
+                            debug!(
+                                "Device Stall while waiting for hardware response. slot {} ep {}",
+                                self.slot_id, self.endpoint_id
+                            );
+                            pcap::out_error(
+                                self.pcap_meta,
+                                *address,
+                                &OutTrbProcessingResult::Stall,
+                                &[],
+                            );
+
+                            let event = EventTrb::new_transfer_event_trb(
+                                *address,
+                                0,
+                                CompletionCode::StallError,
+                                false,
+                                self.endpoint_id,
+                                self.slot_id,
+                            );
+                            self.event_sender.send(event)?;
+
+                            // We do not need to rewind the dequeue pointer (hence the None)
+                            // here like the IN endpoint with TD aggregation would need to do.
+                            TrbProcessingResult::Stall(None)
+                        }
+                        OutTrbProcessingResult::TransactionError => {
+                            info!("Transaction Error while waiting for hardware response. slot {} ep {}",
+                                self.slot_id, self.endpoint_id);
+                            pcap::out_error(
+                                self.pcap_meta,
+                                *address,
+                                &OutTrbProcessingResult::TransactionError,
+                                &[],
+                            );
+
+                            let event = EventTrb::new_transfer_event_trb(
+                                *address,
+                                0,
+                                CompletionCode::UsbTransactionError,
+                                false,
+                                self.endpoint_id,
+                                self.slot_id,
+                            );
+                            self.event_sender.send(event)?;
+
+                            TrbProcessingResult::TransactionError(None)
+                        }
+                        OutTrbProcessingResult::Success => {
+                            self.handle_normal_trb_post_hardware(*address, normal.clone())?;
+                            TrbProcessingResult::Ok
+                        }
                     }
-
-                    processing_result
                 }
-                NormalSubmissionState::NoTrbSubmitted => unreachable!(),
+                NormalSubmissionState::NoTrbSubmitted => {
+                    unreachable!("internal error: Always set a different ControlSubmissionState in submit_trb().")
+                }
             };
             self.submission_state = NormalSubmissionState::NoTrbSubmitted;
 
@@ -1078,8 +1178,8 @@ impl TryFrom<TransferTrbVariant> for SupportedInEndpointTrbVariant {
 
     fn try_from(value: TransferTrbVariant) -> Result<Self, Self::Error> {
         match value {
-            TransferTrbVariant::Normal(data) => Ok(Self::Normal(data)),
-            TransferTrbVariant::EventData(data) => Ok(Self::EventData(data)),
+            TransferTrbVariant::Normal(normal) => Ok(Self::Normal(normal)),
+            TransferTrbVariant::EventData(event_data) => Ok(Self::EventData(event_data)),
             variant => Err(variant),
         }
     }
@@ -1125,6 +1225,8 @@ pub struct TdBasedInEndpointHandle<RIEH: RealInEndpointHandle> {
     dma_bus: BusDeviceRef,
     event_sender: EventSender,
     submission_state: TdBasedNormalSubmissionState,
+    /// Values we will need to handle an incoming Event Data Trb.
+    event_meta: EventDataTrbMetadata,
 }
 
 impl<RIEH: RealInEndpointHandle> TdBasedInEndpointHandle<RIEH> {
@@ -1144,6 +1246,7 @@ impl<RIEH: RealInEndpointHandle> TdBasedInEndpointHandle<RIEH> {
             dma_bus,
             event_sender,
             submission_state: TdBasedNormalSubmissionState::default(),
+            event_meta: EventDataTrbMetadata::default(),
         }
     }
 }
@@ -1220,6 +1323,7 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for TdBasedInEndpointHandle<RIEH
                         &self.event_sender,
                         &self.dma_bus,
                         self.pcap_meta,
+                        &mut self.event_meta,
                     )?;
                     Ok(processing_result)
                 }
@@ -1228,6 +1332,7 @@ impl<RIEH: RealInEndpointHandle> EndpointHandle for TdBasedInEndpointHandle<RIEH
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn process_real_transfer_response(
     endpoint_id: u8,
     slot_id: u8,
@@ -1236,6 +1341,7 @@ fn process_real_transfer_response(
     event_sender: &EventSender,
     dma_bus: &BusDeviceRef,
     pcap_meta: EndpointPcapMeta,
+    event_meta: &mut EventDataTrbMetadata,
 ) -> anyhow::Result<TrbProcessingResult> {
     debug!(
         "received device response with {} bytes",
@@ -1254,7 +1360,7 @@ fn process_real_transfer_response(
     };
 
     for trb in trbs {
-        if let Some(early_return_result) = td_info.process_trb(trb)? {
+        if let Some(early_return_result) = td_info.process_trb(trb, event_meta)? {
             return Ok(early_return_result);
         }
     }
@@ -1294,21 +1400,24 @@ impl<'a> TdProcessingInfo<'a> {
     fn process_trb(
         &mut self,
         trb: SupportedInEndpointTrb,
+        event_meta: &mut EventDataTrbMetadata,
     ) -> anyhow::Result<Option<TrbProcessingResult>> {
-        // assumption: Only normal TRBs
         match trb.variant {
-            SupportedInEndpointTrbVariant::Normal(data) => {
-                self.process_normal_trb(trb.addr, trb.cycle_bit, data)
+            SupportedInEndpointTrbVariant::Normal(normal) => {
+                self.handle_normal_trb(trb.addr, trb.cycle_bit, normal, event_meta)
             }
-            SupportedInEndpointTrbVariant::EventData(_data) => todo!(),
+            SupportedInEndpointTrbVariant::EventData(event_data) => {
+                self.handle_event_data_trb(event_data, event_meta)
+            }
         }
     }
 
-    fn process_normal_trb(
+    fn handle_normal_trb(
         &mut self,
         addr: u64,
         cs: bool,
         trb_data: NormalTrb,
+        event_meta: &mut EventDataTrbMetadata,
     ) -> anyhow::Result<Option<TrbProcessingResult>> {
         match self.state {
             TdProcessingState::Default => {
@@ -1325,6 +1434,8 @@ impl<'a> TdProcessingInfo<'a> {
                     trb_data.data_pointer
                 );
                 self.dma_bus.write_bulk(trb_data.data_pointer, bytes);
+
+                event_meta.add(dma_byte_count as u32);
 
                 if bytes_available < bytes_requested {
                     let bytes_missing = bytes_requested - bytes_available;
@@ -1383,15 +1494,14 @@ impl<'a> TdProcessingInfo<'a> {
 
                 // event sending only when IOC is set
                 if trb_data.interrupt_on_completion {
-                    let transfer_event = EventTrb::new_transfer_event_trb(
+                    interrupt_on_completion(
                         addr,
-                        0,
                         CompletionCode::Success,
                         false,
                         self.endpoint_id,
                         self.slot_id,
-                    );
-                    self.event_sender.send(transfer_event)?;
+                        self.event_sender,
+                    )?;
                 }
 
                 Ok(None)
@@ -1402,6 +1512,22 @@ impl<'a> TdProcessingInfo<'a> {
                 Ok(None)
             }
         }
+    }
+
+    fn handle_event_data_trb(
+        &self,
+        trb_data: EventDataTrb,
+        event_meta: &mut EventDataTrbMetadata,
+    ) -> anyhow::Result<Option<TrbProcessingResult>> {
+        handle_event_data_trb_normal_ep(
+            &trb_data,
+            event_meta,
+            self.endpoint_id,
+            self.slot_id,
+            self.event_sender,
+        )?;
+
+        Ok(None)
     }
 }
 

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -49,8 +49,10 @@ pub trait EndpointHandle: BaseEndpointHandle {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrbProcessingResult {
     Ok,
+    /// (trb_address, cycle_bit)
     Stall(Option<(u64, bool)>),
     TrbError,
+    /// (trb_address, cycle_bit)
     TransactionError(Option<(u64, bool)>),
     Disconnect,
 }
@@ -1570,7 +1572,8 @@ pub mod tests {
 
     use crate::device::xhci::endpoint_handle::tests::testutils::{
         MockRealControlEndpointExpectDataPattern, MockRealControlEndpointHardwareError,
-        MockRealControlEndpointReadStatic, MockRealInEndpoint, MockRealOutEndpoint,
+        MockRealControlEndpointReadStatic, MockRealInEndpointHardwareError,
+        MockRealInEndpointReadStatic, MockRealOutEndpoint,
     };
     use crate::device::xhci::interrupter::tests::testutils::MockInterrupter;
     use crate::device::{bus::testutils::TestBusDevice, xhci::trb::testutils::RawTrbBuilder};
@@ -1763,17 +1766,17 @@ pub mod tests {
 
         // will return `vec![42; requested length]`
         #[derive(Debug)]
-        pub struct MockRealInEndpoint {
+        pub struct MockRealInEndpointReadStatic {
             data_length: usize,
         }
 
-        impl MockRealInEndpoint {
+        impl MockRealInEndpointReadStatic {
             pub fn new() -> Self {
                 Self { data_length: 0 }
             }
         }
 
-        impl RealInEndpointHandle for MockRealInEndpoint {
+        impl RealInEndpointHandle for MockRealInEndpointReadStatic {
             type TrbCompletionFuture<'a> =
                 Pin<Box<dyn Future<Output = anyhow::Result<InTrbProcessingResult>> + Send + 'a>>;
 
@@ -1794,7 +1797,7 @@ pub mod tests {
             }
         }
 
-        impl BaseEndpointHandle for MockRealInEndpoint {
+        impl BaseEndpointHandle for MockRealInEndpointReadStatic {
             type CompletionFuture<'a> =
                 Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
 
@@ -1805,6 +1808,49 @@ pub mod tests {
 
             fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
                 // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+        }
+
+        // mock for bulk in real endpoint returning `vec![42; 512 + 64]` and then a given InTrbProcessingStatus
+        #[derive(Debug)]
+        pub struct MockRealInEndpointHardwareError {
+            status: InTrbProcessingStatus,
+        }
+
+        impl MockRealInEndpointHardwareError {
+            pub fn new(status: InTrbProcessingStatus) -> Self {
+                Self { status }
+            }
+        }
+
+        impl RealInEndpointHandle for MockRealInEndpointHardwareError {
+            type TrbCompletionFuture<'a> =
+                Pin<Box<dyn Future<Output = anyhow::Result<InTrbProcessingResult>> + Send + 'a>>;
+
+            fn submit(&mut self, _data: usize) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_> {
+                Box::pin(async {
+                    Ok(InTrbProcessingResult {
+                        status: self.status.clone(),
+                        data: vec![42; 512 + 64],
+                    })
+                })
+            }
+        }
+
+        impl BaseEndpointHandle for MockRealInEndpointHardwareError {
+            type CompletionFuture<'a> =
+                Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+            fn cancel(&mut self) -> Self::CompletionFuture<'_> {
+                Box::pin(async { Ok(()) })
+            }
+
+            fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
                 Box::pin(async { Ok(()) })
             }
         }
@@ -2494,7 +2540,7 @@ pub mod tests {
         let pcap_usb_bus_number = 1;
         let pcap_meta = EndpointPcapMeta::bulk(pcap_usb_bus_number, SLOT_ID, ENDPOINT_ID);
 
-        let real_ep = MockRealInEndpoint::new();
+        let real_ep = MockRealInEndpointReadStatic::new();
 
         let dma_bus = Arc::new(DynamicBus::new());
         let dma_backing = vec![99; 2048];
@@ -2592,6 +2638,115 @@ pub mod tests {
             interrupter.await_event().await,
             Some(expected_event(EVENT_DATA_FIELD, TRANSFER_LENGTH, true))
         );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn normal_in_returns_hardware_stall() {
+        const SLOT_ID: u8 = 1;
+        const ENDPOINT_ID: u8 = 1;
+
+        let pcap_usb_bus_number = 1;
+        let pcap_meta = EndpointPcapMeta::bulk(pcap_usb_bus_number, SLOT_ID, ENDPOINT_ID);
+
+        let real_ep = MockRealInEndpointHardwareError::new(InTrbProcessingStatus::Stall);
+
+        let dma_bus = Arc::new(DynamicBus::new());
+        let dma_backing = vec![99; 2048];
+        dma_bus
+            .add(0x0, Arc::new(TestBusDevice::new(&dma_backing[..])))
+            .expect("Adding Memory to the DynamicBus should never fail.");
+
+        let (event_sender, mut interrupter) = MockInterrupter::new();
+
+        let mut bulk_in_endpoint = TdBasedInEndpointHandle::new(
+            SLOT_ID,
+            ENDPOINT_ID,
+            pcap_meta,
+            real_ep,
+            dma_bus,
+            event_sender,
+        );
+
+        let normal_1 = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .with_trb_transfer_length(512)
+            .with_interrupt_on_completion()
+            .with_direction()
+            .with_chain()
+            .build();
+
+        let normal_2 = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .with_trb_transfer_length(512)
+            .with_interrupt_on_completion()
+            .with_direction()
+            .with_chain()
+            .build();
+
+        let normal_3 = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .with_trb_transfer_length(512)
+            .with_interrupt_on_completion()
+            .with_direction()
+            .build();
+
+        bulk_in_endpoint
+            .submit_trb(normal_1)
+            .expect("this mock hardware request should never fail");
+
+        assert_eq!(
+            bulk_in_endpoint.next_completion().await.ok(),
+            Some(TrbProcessingResult::Ok)
+        );
+
+        bulk_in_endpoint
+            .submit_trb(normal_2)
+            .expect("this mock hardware request should never fail");
+
+        assert_eq!(
+            bulk_in_endpoint.next_completion().await.ok(),
+            Some(TrbProcessingResult::Ok)
+        );
+
+        bulk_in_endpoint
+            .submit_trb(normal_3)
+            .expect("this mock hardware request should never fail");
+
+        // The TdBasedInEndpointHandle called its processing and is done with the TD.
+        let completion = bulk_in_endpoint.next_completion().await.ok();
+
+        assert_eq!(
+            completion,
+            Some(TrbProcessingResult::Stall(Some((SECOND_ADDRESS, false))))
+        );
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                FIRST_ADDRESS,
+                0,
+                CompletionCode::Success,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                SECOND_ADDRESS,
+                448, // missing this many bytes
+                CompletionCode::StallError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
+
+        // no event for the third normal Trb because we (in theory) have yet to touch it
 
         assert!(interrupter.is_empty());
     }

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -46,7 +46,7 @@ pub trait EndpointHandle: BaseEndpointHandle {
 /// - Some((addr, cs)) indicates that the stall/error happened on an earlier TRB but we notice it only
 ///   now because we aggregated all TRBs of a TD before talking to the real device; the endpoint
 ///   state machine should wind the dequeue pointer (and associated cycle state) back to this TRB.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrbProcessingResult {
     Ok,
     Stall(Option<(u64, bool)>),
@@ -1568,6 +1568,47 @@ impl<RIEH: RealInEndpointHandle> BaseEndpointHandle for TdBasedInEndpointHandle<
 pub mod tests {
     use super::*;
 
+    use crate::device::xhci::endpoint_handle::tests::testutils::{
+        MockRealControlEndpointExpectDataPattern, MockRealControlEndpointHardwareError,
+        MockRealControlEndpointReadStatic, MockRealInEndpoint, MockRealOutEndpoint,
+    };
+    use crate::device::xhci::interrupter::tests::testutils::MockInterrupter;
+    use crate::device::{bus::testutils::TestBusDevice, xhci::trb::testutils::RawTrbBuilder};
+    use crate::dynamic_bus::DynamicBus;
+
+    use std::sync::Arc;
+
+    const SLOT_ID: u8 = 1;
+    const ENDPOINT_ID: u8 = 1;
+
+    const FIRST_ADDRESS: u64 = 0x10;
+    const SECOND_ADDRESS: u64 = 0x20;
+    const THIRD_ADDRESS: u64 = 0x30;
+    const FOURTH_ADDRESS: u64 = 0x40;
+    const FIFTH_ADDRESS: u64 = 0x50;
+    const SIXTH_ADDRESS: u64 = 0x60;
+
+    const DMA_POINTER_1: u64 = 0x200;
+    const DMA_POINTER_2: u64 = 0x400;
+    const DMA_POINTER_3: u64 = 0x600;
+    const DMA_POINTER_4: u64 = 0x800;
+
+    const SETUP_WLENGTH: u16 = 512;
+    const TRANSFER_LENGTH: u32 = SETUP_WLENGTH as u32;
+    const EVENT_DATA_FIELD: u64 = 0xda7a;
+
+    const TRB_TYPE_NORMAL: u8 = 0x1;
+    const TRB_TYPE_SETUP_STAGE: u8 = 0x2;
+    const TRB_TYPE_DATA_STAGE: u8 = 0x3;
+    const TRB_TYPE_STATUS_STAGE: u8 = 0x4;
+    const TRB_TYPE_EVENT_DATA: u8 = 0x7;
+
+    const SETUP_BM_REQUEST_TYPE_IN: u8 = 0x80;
+    const SETUP_BM_REQUEST_TYPE_OUT: u8 = 0;
+
+    const SETUP_TRANSFER_TYPE_OUT_DATA: u8 = 0x2;
+    const SETUP_TRANSFER_TYPE_IN_DATA: u8 = 0x3;
+
     pub mod testutils {
         use super::*;
 
@@ -1577,6 +1618,7 @@ pub mod tests {
             data_length: u16,
             direction: bool,
         }
+
         impl MockRealControlEndpointReadStatic {
             pub fn new() -> Self {
                 Self {
@@ -1616,6 +1658,94 @@ pub mod tests {
             }
         }
 
+        // expecting to receive 0xda7a via an out request
+        #[derive(Debug)]
+        pub struct MockRealControlEndpointExpectDataPattern {}
+
+        impl MockRealControlEndpointExpectDataPattern {
+            pub fn new() -> Self {
+                Self {}
+            }
+        }
+
+        impl RealControlEndpointHandle for MockRealControlEndpointExpectDataPattern {
+            type TrbCompletionFuture<'a> = Pin<
+                Box<
+                    dyn Future<Output = anyhow::Result<ControlRequestProcessingResult>> + Send + 'a,
+                >,
+            >;
+
+            fn submit_control_request(&mut self, request: UsbRequest) -> anyhow::Result<()> {
+                assert_eq!(request.data, 0xda7a_u64.to_le_bytes()[..2]);
+                Ok(())
+            }
+
+            fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_> {
+                Box::pin(async {
+                    let result = ControlRequestProcessingResult::SuccessfulControlOut;
+                    Ok(result)
+                })
+            }
+        }
+
+        impl BaseEndpointHandle for MockRealControlEndpointExpectDataPattern {
+            type CompletionFuture<'a> =
+                Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+            fn cancel(&mut self) -> Self::CompletionFuture<'_> {
+                // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+
+            fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
+                // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+        }
+
+        // expecting to receive 0xda7a via an out request
+        #[derive(Debug)]
+        pub struct MockRealControlEndpointHardwareError {
+            error: ControlRequestProcessingResult,
+        }
+
+        impl MockRealControlEndpointHardwareError {
+            pub fn new(error: ControlRequestProcessingResult) -> Self {
+                Self { error }
+            }
+        }
+
+        impl RealControlEndpointHandle for MockRealControlEndpointHardwareError {
+            type TrbCompletionFuture<'a> = Pin<
+                Box<
+                    dyn Future<Output = anyhow::Result<ControlRequestProcessingResult>> + Send + 'a,
+                >,
+            >;
+
+            fn submit_control_request(&mut self, _request: UsbRequest) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_> {
+                Box::pin(async { Ok(self.error.clone()) })
+            }
+        }
+
+        impl BaseEndpointHandle for MockRealControlEndpointHardwareError {
+            type CompletionFuture<'a> =
+                Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+            fn cancel(&mut self) -> Self::CompletionFuture<'_> {
+                // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+
+            fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
+                // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+        }
+
         impl BaseEndpointHandle for MockRealControlEndpointReadStatic {
             type CompletionFuture<'a> =
                 Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
@@ -1636,11 +1766,13 @@ pub mod tests {
         pub struct MockRealInEndpoint {
             data_length: usize,
         }
+
         impl MockRealInEndpoint {
             pub fn new() -> Self {
                 Self { data_length: 0 }
             }
         }
+
         impl RealInEndpointHandle for MockRealInEndpoint {
             type TrbCompletionFuture<'a> =
                 Pin<Box<dyn Future<Output = anyhow::Result<InTrbProcessingResult>> + Send + 'a>>;
@@ -1661,6 +1793,7 @@ pub mod tests {
                 })
             }
         }
+
         impl BaseEndpointHandle for MockRealInEndpoint {
             type CompletionFuture<'a> =
                 Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
@@ -1684,6 +1817,7 @@ pub mod tests {
                 Self {}
             }
         }
+
         impl RealOutEndpointHandle for MockRealOutEndpoint {
             type TrbCompletionFuture<'a> =
                 Pin<Box<dyn Future<Output = anyhow::Result<OutTrbProcessingResult>> + Send + 'a>>;
@@ -1700,6 +1834,7 @@ pub mod tests {
                 })
             }
         }
+
         impl BaseEndpointHandle for MockRealOutEndpoint {
             type CompletionFuture<'a> =
                 Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
@@ -1714,5 +1849,858 @@ pub mod tests {
                 Box::pin(async { Ok(()) })
             }
         }
+    }
+
+    // Initialize test environment using the MockRealControlEndpointReadStatic
+    //
+    // Use the ControlEndpointHandle to submit some TransferTrb.
+    // Use the UnboundedReceiver to directly check events meant for a EventRing.
+    fn init_control_endpoint_handle_test<T: RealControlEndpointHandle>(
+        real_ep: T,
+    ) -> (MockInterrupter, ControlEndpointHandle<T>) {
+        let pcap_usb_bus_number = 1;
+        let pcap_meta = EndpointPcapMeta::control(pcap_usb_bus_number, SLOT_ID, ENDPOINT_ID);
+
+        let dma_bus = Arc::new(DynamicBus::new());
+        let dma_backing = vec![99; 2048];
+        dma_bus
+            .add(0x0, Arc::new(TestBusDevice::new(&dma_backing[..])))
+            .expect("Adding Memory to the DynamicBus should never fail.");
+
+        let (event_sender, interrupter) = MockInterrupter::new();
+
+        let control_endpoint = ControlEndpointHandle::new(
+            SLOT_ID,
+            ENDPOINT_ID,
+            pcap_meta,
+            real_ep,
+            dma_bus,
+            event_sender,
+        );
+        (interrupter, control_endpoint)
+    }
+
+    /// Wrapper to simplify creating a successful expected EventTrb for comparison.
+    fn expected_event(trb_pointer: u64, trb_transfer_length: u32, event_data: bool) -> EventTrb {
+        EventTrb::new_transfer_event_trb(
+            trb_pointer,
+            trb_transfer_length,
+            CompletionCode::Success,
+            event_data,
+            ENDPOINT_ID,
+            SLOT_ID,
+        )
+    }
+
+    #[tokio::test]
+    async fn submit_shortest_possible_control_in_request() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointReadStatic::new());
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            .with_immediate_data()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .build();
+        let status_stage = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .with_direction()
+            .build();
+
+        let input_trb = vec![setup_stage, status_stage];
+
+        for trb in input_trb.clone() {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(SECOND_ADDRESS, 0, false))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_shortest_possible_control_in_request_with_data_stage() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointReadStatic::new());
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            .with_setup_wlength(SETUP_WLENGTH)
+            .with_immediate_data()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .with_byte(14, SETUP_TRANSFER_TYPE_IN_DATA)
+            .build();
+        let data_stage = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_data_pointer(DMA_POINTER_1)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_DATA_STAGE)
+            .with_direction()
+            .build();
+        let status_stage = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .with_direction()
+            .build();
+
+        let input_trb = vec![setup_stage, data_stage, status_stage];
+
+        for trb in input_trb.clone() {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(SECOND_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(THIRD_ADDRESS, 0, false))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_second_illegal_data_stage_trb() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointReadStatic::new());
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            .with_setup_wlength(SETUP_WLENGTH)
+            .with_immediate_data()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .with_byte(14, SETUP_TRANSFER_TYPE_IN_DATA)
+            .build();
+        let data_stage_1 = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_data_pointer(DMA_POINTER_1)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_chain()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_DATA_STAGE)
+            .with_direction()
+            .build();
+        let data_stage_2 = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_data_pointer(DMA_POINTER_1)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_DATA_STAGE)
+            .with_direction()
+            .build();
+        let status_stage = RawTrbBuilder::new(FOURTH_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .with_direction()
+            .build();
+
+        let input_trb = vec![setup_stage, data_stage_1, data_stage_2, status_stage];
+
+        for trb in input_trb.clone() {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(SECOND_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                THIRD_ADDRESS,
+                0,
+                CompletionCode::TrbError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                FOURTH_ADDRESS,
+                0,
+                CompletionCode::TrbError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_control_in_request_with_event_data_at_the_end_of_the_data_stage() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointReadStatic::new());
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            .with_setup_wlength(SETUP_WLENGTH)
+            .with_immediate_data()
+            .with_interrupt_on_completion()
+            .with_trb_type(0x2)
+            .with_byte(14, SETUP_TRANSFER_TYPE_IN_DATA)
+            .build();
+        let data_stage = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_data_pointer(DMA_POINTER_1)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_chain()
+            .with_trb_type(0x3)
+            .with_direction()
+            .build();
+        let event_data = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_data_pointer(EVENT_DATA_FIELD)
+            .with_interrupt_on_completion()
+            .with_trb_type(0x7)
+            .with_direction()
+            .build();
+        let status_stage = RawTrbBuilder::new(FOURTH_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(0x4)
+            .with_direction()
+            .build();
+
+        let input_trb = vec![setup_stage, data_stage, event_data, status_stage];
+
+        for trb in input_trb {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(EVENT_DATA_FIELD, 512, true))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FOURTH_ADDRESS, 0, false))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_control_in_request_with_event_data_between_two_trb_of_the_data_td() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointReadStatic::new());
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            .with_setup_wlength(SETUP_WLENGTH * 2)
+            .with_immediate_data()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .with_byte(14, SETUP_TRANSFER_TYPE_IN_DATA)
+            .build();
+        let data_stage = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_data_pointer(DMA_POINTER_1)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_chain()
+            .with_trb_type(TRB_TYPE_DATA_STAGE)
+            .with_direction()
+            .build();
+        let event_data = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_data_pointer(EVENT_DATA_FIELD)
+            .with_chain()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_EVENT_DATA)
+            .with_direction()
+            .build();
+        let normal = RawTrbBuilder::new(FOURTH_ADDRESS)
+            .with_data_pointer(DMA_POINTER_2)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .build();
+        let status_stage = RawTrbBuilder::new(FIFTH_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .with_direction()
+            .build();
+
+        let input_trb = vec![setup_stage, data_stage, event_data, normal, status_stage];
+
+        for trb in input_trb {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint
+                    .next_completion()
+                    .await
+                    .expect("this mock hardware request should never fail"),
+                TrbProcessingResult::Ok
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(EVENT_DATA_FIELD, 512, true))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FOURTH_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIFTH_ADDRESS, 0, false))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_control_in_request_with_event_data_after_status_stage_trb() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointReadStatic::new());
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            .with_immediate_data()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .build();
+        let status_stage = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_chain()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .with_direction()
+            .build();
+        let event_data = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_data_pointer(EVENT_DATA_FIELD)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_EVENT_DATA)
+            .with_direction()
+            .build();
+
+        let input_trb = vec![setup_stage, status_stage, event_data];
+
+        for trb in input_trb.clone() {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(EVENT_DATA_FIELD, 0, true))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_control_out_request_with_data_stage_using_immediate_data() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointExpectDataPattern::new());
+
+        const DMA_POINTER: u64 = 0xeb8bda7a;
+        const TRANSFER_LENGTH: u32 = 2;
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_OUT)
+            .with_setup_wlength(SETUP_WLENGTH)
+            .with_immediate_data()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .with_byte(14, SETUP_TRANSFER_TYPE_OUT_DATA)
+            .build();
+        let data_stage = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_data_pointer(DMA_POINTER)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_interrupt_on_completion()
+            .with_immediate_data()
+            .with_trb_type(TRB_TYPE_DATA_STAGE)
+            .build();
+        let status_stage = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .build();
+
+        let input_trb = vec![setup_stage, data_stage, status_stage];
+
+        for trb in input_trb.clone() {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(SECOND_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(THIRD_ADDRESS, 0, false))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submitting_out_of_order_or_unfinished_sequence_does_not_prevent_the_following_valid_sequence_of_trb(
+    ) {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointReadStatic::new());
+
+        let status_stage_out_of_order = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .with_direction()
+            .build();
+        let setup_stage_incomplete_sequence = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            .with_immediate_data()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .build();
+        let setup_stage = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            .with_immediate_data()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .build();
+        let status_stage = RawTrbBuilder::new(FOURTH_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .with_direction()
+            .build();
+
+        let input_trb = vec![
+            status_stage_out_of_order,
+            setup_stage_incomplete_sequence,
+            setup_stage,
+            status_stage,
+        ];
+
+        for trb in input_trb.clone() {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                FIRST_ADDRESS,
+                0,
+                CompletionCode::TrbError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(SECOND_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(THIRD_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FOURTH_ADDRESS, 0, false))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn control_request_returns_hardware_disconnect() {
+        let (mut interrupter, mut control_endpoint) = init_control_endpoint_handle_test(
+            MockRealControlEndpointHardwareError::new(ControlRequestProcessingResult::Disconnect),
+        );
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            .with_setup_wlength(SETUP_WLENGTH)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .build();
+
+        control_endpoint
+            .submit_trb(setup_stage)
+            .expect("this mock hardware request should never fail");
+
+        assert_eq!(
+            control_endpoint.next_completion().await.ok(),
+            Some(TrbProcessingResult::Disconnect)
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                FIRST_ADDRESS,
+                0,
+                CompletionCode::UsbTransactionError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn control_request_returns_hardware_stall() {
+        let (mut interrupter, mut control_endpoint) = init_control_endpoint_handle_test(
+            MockRealControlEndpointHardwareError::new(ControlRequestProcessingResult::Stall),
+        );
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            .with_setup_wlength(SETUP_WLENGTH)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .build();
+
+        control_endpoint
+            .submit_trb(setup_stage)
+            .expect("this mock hardware request should never fail");
+
+        assert_eq!(
+            control_endpoint.next_completion().await.ok(),
+            Some(TrbProcessingResult::Stall(None))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                FIRST_ADDRESS,
+                0,
+                CompletionCode::StallError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn control_request_returns_hardware_transaction_error() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointHardwareError::new(
+                ControlRequestProcessingResult::TransactionError,
+            ));
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            .with_setup_wlength(SETUP_WLENGTH)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .build();
+
+        control_endpoint
+            .submit_trb(setup_stage)
+            .expect("this mock hardware request should never fail");
+
+        assert_eq!(
+            control_endpoint.next_completion().await.ok(),
+            Some(TrbProcessingResult::TransactionError(None))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                FIRST_ADDRESS,
+                0,
+                CompletionCode::UsbTransactionError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_multi_trb_bulk_in_transfer_with_event_data() {
+        const SLOT_ID: u8 = 1;
+        const ENDPOINT_ID: u8 = 1;
+
+        let pcap_usb_bus_number = 1;
+        let pcap_meta = EndpointPcapMeta::bulk(pcap_usb_bus_number, SLOT_ID, ENDPOINT_ID);
+
+        let real_ep = MockRealInEndpoint::new();
+
+        let dma_bus = Arc::new(DynamicBus::new());
+        let dma_backing = vec![99; 2048];
+        dma_bus
+            .add(0x0, Arc::new(TestBusDevice::new(&dma_backing[..])))
+            .expect("Adding Memory to the DynamicBus should never fail.");
+
+        let (event_sender, mut interrupter) = MockInterrupter::new();
+
+        let mut bulk_in_endpoint = TdBasedInEndpointHandle::new(
+            SLOT_ID,
+            ENDPOINT_ID,
+            pcap_meta,
+            real_ep,
+            dma_bus,
+            event_sender,
+        );
+
+        let normal_1 = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_data_pointer(DMA_POINTER_1)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_byte(11, 0x8) // remaining TD Size: 2048
+            .with_chain()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .build();
+        let normal_2 = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_data_pointer(DMA_POINTER_2)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_byte(11, 0x6) // remaining TD Size: 1536
+            .with_chain()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .build();
+        let normal_3 = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_data_pointer(DMA_POINTER_3)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_byte(11, 0x4) // remaining TD Size: 1024
+            .with_chain()
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .build();
+        let event_data_1 = RawTrbBuilder::new(FOURTH_ADDRESS)
+            .with_data_pointer(EVENT_DATA_FIELD)
+            .with_chain()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_EVENT_DATA)
+            .with_direction()
+            .build();
+        let normal_4 = RawTrbBuilder::new(FIFTH_ADDRESS)
+            .with_data_pointer(DMA_POINTER_4)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_byte(11, 0x2) // remaining TD Size: 512
+            .with_chain()
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .build();
+        let event_data_2 = RawTrbBuilder::new(SIXTH_ADDRESS)
+            .with_data_pointer(EVENT_DATA_FIELD)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_EVENT_DATA)
+            .with_direction()
+            .build();
+
+        let input_trb = vec![
+            normal_1,
+            normal_2,
+            normal_3,
+            event_data_1,
+            normal_4,
+            event_data_2,
+        ];
+
+        for trb in input_trb {
+            bulk_in_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                bulk_in_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(SECOND_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(EVENT_DATA_FIELD, TRANSFER_LENGTH * 3, true))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(EVENT_DATA_FIELD, TRANSFER_LENGTH, true))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_multi_trb_bulk_out_transfer_with_event_data() {
+        const SLOT_ID: u8 = 1;
+        const ENDPOINT_ID: u8 = 1;
+
+        let pcap_usb_bus_number = 1;
+        let pcap_meta = EndpointPcapMeta::bulk(pcap_usb_bus_number, SLOT_ID, ENDPOINT_ID);
+
+        let real_ep = MockRealOutEndpoint::new();
+
+        let dma_bus = Arc::new(DynamicBus::new());
+        let dma_backing = vec![99; 2048];
+        dma_bus
+            .add(0x0, Arc::new(TestBusDevice::new(&dma_backing[..])))
+            .expect("Adding Memory to the DynamicBus should never fail.");
+
+        let (event_sender, mut interrupter) = MockInterrupter::new();
+
+        let mut bulk_out_endpoint = OutEndpointHandle::new(
+            SLOT_ID,
+            ENDPOINT_ID,
+            pcap_meta,
+            real_ep,
+            dma_bus,
+            event_sender,
+        );
+
+        let normal_1 = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_data_pointer(DMA_POINTER_1)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_byte(11, 0x8) // remaining TD Size: 2048
+            .with_chain()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .build();
+        let normal_2 = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_data_pointer(DMA_POINTER_2)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_byte(11, 0x6) // remaining TD Size: 1536
+            .with_chain()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .build();
+        let normal_3 = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_data_pointer(DMA_POINTER_3)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_byte(11, 0x4) // remaining TD Size: 1024
+            .with_chain()
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .build();
+        let event_data_1 = RawTrbBuilder::new(FOURTH_ADDRESS)
+            .with_data_pointer(EVENT_DATA_FIELD)
+            .with_chain()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_EVENT_DATA)
+            .build();
+        let normal_4 = RawTrbBuilder::new(FIFTH_ADDRESS)
+            .with_data_pointer(DMA_POINTER_4)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_byte(11, 0x2) // remaining TD Size: 512
+            .with_chain()
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .build();
+        let event_data_2 = RawTrbBuilder::new(SIXTH_ADDRESS)
+            .with_data_pointer(EVENT_DATA_FIELD)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_EVENT_DATA)
+            .build();
+
+        let input_trb = vec![
+            normal_1,
+            normal_2,
+            normal_3,
+            event_data_1,
+            normal_4,
+            event_data_2,
+        ];
+
+        for trb in input_trb {
+            bulk_out_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                bulk_out_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(SECOND_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(EVENT_DATA_FIELD, TRANSFER_LENGTH * 3, true))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(EVENT_DATA_FIELD, TRANSFER_LENGTH, true))
+        );
+
+        assert!(interrupter.is_empty());
     }
 }

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -589,6 +589,7 @@ enum ControlSubmissionState {
     NoTrbSubmitted,
     ParserConsumedTrb(u64, TransferTrbVariant),
     ParserError(u64),
+    UnexpectedTrb(u64, TransferTrbVariant),
     AwaitingControlIn(u64, TransferTrbVariant),
     AwaitingControlOut(u64, TransferTrbVariant),
 }
@@ -615,8 +616,9 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                         "invalid control transfer sequence; expected Setup Stage Trb, got: {:?}",
                         other_trb
                     );
+
                     self.submission_state =
-                        ControlSubmissionState::ParserConsumedTrb(trb.address, other_trb);
+                        ControlSubmissionState::UnexpectedTrb(trb.address, other_trb);
                 }
             },
             ControlTransferStage::MaybeDataStageTrb => match variant {
@@ -637,9 +639,10 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                         "invalid control transfer sequence; expected Setup, Data or Status Stage Trb, got: {:?}",
                         other_trb
                     );
+
                     self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
                     self.submission_state =
-                        ControlSubmissionState::ParserConsumedTrb(trb.address, other_trb);
+                        ControlSubmissionState::UnexpectedTrb(trb.address, other_trb);
                 }
             },
             ControlTransferStage::MoreData => match variant {
@@ -660,9 +663,10 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                         "invalid control transfer sequence; expected Setup Stage, Normal or Event Data Trb, got: {:?}",
                         other_trb
                     );
+
                     self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
                     self.submission_state =
-                        ControlSubmissionState::ParserConsumedTrb(trb.address, other_trb);
+                        ControlSubmissionState::UnexpectedTrb(trb.address, other_trb);
                 }
             },
 
@@ -681,9 +685,10 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                         "invalid control transfer sequence; expected Setup or Status Stage Trb, got: {:?}",
                         other_trb
                     );
+
                     self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
                     self.submission_state =
-                        ControlSubmissionState::ParserConsumedTrb(trb.address, other_trb);
+                        ControlSubmissionState::UnexpectedTrb(trb.address, other_trb);
                 }
             },
             ControlTransferStage::ExpectFinalEventDataTrb => match variant {
@@ -701,9 +706,10 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
                         "invalid control transfer sequence; expected Setup Stage or Event Data Trb, got: {:?}",
                         other_trb
                     );
+
                     self.transfer_state.state = ControlTransferStage::ExpectSetupStageTrb;
                     self.submission_state =
-                        ControlSubmissionState::ParserConsumedTrb(trb.address, other_trb);
+                        ControlSubmissionState::UnexpectedTrb(trb.address, other_trb);
                 }
             },
         }
@@ -716,6 +722,21 @@ impl<RCEH: RealControlEndpointHandle> EndpointHandle for ControlEndpointHandle<R
             let result = match self.submission_state.clone() {
                 ControlSubmissionState::ParserConsumedTrb(address, variant) => {
                     trace!("consumed trb from address: {} as: {:?}", address, variant);
+                    TrbProcessingResult::Ok
+                }
+                ControlSubmissionState::UnexpectedTrb(address, variant) => {
+                    warn!("unexpected trb from address: {} as: {:?}", address, variant);
+
+                    let event = EventTrb::new_transfer_event_trb(
+                        address,
+                        0,
+                        CompletionCode::TrbError,
+                        false,
+                        self.endpoint_id,
+                        self.slot_id,
+                    );
+                    self.event_sender.send(event)?;
+
                     TrbProcessingResult::Ok
                 }
                 ControlSubmissionState::ParserError(address) => {

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -357,6 +357,7 @@ impl<RCEH: RealControlEndpointHandle> ControlEndpointHandle<RCEH> {
                 // TRBs) is equal to wLength. Note that communicating with some non-compliant
                 // devices may require violating this rule.
                 if usb_request.data.len() < transfer_length as usize {
+                    warn!("SetupStageTrb.wLength field mismatched while handling the actual and individual data slices.");
                     self.transfer_state.state = ControlTransferStage::ExpectStatusStageTrb;
                     self.transfer_state.event_meta.zero();
                     self.submission_state = ControlSubmissionState::ParserError(address);
@@ -2077,6 +2078,279 @@ pub mod tests {
         assert_eq!(
             interrupter.await_event().await,
             Some(expected_event(THIRD_ADDRESS, 0, false))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "assertion `left == right` failed: second trb")]
+    async fn submit_control_in_with_empty_wlength_but_have_transferred_data() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointReadStatic::new());
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            // use vendor specific theoretically spec violating data in wLength
+            .with_setup_wlength(0x0)
+            .with_immediate_data()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .with_byte(14, SETUP_TRANSFER_TYPE_IN_DATA)
+            .build();
+        let data_stage = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_data_pointer(DMA_POINTER_1)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_DATA_STAGE)
+            .with_direction()
+            .build();
+        let status_stage = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .with_direction()
+            .build();
+
+        let input_trb = vec![setup_stage, data_stage, status_stage];
+
+        for trb in input_trb.clone() {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(SECOND_ADDRESS, TRANSFER_LENGTH, false)),
+            "second trb"
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(THIRD_ADDRESS, 0, false))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "assertion `left == right` failed: second trb")]
+    async fn submit_control_out_with_empty_wlength_but_have_transferred_data() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointReadStatic::new());
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_OUT)
+            // use vendor specific theoretically spec violating data in wLength
+            .with_setup_wlength(0x0)
+            .with_immediate_data()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .with_byte(14, SETUP_TRANSFER_TYPE_IN_DATA)
+            .build();
+        let data_stage = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_data_pointer(DMA_POINTER_1)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_DATA_STAGE)
+            .build();
+        let status_stage = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .build();
+
+        let input_trb = vec![setup_stage, data_stage, status_stage];
+
+        for trb in input_trb.clone() {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(SECOND_ADDRESS, TRANSFER_LENGTH, false)),
+            "second trb"
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(THIRD_ADDRESS, 0, false))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "assertion `left == right` failed: third trb")]
+    async fn submit_control_in_with_less_wlength_than_expected_data() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointReadStatic::new());
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            // system software made a mistake; should be TRANSFER_LENGTH*3
+            .with_setup_wlength(SETUP_WLENGTH)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .build();
+        let data_stage = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_data_pointer(DMA_POINTER_1)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_chain()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_DATA_STAGE)
+            .with_direction()
+            .build();
+        // with the above mistake this trb will fail
+        let normal_1 = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_data_pointer(DMA_POINTER_2)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_chain()
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .build();
+        let normal_2 = RawTrbBuilder::new(FOURTH_ADDRESS)
+            .with_data_pointer(DMA_POINTER_3)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_NORMAL)
+            .build();
+        let status_stage = RawTrbBuilder::new(FIFTH_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .with_direction()
+            .build();
+
+        let input_trb = vec![setup_stage, data_stage, normal_1, normal_2, status_stage];
+
+        for trb in input_trb.clone() {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(SECOND_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                THIRD_ADDRESS,
+                0,
+                CompletionCode::TrbError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            )),
+            "third trb"
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                FOURTH_ADDRESS,
+                0,
+                CompletionCode::TrbError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                FIFTH_ADDRESS,
+                0,
+                CompletionCode::TrbError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            ))
+        );
+
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "assertion `left == right` failed: third trb")]
+    async fn submit_control_in_with_more_wlength_than_expected_data() {
+        let (mut interrupter, mut control_endpoint) =
+            init_control_endpoint_handle_test(MockRealControlEndpointReadStatic::new());
+
+        let setup_stage = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_setup_type(SETUP_BM_REQUEST_TYPE_IN)
+            // system software made a mistake; should be TRANSFER_LENGTH*3
+            .with_setup_wlength(SETUP_WLENGTH * 3)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_SETUP_STAGE)
+            .build();
+        let data_stage = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_data_pointer(DMA_POINTER_1)
+            .with_trb_transfer_length(TRANSFER_LENGTH)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_DATA_STAGE)
+            .with_direction()
+            .build();
+        let status_stage = RawTrbBuilder::new(FIFTH_ADDRESS)
+            .with_interrupt_on_completion()
+            .with_trb_type(TRB_TYPE_STATUS_STAGE)
+            .with_direction()
+            .build();
+
+        let input_trb = vec![setup_stage, data_stage, status_stage];
+
+        for trb in input_trb.clone() {
+            control_endpoint
+                .submit_trb(trb)
+                .expect("this mock hardware request should never fail");
+            assert_eq!(
+                control_endpoint.next_completion().await.ok(),
+                Some(TrbProcessingResult::Ok)
+            );
+        }
+
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(FIRST_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(expected_event(SECOND_ADDRESS, 0, false))
+        );
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_transfer_event_trb(
+                THIRD_ADDRESS,
+                0,
+                CompletionCode::TrbError,
+                false,
+                ENDPOINT_ID,
+                SLOT_ID,
+            )),
+            "third trb"
         );
 
         assert!(interrupter.is_empty());

--- a/src/device/xhci/nusb.rs
+++ b/src/device/xhci/nusb.rs
@@ -235,14 +235,13 @@ async fn control_endpoint_worker(
 
             let processing_result = match is_out_request {
                 true => {
-                    let data = request.data.unwrap_or(Vec::new());
                     let control = ControlOut {
                         control_type,
                         recipient,
                         request: request.request,
                         value: request.value,
                         index: request.index,
-                        data: &data,
+                        data: &request.data,
                     };
                     match device
                         .control_out(control, Duration::from_millis(2000))

--- a/src/device/xhci/real_device.rs
+++ b/src/device/xhci/real_device.rs
@@ -121,7 +121,8 @@ pub mod tests {
 
         use crate::device::xhci::{
             endpoint_handle::tests::testutils::{
-                MockRealControlEndpointReadStatic, MockRealInEndpoint, MockRealOutEndpoint,
+                MockRealControlEndpointReadStatic, MockRealInEndpointReadStatic,
+                MockRealOutEndpoint,
             },
             real_device,
         };
@@ -131,9 +132,9 @@ pub mod tests {
 
         impl RealDevice for MockRealDevice {
             type RCEH = MockRealControlEndpointReadStatic;
-            type RBIEH = MockRealInEndpoint;
+            type RBIEH = MockRealInEndpointReadStatic;
             type RBOEH = MockRealOutEndpoint;
-            type RIIEH = MockRealInEndpoint;
+            type RIIEH = MockRealInEndpointReadStatic;
             type RIOEH = MockRealOutEndpoint;
 
             fn speed(&self) -> Option<real_device::Speed> {
@@ -145,7 +146,7 @@ pub mod tests {
             }
 
             fn bulk_in_endpoint_handle(&self, _endpoint_id: u8) -> Self::RBIEH {
-                MockRealInEndpoint::new()
+                MockRealInEndpointReadStatic::new()
             }
 
             fn bulk_out_endpoint_handle(&self, _endpoint_id: u8) -> Self::RBOEH {
@@ -153,7 +154,7 @@ pub mod tests {
             }
 
             fn interrupt_in_endpoint_handle(&self, _endpoint_id: u8) -> Self::RIIEH {
-                MockRealInEndpoint::new()
+                MockRealInEndpointReadStatic::new()
             }
 
             fn interrupt_out_endpoint_handle(&self, _endpoint_id: u8) -> Self::RIOEH {

--- a/src/device/xhci/real_endpoint_handle.rs
+++ b/src/device/xhci/real_endpoint_handle.rs
@@ -44,7 +44,7 @@ pub trait RealInEndpointHandle: BaseEndpointHandle {
     fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum InTrbProcessingStatus {
     Disconnect,
     Stall,

--- a/src/device/xhci/real_endpoint_handle.rs
+++ b/src/device/xhci/real_endpoint_handle.rs
@@ -29,7 +29,7 @@ pub trait RealOutEndpointHandle: BaseEndpointHandle {
     fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum OutTrbProcessingResult {
     Disconnect,
     Stall,

--- a/src/device/xhci/real_endpoint_handle.rs
+++ b/src/device/xhci/real_endpoint_handle.rs
@@ -11,7 +11,7 @@ pub trait RealControlEndpointHandle: BaseEndpointHandle {
     fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ControlRequestProcessingResult {
     Disconnect,
     Stall,

--- a/src/device/xhci/trb.rs
+++ b/src/device/xhci/trb.rs
@@ -816,7 +816,7 @@ pub struct TransferTrb {
 /// Represents a TRB that the driver can place on a transfer ring.
 ///
 /// See XHCI specification Section 6.4.1 for detailed transfer TRB type descriptions.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TransferTrbVariant {
     Normal(NormalTrbData),
     SetupStage(SetupStageTrbData),
@@ -861,7 +861,7 @@ impl TransferTrbVariant {
 ///
 /// This struct contains only the commonly used fields from the Normal TRB.
 /// See XHCI specification Section 6.4.1.1 for the complete TRB layout.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalTrbData {
     pub data_pointer: u64,
     pub transfer_length: u32,
@@ -914,7 +914,7 @@ impl TrbData for NormalTrbData {
 /// Setup Stage TRB data structure.
 ///
 /// See XHCI specification Section 6.4.1.2.1 for detailed field descriptions.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetupStageTrbData {
     pub request_type: u8,
     pub request: u8,
@@ -962,7 +962,7 @@ impl TrbData for SetupStageTrbData {
 /// Data Stage TRB data structure.
 ///
 /// See XHCI specification Section 6.4.1.2.2 for detailed field descriptions.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataStageTrbData {
     pub data_pointer: u64,
     pub transfer_length: u16,
@@ -1015,7 +1015,7 @@ impl TrbData for DataStageTrbData {
 /// Status Stage TRB data structure.
 ///
 /// See XHCI specification Section 6.4.1.2.3 for detailed field descriptions.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StatusStageTrbData {
     pub chain: bool,
     pub interrupt_on_completion: bool,
@@ -1054,7 +1054,7 @@ impl TrbData for StatusStageTrbData {
 /// Event Data TRB data structure.
 ///
 /// See XHCI specification Section 6.4.4.2 for detailed field descriptions.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EventDataTrbData {
     pub event_data: u64,
     pub chain: bool,

--- a/src/device/xhci/trb.rs
+++ b/src/device/xhci/trb.rs
@@ -172,6 +172,7 @@ impl PortStatusChangeEventTrbData {
 #[derive(Debug, PartialEq, Eq)]
 pub struct TransferEventTrbData {
     trb_pointer: u64,
+    /// 24 Bit
     trb_transfer_length: u32,
     completion_code: CompletionCode,
     event_data: bool,

--- a/src/device/xhci/trb.rs
+++ b/src/device/xhci/trb.rs
@@ -818,14 +818,13 @@ pub struct TransferTrb {
 /// See XHCI specification Section 6.4.1 for detailed transfer TRB type descriptions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TransferTrbVariant {
-    Normal(NormalTrbData),
-    SetupStage(SetupStageTrbData),
-    DataStage(DataStageTrbData),
-    StatusStage(StatusStageTrbData),
+    Normal(NormalTrb),
+    SetupStage(SetupStageTrb),
+    DataStage(DataStageTrb),
+    StatusStage(StatusStageTrb),
     Isoch,
-    EventData(EventDataTrbData),
+    EventData(EventDataTrb),
     NoOp,
-    #[allow(unused)]
     Unrecognized(RawTrbBuffer, TrbParseError),
 }
 
@@ -862,8 +861,9 @@ impl TransferTrbVariant {
 /// This struct contains only the commonly used fields from the Normal TRB.
 /// See XHCI specification Section 6.4.1.1 for the complete TRB layout.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NormalTrbData {
+pub struct NormalTrb {
     pub data_pointer: u64,
+    /// 17 Bit
     pub transfer_length: u32,
     pub chain: bool,
     pub interrupt_on_completion: bool,
@@ -871,7 +871,7 @@ pub struct NormalTrbData {
     pub immediate_data: bool,
 }
 
-impl TrbData for NormalTrbData {
+impl TrbData for NormalTrb {
     /// Parse data of a Normal TRB.
     ///
     /// Only `TransferTrb::try_from` should call this function.
@@ -915,16 +915,17 @@ impl TrbData for NormalTrbData {
 ///
 /// See XHCI specification Section 6.4.1.2.1 for detailed field descriptions.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SetupStageTrbData {
+pub struct SetupStageTrb {
     pub request_type: u8,
     pub request: u8,
     pub value: u16,
     pub index: u16,
+    /// wLength
     pub length: u16,
     pub interrupt_on_completion: bool,
 }
 
-impl TrbData for SetupStageTrbData {
+impl TrbData for SetupStageTrb {
     /// Parse data of a Setup Stage TRB.
     ///
     /// Only `TransferTrb::try_from` should call this function.
@@ -963,16 +964,17 @@ impl TrbData for SetupStageTrbData {
 ///
 /// See XHCI specification Section 6.4.1.2.2 for detailed field descriptions.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DataStageTrbData {
+pub struct DataStageTrb {
     pub data_pointer: u64,
-    pub transfer_length: u16,
+    /// 17 Bit
+    pub transfer_length: u32,
     pub chain: bool,
     pub interrupt_on_completion: bool,
     pub immediate_data: bool,
     pub direction: bool,
 }
 
-impl TrbData for DataStageTrbData {
+impl TrbData for DataStageTrb {
     /// Parse data of a Data Stage TRB.
     ///
     /// Only `TransferTrb::try_from` should call this function.
@@ -993,8 +995,8 @@ impl TrbData for DataStageTrbData {
         let dp_bytes: [u8; 8] = trb_bytes[0..8].try_into().unwrap();
         let data_pointer = u64::from_le_bytes(dp_bytes);
 
-        let tl_bytes: [u8; 2] = trb_bytes[8..10].try_into().unwrap();
-        let transfer_length = u16::from_le_bytes(tl_bytes);
+        let tl_bytes: [u8; 4] = [trb_bytes[8], trb_bytes[9], trb_bytes[10] & 0x01, 0];
+        let transfer_length = u32::from_le_bytes(tl_bytes);
 
         let chain = trb_bytes[12] & 0x10 != 0;
         let interrupt_on_completion = trb_bytes[12] & 0x20 != 0;
@@ -1016,13 +1018,13 @@ impl TrbData for DataStageTrbData {
 ///
 /// See XHCI specification Section 6.4.1.2.3 for detailed field descriptions.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StatusStageTrbData {
+pub struct StatusStageTrb {
     pub chain: bool,
     pub interrupt_on_completion: bool,
     pub direction: bool,
 }
 
-impl TrbData for StatusStageTrbData {
+impl TrbData for StatusStageTrb {
     /// Parse data of a Status Stage TRB.
     ///
     /// Only `TransferTrb::try_from` should call this function.
@@ -1055,13 +1057,13 @@ impl TrbData for StatusStageTrbData {
 ///
 /// See XHCI specification Section 6.4.4.2 for detailed field descriptions.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EventDataTrbData {
+pub struct EventDataTrb {
     pub event_data: u64,
     pub chain: bool,
     pub interrupt_on_completion: bool,
 }
 
-impl TrbData for EventDataTrbData {
+impl TrbData for EventDataTrb {
     /// Parse data of a Event Data TRB.
     ///
     /// Only `TransferTrb::try_from` should call this function.
@@ -1439,7 +1441,7 @@ mod tests {
             0x11, 0x22, 0x44, 0x33, 0x66, 0x55, 0x88, 0x77, 0x12, 0x34, 0x00, 0x00, 0x34, 0x04,
             0x00, 0x00,
         ];
-        let expected = TransferTrbVariant::Normal(NormalTrbData {
+        let expected = TransferTrbVariant::Normal(NormalTrb {
             data_pointer: 0x7788556633442211,
             transfer_length: 0x3412,
             chain: true,
@@ -1456,7 +1458,7 @@ mod tests {
             0x11, 0x22, 0x44, 0x33, 0x66, 0x55, 0x88, 0x77, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08,
             0x00, 0x00,
         ];
-        let expected = TransferTrbVariant::SetupStage(SetupStageTrbData {
+        let expected = TransferTrbVariant::SetupStage(SetupStageTrb {
             request_type: 0x11,
             request: 0x22,
             value: 0x3344,
@@ -1473,7 +1475,7 @@ mod tests {
             0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x10, 0x00, 0x00, 0x00, 0x00, 0x0c,
             0x00, 0x00,
         ];
-        let expected = TransferTrbVariant::DataStage(DataStageTrbData {
+        let expected = TransferTrbVariant::DataStage(DataStageTrb {
             data_pointer: 0x1122334455667788,
             transfer_length: 0x0010,
             chain: false,
@@ -1490,7 +1492,7 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x10,
             0x01, 0x00,
         ];
-        let expected = TransferTrbVariant::StatusStage(StatusStageTrbData {
+        let expected = TransferTrbVariant::StatusStage(StatusStageTrb {
             chain: true,
             interrupt_on_completion: true,
             direction: true,
@@ -1504,7 +1506,7 @@ mod tests {
             0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x10, 0x00, 0x00, 0x00, 0x30, 0x1c,
             0x00, 0x00,
         ];
-        let expected = TransferTrbVariant::EventData(EventDataTrbData {
+        let expected = TransferTrbVariant::EventData(EventDataTrb {
             event_data: 0x1122334455667788,
             chain: true,
             interrupt_on_completion: true,

--- a/src/device/xhci/trb.rs
+++ b/src/device/xhci/trb.rs
@@ -11,7 +11,7 @@ use super::super::pci::constants::xhci::rings::trb_types::{self, *};
 /// of a Transfer Request Block.
 pub type RawTrbBuffer = [u8; 16];
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RawTrb {
     pub address: u64,
     pub buffer: RawTrbBuffer,
@@ -856,6 +856,13 @@ impl TransferTrbVariant {
     }
 }
 
+/// All necessary information of a data source/target for DMA or immediate data.
+pub trait TrbDmaInfo {
+    fn data_pointer(&self) -> u64;
+    fn transfer_length(&self) -> u32;
+    fn has_immediate_data(&self) -> bool;
+}
+
 /// Normal TRB data structure (simplified representation).
 ///
 /// This struct contains only the commonly used fields from the Normal TRB.
@@ -908,6 +915,18 @@ impl TrbData for NormalTrb {
             interrupt_on_short,
             immediate_data,
         })
+    }
+}
+
+impl TrbDmaInfo for NormalTrb {
+    fn data_pointer(&self) -> u64 {
+        self.data_pointer
+    }
+    fn transfer_length(&self) -> u32 {
+        self.transfer_length
+    }
+    fn has_immediate_data(&self) -> bool {
+        self.immediate_data
     }
 }
 
@@ -1011,6 +1030,18 @@ impl TrbData for DataStageTrb {
             immediate_data,
             direction,
         })
+    }
+}
+
+impl TrbDmaInfo for DataStageTrb {
+    fn data_pointer(&self) -> u64 {
+        self.data_pointer
+    }
+    fn transfer_length(&self) -> u32 {
+        self.transfer_length
+    }
+    fn has_immediate_data(&self) -> bool {
+        self.immediate_data
     }
 }
 

--- a/src/device/xhci/trb.rs
+++ b/src/device/xhci/trb.rs
@@ -805,15 +805,6 @@ impl TrbData for ResetDeviceCommandTrbData {
 }
 
 /// Represents a TRB that the driver can place on a transfer ring.
-#[derive(Debug, PartialEq, Eq)]
-pub struct TransferTrb {
-    /// Guest memory address where the driver placed the TRB.
-    pub address: u64,
-    /// Information specific to the particular transfer TRB variant.
-    pub variant: TransferTrbVariant,
-}
-
-/// Represents a TRB that the driver can place on a transfer ring.
 ///
 /// See XHCI specification Section 6.4.1 for detailed transfer TRB type descriptions.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -881,7 +872,7 @@ pub struct NormalTrb {
 impl TrbData for NormalTrb {
     /// Parse data of a Normal TRB.
     ///
-    /// Only `TransferTrb::try_from` should call this function.
+    /// Only `TransferTrbVariant::try_from` should call this function.
     ///
     /// # Limitations
     ///
@@ -947,7 +938,7 @@ pub struct SetupStageTrb {
 impl TrbData for SetupStageTrb {
     /// Parse data of a Setup Stage TRB.
     ///
-    /// Only `TransferTrb::try_from` should call this function.
+    /// Only `TransferTrbVariant::try_from` should call this function.
     ///
     /// # Limitations
     ///
@@ -996,7 +987,7 @@ pub struct DataStageTrb {
 impl TrbData for DataStageTrb {
     /// Parse data of a Data Stage TRB.
     ///
-    /// Only `TransferTrb::try_from` should call this function.
+    /// Only `TransferTrbVariant::try_from` should call this function.
     ///
     /// # Limitations
     ///
@@ -1058,7 +1049,7 @@ pub struct StatusStageTrb {
 impl TrbData for StatusStageTrb {
     /// Parse data of a Status Stage TRB.
     ///
-    /// Only `TransferTrb::try_from` should call this function.
+    /// Only `TransferTrbVariant::try_from` should call this function.
     ///
     /// # Limitations
     ///
@@ -1097,7 +1088,7 @@ pub struct EventDataTrb {
 impl TrbData for EventDataTrb {
     /// Parse data of a Event Data TRB.
     ///
-    /// Only `TransferTrb::try_from` should call this function.
+    /// Only `TransferTrbVariant::try_from` should call this function.
     ///
     /// # Limitations
     ///

--- a/src/device/xhci/usbrequest.rs
+++ b/src/device/xhci/usbrequest.rs
@@ -22,7 +22,7 @@ pub struct UsbRequest {
     pub index: u16,
     pub length: u16,
     pub data_pointer: Option<u64>,
-    pub data: Option<Vec<u8>>,
+    pub data: Vec<u8>,
 }
 
 impl UsbRequest {
@@ -37,7 +37,7 @@ impl UsbRequest {
             index: self.index,
             length: self.length,
             data_pointer: self.data_pointer,
-            data: None,
+            data: vec![],
         }
     }
 }

--- a/src/device/xhci/usbrequest.rs
+++ b/src/device/xhci/usbrequest.rs
@@ -2,16 +2,10 @@
 
 /// Represents a USB control request.
 ///
-/// For documentation of the fields other than `address`, see Section "9.3 USB
+/// See xhci specification chapter 6.4.1.2.
+///
+/// For additional documentation of the fields other than `address`, see Section "9.3 USB
 /// Device Requests" in the USB 2.0 specification.
-///
-/// A request without data is packaged in two TRBs (a Setup Stage and a
-/// Status Stage). `data` should then be `None`.
-///
-/// A request with data is packaged in three TRBs (a Setup Stage, a Data
-/// Stage and a Status Stage). `data` should then contain the pointer
-/// from the Data Stage).
-///
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct UsbRequest {
     /// The guest address of the Status Stage of this request.
@@ -23,21 +17,4 @@ pub struct UsbRequest {
     pub length: u16,
     pub data_pointer: Option<u64>,
     pub data: Vec<u8>,
-}
-
-impl UsbRequest {
-    // so that the control endpoint handler can make a copy
-    // (to store the request between submit_trb and next_complete)
-    pub const fn clone_without_data(&self) -> Self {
-        Self {
-            address: self.address,
-            request_type: self.request_type,
-            request: self.request,
-            value: self.value,
-            index: self.index,
-            length: self.length,
-            data_pointer: self.data_pointer,
-            data: vec![],
-        }
-    }
 }


### PR DESCRIPTION
Windows is never (as far as I saw in logs at least) utilizing the interrupt on completion bit. Windows will instead use event data trb.

The event data appeared on the Control Endpoint and the handler is initially written for the Control Endpoint.

When NormalIn and NormalOut Endpoints also needed event data handling I vendored the handle functions into the respective NormalEndpoint implementations because it seemed easiest. Combining this so that any endpoint can call the same handle_event_data seems better/less error prone.
Should that be added to this PR?