### PR TITLE
hotplug_endpoint_handle: stop detach handler when handle drops

### DIFF
--- a/src/device/xhci/hotplug_endpoint_handle.rs
+++ b/src/device/xhci/hotplug_endpoint_handle.rs
@@ -60,6 +60,7 @@ pub struct HotplugEndpointHandleImpl<EH: EndpointHandle> {
     endpoint_handle: Arc<Mutex<Option<EH>>>,
     event_sender: EventSender,
     notify_detach: CancellationToken,
+    notify_drop: CancellationToken,
     submission_state: HotplugSubmissionState,
 }
 
@@ -81,10 +82,12 @@ impl<EH: EndpointHandle> HotplugEndpointHandleImpl<EH> {
         async_runtime: &runtime::Handle,
     ) -> Self {
         let endpoint_handle = Arc::new(Mutex::new(Some(endpoint_handle)));
+        let notify_drop = CancellationToken::new();
 
         async_runtime.spawn(Self::detach_handler(
             endpoint_handle.clone(),
             notify_detach.clone(),
+            notify_drop.clone(),
         ));
 
         Self {
@@ -93,6 +96,7 @@ impl<EH: EndpointHandle> HotplugEndpointHandleImpl<EH> {
             endpoint_handle,
             event_sender,
             notify_detach,
+            notify_drop,
             submission_state: HotplugSubmissionState::NoTrbSubmitted,
         }
     }
@@ -102,10 +106,22 @@ impl<EH: EndpointHandle> HotplugEndpointHandleImpl<EH> {
     async fn detach_handler(
         endpoint_handle: Arc<Mutex<Option<EH>>>,
         notify_detach: CancellationToken,
+        notify_drop: CancellationToken,
     ) {
-        notify_detach.cancelled().await;
-        let mut ep = endpoint_handle.lock().await;
-        *ep = None;
+        select! {
+            _ = notify_drop.cancelled() => {}
+            _ = notify_detach.cancelled() => {
+                let mut ep = endpoint_handle.lock().await;
+                *ep = None;
+            }
+        }
+    }
+}
+
+impl<EH: EndpointHandle> Drop for HotplugEndpointHandleImpl<EH> {
+    fn drop(&mut self) {
+        // make sure that detach_handler also stops
+        self.notify_drop.cancel();
     }
 }
 
@@ -238,6 +254,8 @@ impl HotplugEndpointHandleImpl<DummyEndpointHandle> {
             submission_state: HotplugSubmissionState::NoTrbSubmitted,
             // just a dummy; nobody will notify, nobody listens
             notify_detach: CancellationToken::new(),
+            // just a dummy; the drop implementation will notify, but nobody listens
+            notify_drop: CancellationToken::new(),
         }
     }
 }


### PR DESCRIPTION
This PR fixes a bug, which caused us to leak `EndpointHandle` instances.

Our expectation is that sending a Terminate message to an `EndpointWorker` causes the worker to stop running and drop itself, which in turn should clean up everything that belongs to the worker. Most importantly, the `EndpointWorker` holds a `HotplugEndpointHandle`, which holds an `EndpointHandle`, which holds an instance of one of the real endpoint handle traits.

Right now, the behavior is different: `EndpointWorker` stops as expected, which also correctly drops the `HotplugEndpointHandle`. However, the contained `EndpointHandle` is not solely owned by the `HotplugEndpointHandle`, it is wrappend in `Arc<Mutex<...>>>` and the `detach_handler` task holds another copy. So, we drop one instance of the `Arc`, but the other remains alive and thus prevents the drop of `EndpointHandle` and the contained real endpoint handle.

We do hit this bug probably on every device attach, but the leak is not very problematic in our test scenarios. USB stick as an example, with endpoints 3 and 4 as the bulk endpoints: The linux driver issues a ConfigureEndpoint command with A3 and A4 flags set first; we launch two endpoint workers accordingly. Then, the driver issues a ConfigureEndpoint command with D3 and A3 flags. So, we terminate the endpoint-3 worker and then start a new endpoint worker. We now have an `EndpointHandle` and a real endpoint handle hanging around. We get away with their existence, because we lazily open nusb endpoints (i.e., on the first TRB submission) and there was no submission in the mean time. The same then happens for endpoint 4 on the third ConfigureEndpoint command. When we detach device, then `detach_handler` triggers and releases the second `Arc`, so the clean up on device detach is proper.

The issue would arise when the driver configures an endpoint, submits TRBs, then deconfigures and reconfigures the endpoint and tries to submit TRBs again. The lazy endpoint opening will try to open the nusb endpoint, which the leaked `Arc` still has exclusive access to. We have seen the error message before when something else went wrong, the driver tried a device reset and reconfigured the previously used endpoints.

I spotted the bug in a debug session with @Noi0103, who experimented with rewriting the nusb-endpoint code to use [reader](https://docs.rs/nusb/latest/nusb/struct.Endpoint.html#method.reader). He opened the endpoint and reader on startup instead of on the first submission, which caused the nusb-endpoint-claim error to occur in the second ConfigureEndpoint command (which stops and restarts one of the endpoints).