### PR TITLE
Use RUST_BACKTRACE=full for the usbvfiod systemd service in integration tests

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -549,6 +549,9 @@ let
                 } --socket-path ${usbvfiodSocket} --hotplug-socket-path ${usbvfiodSocketHotplug} ${lib.concatStringsSep " " (builtins.map mkDeviceFlag args.virtualDevices)}
               '';
             };
+            environment = {
+              RUST_BACKTRACE = "full";
+            };
           };
 
           cloud-hypervisor =


### PR DESCRIPTION
More information in failed tests should be nice to have.