### PR TITLE
Centralize port ID offsetting in MMIO helpers

### DIFF
--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -16,7 +16,7 @@ use crate::device::{
     },
     xhci::{
         endpoint_launcher::EndpointLauncher,
-        port::{get_portli_index, get_portpmsc_index, get_portsc_index, HotplugControl, PortArray},
+        port::{get_portli_id, get_portpmsc_id, get_portsc_id, HotplugControl, PortArray},
         real_device::CompleteRealDevice,
         registers::{UsbcmdRegister, UsbstsRegister},
         slot_manager::SlotManager,
@@ -154,21 +154,17 @@ impl<CRD: CompleteRealDevice> PciDevice for XhciController<CRD> {
                     .doorbell(slot_id, value as u8)
                     .expect("slot worker should be alive");
             }
-            addr if get_portsc_index(addr).is_some() => {
+            addr if get_portsc_id(addr).is_some() => {
                 // SAFETY: unwrap() is safe because we already checked is_some() in the match guard above
-                let port_index = get_portsc_index(addr).unwrap();
-                // port ids start at 1, so we have to convert the MMIO address offset to the id
-                let port_id = port_index + 1;
+                let port_id = get_portsc_id(addr).unwrap();
                 self.port_array
                     .write_portsc(port_id, value)
                     .expect("event_sender should be alive");
             }
 
-            addr if get_portpmsc_index(addr).is_some() => {
+            addr if get_portpmsc_id(addr).is_some() => {
                 // SAFETY: unwrap() is safe because we already checked is_some() in the match guard above
-                let port_index = get_portpmsc_index(addr).unwrap();
-                // port ids start at 1, so we have to convert the MMIO address offset to the id
-                let port_id = port_index + 1;
+                let port_id = get_portpmsc_id(addr).unwrap();
                 // SAFETY: The PORTPMSC is defined as 32 bit
                 self.port_array.write_portpmsc(port_id, value as u32);
             }
@@ -234,25 +230,21 @@ impl<CRD: CompleteRealDevice> PciDevice for XhciController<CRD> {
             offset::MFINDEX => 0x0,
 
             // Port Status and Control Register (PORTSC)
-            addr if get_portsc_index(addr).is_some() => {
+            addr if get_portsc_id(addr).is_some() => {
                 // SAFETY: unwrap() is safe because we already checked is_some() in the match guard above
-                let port_index = get_portsc_index(addr).unwrap();
-                // port ids start at 1, so we have to convert the MMIO address offset to the id
-                let port_id = port_index + 1;
+                let port_id = get_portsc_id(addr).unwrap();
                 self.port_array.read_portsc(port_id)
             }
 
             // Port Power Management Status and Control (PORTPMSC)
-            addr if get_portpmsc_index(addr).is_some() => {
+            addr if get_portpmsc_id(addr).is_some() => {
                 // SAFETY: unwrap() is safe because we already checked is_some() in the match guard above
-                let port_index = get_portpmsc_index(addr).unwrap();
-                // port ids start at 1, so we have to convert the MMIO address offset to the id
-                let port_id = port_index + 1;
+                let port_id = get_portpmsc_id(addr).unwrap();
                 self.port_array.read_portpmsc(port_id) as u64
             }
 
             // Port Link Info Register (PORTLI_USB3)
-            addr if get_portli_index(addr).is_some() => 0,
+            addr if get_portli_id(addr).is_some() => 0,
 
             // Everything else is Reserved Zero
             addr => {

--- a/src/device/xhci/port.rs
+++ b/src/device/xhci/port.rs
@@ -307,8 +307,8 @@ impl UsbVersion {
     }
 }
 
-// Helper function to get port index from MMIO address
-const fn get_port_index_from_addr(
+// Helper function to get port id from MMIO address
+const fn get_port_id_from_addr(
     addr: u64,
     base_addr: u64,
     port_count: u64,
@@ -317,7 +317,7 @@ const fn get_port_index_from_addr(
     if addr >= base_addr && addr < base_addr + (port_count * offset::PORT_STRIDE) {
         // Check if this is the correct register within the port's PORT_STRIDE byte range
         if (addr - base_addr) % offset::PORT_STRIDE == register_offset {
-            Some(((addr - base_addr) / offset::PORT_STRIDE) as usize)
+            Some(((addr - base_addr) / offset::PORT_STRIDE) as usize + 1)
         } else {
             None
         }
@@ -326,16 +326,16 @@ const fn get_port_index_from_addr(
     }
 }
 
-pub const fn get_portsc_index(addr: u64) -> Option<usize> {
-    get_port_index_from_addr(addr, offset::PORTSC, MAX_PORTS, 0)
+pub const fn get_portsc_id(addr: u64) -> Option<usize> {
+    get_port_id_from_addr(addr, offset::PORTSC, MAX_PORTS, 0)
 }
 
-pub const fn get_portpmsc_index(addr: u64) -> Option<usize> {
-    get_port_index_from_addr(addr, offset::PORTSC, MAX_PORTS, 0x4)
+pub const fn get_portpmsc_id(addr: u64) -> Option<usize> {
+    get_port_id_from_addr(addr, offset::PORTSC, MAX_PORTS, 0x4)
 }
 
-pub const fn get_portli_index(addr: u64) -> Option<usize> {
-    get_port_index_from_addr(addr, offset::PORTSC, MAX_PORTS, 0x8)
+pub const fn get_portli_id(addr: u64) -> Option<usize> {
+    get_port_id_from_addr(addr, offset::PORTSC, MAX_PORTS, 0x8)
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This updates the xHCI port MMIO helpers to return one-based port IDs instead of zero-based port indices.
It follows up on the discussion in [previous PR](https://github.com/cyberus-technology/usbvfiod/pull/236#discussion_r3189701323).

`PortArray` uses `OneIndexed` storage and its `PORTSC` / `PORTPMSC` accessors already expect xHCI port IDs. The MMIO path was previously converting the helper result with `port_index + 1` at each call site. This change moves that conversion into the address helper itself and renames the public helpers from `*_index` to `*_id` to match the actual semantics.