### PR TITLE
Async normal in endpoint reader as background task

### DIFF
--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -557,6 +557,12 @@ impl<ROEH: RealOutEndpointHandle> BaseEndpointHandle for OutEndpointHandle<ROEH>
     }
 }
 
+impl<RIEH: RealInEndpointHandle> Drop for InEndpointHandle<RIEH> {
+    fn drop(&mut self) {
+        trace!("called <RIEH: RealInEndpointHandle> Drop for InEndpointHandle<RIEH>");
+    }
+}
+
 #[derive(Debug)]
 pub struct InEndpointHandle<RIEH: RealInEndpointHandle> {
     slot_id: u8,

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, future::Future, mem, ops::ControlFlow, pin::Pin};
 
-use tracing::debug;
+use tracing::{debug, trace};
 
 use crate::device::{
     bus::BusDeviceRef,

--- a/src/device/xhci/nusb.rs
+++ b/src/device/xhci/nusb.rs
@@ -569,9 +569,12 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt>(
     // seconds * N
     const NUSB_TIMEOUT: u64 = 1000 * 20;
 
+    let size = endpoint.max_packet_size();
+
     let mut reader = endpoint
         // 1KB * 10
-        .reader(512 * 2 * 10) // maybe 16MB since that should be the max buffering the edtla can do
+        //.reader(512 * 2 * 10) // maybe 16MB since that should be the max buffering the edtla can do
+        .reader(size) // maybe 16MB since that should be the max buffering the edtla can do
         .with_num_transfers(1)
         .with_read_timeout(Duration::from_millis(NUSB_TIMEOUT));
     let mut pkt_reader = reader.until_short_packet();
@@ -594,6 +597,15 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt>(
             // do reading until end aka short or null package
             let read_length = if requested_length > buffer.len() {
                 trace!("attempting a read");
+
+                loop {
+                    // read
+
+                    // if EOF, clear end and break and send
+                    // if requested_length on interrupt on usb 1.1 break and return
+
+                    break;
+                }
 
                 match pkt_reader.read_to_end(&mut buffer).await {
                     Ok(read_length) => {

--- a/src/device/xhci/nusb.rs
+++ b/src/device/xhci/nusb.rs
@@ -1,4 +1,6 @@
-use std::{fmt::Debug, future::Future, pin::Pin, sync::Arc, thread::sleep, time::Duration};
+use std::{
+    cmp::min, fmt::Debug, future::Future, pin::Pin, sync::Arc, thread::sleep, time::Duration,
+};
 
 use anyhow::{anyhow, Error};
 use nusb::{
@@ -245,6 +247,8 @@ async fn control_endpoint_worker(
             let processing_result = match is_out_request {
                 true => {
                     let data = request.data.unwrap_or(Vec::new());
+                    error!("nusb file: doing controlout");
+
                     let control = ControlOut {
                         control_type,
                         recipient,
@@ -253,12 +257,16 @@ async fn control_endpoint_worker(
                         index: request.index,
                         data: &data,
                     };
+                    error!("{:?}", control);
                     match device
                         .control_out(control, Duration::from_millis(2000))
                         .await
                     {
                         Ok(_) => ControlRequestProcessingResult::SuccessfulControlOut,
-                        Err(err) => map_error(err),
+                        Err(err) => {
+                            error!("mapping {:?}", err);
+                            map_error(err)
+                        }
                     }
                 }
                 false => {
@@ -598,13 +606,12 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
                 info!("current buffer length: {}", buffer.len());
 
                 // do reading until end aka short or null package
-                let read_length = if requested_length > buffer.len() {
+                let read_length = if requested_length > buffer.len() && !pkt_reader.is_end() {
                     info!("attempting a read");
 
                     match pkt_reader.read_to_end(&mut buffer).await {
                         Ok(read_length) => {
                             trace!("we have a return value from the reader {}", read_length);
-                            let _ = pkt_reader.consume_end();
                             Some(read_length)
                         }
                         Err(e) if e.kind() == tokio::io::ErrorKind::OutOfMemory => {
@@ -631,7 +638,13 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
                     }
                 } else {
                     // from buffer only
-                    requested_bytes = buffer.drain(..requested_length).collect();
+                    requested_bytes = buffer
+                        .drain(..min(buffer.len(), requested_length))
+                        .collect();
+                }
+
+                if buffer.is_empty() && pkt_reader.is_end() {
+                    let _ = pkt_reader.consume_end();
                 }
 
                 debug!("the responded bytes len: {:?}", requested_bytes.len());

--- a/src/device/xhci/nusb.rs
+++ b/src/device/xhci/nusb.rs
@@ -10,7 +10,7 @@ use nusb::{
 };
 use tokio::{io::AsyncReadExt, runtime, select, sync::mpsc};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::device::xhci::{
     hotplug_endpoint_handle::BaseEndpointHandle,
@@ -517,8 +517,7 @@ impl BaseEndpointHandle for NormalInEndpointHandle {
     }
 
     fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
-        // nusb handles clearing halts on control endpoints by itself
-        Box::pin(async { Ok(()) })
+        Box::pin(async { todo!("clear halt") })
     }
 }
 
@@ -546,7 +545,7 @@ impl NormalInEndpointHandle {
     }
 }
 
-async fn cancellable_normal_in_endpoint_worker<EpType: BulkOrInterrupt>(
+async fn cancellable_normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
     endpoint: nusb::Endpoint<EpType, In>,
     request_receiver: mpsc::UnboundedReceiver<usize>,
     response_submitter: mpsc::UnboundedSender<Vec<u8>>,
@@ -559,125 +558,195 @@ async fn cancellable_normal_in_endpoint_worker<EpType: BulkOrInterrupt>(
 }
 
 // this function can only return with an error, but ! cannot be used in Result
-async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt>(
+async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
     endpoint: nusb::Endpoint<EpType, In>,
     mut request_receiver: mpsc::UnboundedReceiver<usize>,
-    response_submitter: mpsc::UnboundedSender<Vec<u8>>,
+    response_submitter: mpsc::UnboundedSender<Vec<u8>>, // TODO into a processing result instead of a vec u8?
 ) -> anyhow::Result<()> {
+    use nusb::transfer::{Bulk, Interrupt};
+    use std::any::TypeId;
+
     // seconds * N
-    const NUSB_TIMEOUT: u64 = 1000 * 20;
+    const NUSB_TIMEOUT: u64 = 1000 * 200;
 
-    let size = endpoint.max_packet_size();
+    let mut reader;
+    let size;
 
-    let mut reader = endpoint
-        // 1KB * 10
-        //.reader(512 * 2 * 10) // maybe 16MB since that should be the max buffering the edtla can do
-        .reader(size) // maybe 16MB since that should be the max buffering the edtla can do
-        .with_num_transfers(1)
-        .with_read_timeout(Duration::from_millis(NUSB_TIMEOUT));
-    let mut pkt_reader = reader.until_short_packet();
+    if TypeId::of::<EpType>() == TypeId::of::<Bulk>() {
+        info!("creating normal in worker for bulk");
+        size = 512 * 2 * 5;
+        reader = endpoint
+            .reader(size)
+            .with_num_transfers(1)
+            .with_read_timeout(Duration::from_millis(NUSB_TIMEOUT));
 
-    let mut buffer = Vec::new();
+        let mut pkt_reader = reader.until_short_packet();
 
-    let mut debug_counter = 0;
+        let mut buffer = Vec::new();
 
-    loop {
-        debug_counter += 1;
-        trace!(
-            "normal_in_endpoint_worker loop; counter at {}",
-            debug_counter
-        );
+        let mut debug_counter = 0;
 
-        if let Some(requested_length) = request_receiver.recv().await {
-            debug!("original requested length: {requested_length}");
-            debug!("current buffer length: {}", buffer.len());
+        loop {
+            debug_counter += 1;
+            trace!(
+                "normal_in_endpoint_worker loop; counter at {}",
+                debug_counter
+            );
 
-            // do reading until end aka short or null package
-            let read_length = if requested_length > buffer.len() {
-                trace!("attempting a read");
+            if let Some(requested_length) = request_receiver.recv().await {
+                info!("original requested length: {requested_length}");
+                info!("current buffer length: {}", buffer.len());
 
-                let mut read_sum = 0;
-                loop {
-                    // read
-                    let mut hardware_used_buffer: Vec<u8> = vec![0; size];
+                // do reading until end aka short or null package
+                let read_length = if requested_length > buffer.len() {
+                    info!("attempting a read");
 
-                    let read_length = match pkt_reader.read(&mut hardware_used_buffer).await {
-                        Ok(length) => length,
-                        Err(e) => panic!("read failed: {e:?}"),
-                    };
-
-                    // move from hardware_used_buffer to buffer that will return bytes
-                    //   get slice of hardware_used_buffer according to read_length
-                    //   now we dont care about hardware_used_buffer any more
-                    //   append the slice to our own buffer
-                    //     check if this is possible: we might read more than currently requested -> is possible since max packet is 1024 and min is 512 so it could read 512 bytes too early
-
-                    buffer.append(&mut hardware_used_buffer.split_off(read_length));
-
-                    read_sum += read_length;
-
-                    // if EOF, clear end and break and send
-                    // necessary for short packet handling
-                    if read_length == 0 && pkt_reader.is_end() {
-                        info!("reached EOF, consuming end to continue on next request");
-                        let _ = pkt_reader.consume_end();
-                        break;
+                    match pkt_reader.read_to_end(&mut buffer).await {
+                        Ok(read_length) => {
+                            trace!("we have a return value from the reader {}", read_length);
+                            let _ = pkt_reader.consume_end();
+                            Some(read_length)
+                        }
+                        Err(e) if e.kind() == tokio::io::ErrorKind::OutOfMemory => {
+                            // TODO does a max length for a td exist? -> maybe the 16MB being the edtla limit
+                            panic!("normal in buffer OOM: {e}");
+                        }
+                        Err(e) => panic!("in endpoint reader error: {e}"),
                     }
-
-                    // if requested_length full break and return
-                    // necessary for interrupt ep with no EOF like usb 1.1
-                    if read_length == 0 && read_sum >= requested_length {
-                        info!("read what we needed, rest until EOF is not yet read");
-                        break;
-                    }
-                }
-                Some(read_sum)
-
-                /*
-                match pkt_reader.read_to_end(&mut buffer).await {
-                    Ok(read_length) => {
-                        trace!("we have a return value from the reader {}", read_length);
-                        let _ = pkt_reader.consume_end();
-                        Some(read_length)
-                    }
-                    Err(e) if e.kind() == ErrorKind::OutOfMemory => {
-                        // TODO does a max length for a td exist? -> maybe the 16MB being the edtla limit
-                        panic!("normal in buffer OOM: {e}");
-                    }
-                    Err(e) => panic!("in endpoint reader error: {e}"),
-                }
-                */
-            } else {
-                trace!("skipping hardware request");
-                None
-            };
-
-            // collect data to return
-            let requested_bytes: Vec<u8>;
-            if let Some(length) = read_length {
-                // hardware read happened
-                if length < requested_length {
-                    // got short packet
-                    requested_bytes = buffer.drain(..length).collect();
                 } else {
-                    // received at least full requested length
+                    warn!("skipping hardware request");
+                    None
+                };
+
+                // collect data to return
+                let requested_bytes: Vec<u8>;
+                if let Some(length) = read_length {
+                    // hardware read happened
+                    if length < requested_length {
+                        // got short packet
+                        requested_bytes = buffer.drain(..length).collect();
+                    } else {
+                        // received at least full requested length
+                        requested_bytes = buffer.drain(..requested_length).collect();
+                    }
+                } else {
+                    // from buffer only
                     requested_bytes = buffer.drain(..requested_length).collect();
                 }
+
+                debug!("the responded bytes len: {:?}", requested_bytes.len());
+                debug!("remaining buffer length: {}", buffer.len());
+
+                // ...and return it
+                response_submitter.send(requested_bytes)?;
             } else {
-                // from buffer only
-                requested_bytes = buffer.drain(..requested_length).collect();
+                warn!("received a none from the request_receiver, this worker is dead");
+                // kill task itself
+                return anyhow::Ok(());
             }
-
-            debug!("the responded bytes len: {:?}", requested_bytes.len());
-            debug!("remaining buffer length: {}", buffer.len());
-
-            // ...and return it
-            response_submitter.send(requested_bytes)?;
-        } else {
-            warn!("received a none from the request_receiver, this worker is dead");
-            // kill task itself
-            return anyhow::Ok(());
+            trace!("one loop done");
         }
-        trace!("one loop done");
+    } else if TypeId::of::<EpType>() == TypeId::of::<Interrupt>() {
+        info!("creating normal in worker for interrupt");
+        size = endpoint.max_packet_size();
+        reader = endpoint
+            .reader(size)
+            .with_num_transfers(8)
+            .with_read_timeout(Duration::from_millis(NUSB_TIMEOUT));
+        let mut pkt_reader = reader.until_short_packet();
+
+        let mut buffer = Vec::new();
+
+        let mut debug_counter = 0;
+
+        loop {
+            debug_counter += 1;
+            trace!(
+                "normal_in_endpoint_worker loop; counter at {}",
+                debug_counter
+            );
+
+            if let Some(requested_length) = request_receiver.recv().await {
+                info!("original requested length: {requested_length}");
+                info!("current buffer length: {}", buffer.len());
+
+                // do reading until end aka short or null package
+                let read_length = if requested_length > buffer.len() {
+                    info!("attempting a read");
+
+                    let mut read_sum = 0;
+                    loop {
+                        info!("reading loop");
+
+                        // read
+                        let mut hardware_used_buffer: Vec<u8> = vec![0; size];
+
+                        let read_length = match pkt_reader.read(&mut hardware_used_buffer).await {
+                            Ok(length) => length,
+                            Err(err) => {
+                                error!("read failed: {err:?}");
+                                //processing_result = map_in_err(err);
+                                //panic!("read failed: {err:?}");
+                                0
+                            }
+                        };
+
+                        info!("read {read_length} characters: {hardware_used_buffer:?}");
+
+                        if pkt_reader.is_end() {
+                            info!("reached EOF, consuming end to continue on next request");
+                            let _ = pkt_reader.consume_end();
+                            break;
+                        }
+
+                        info!("buffer.append");
+                        buffer.append(&mut hardware_used_buffer.drain(0..(read_length)).collect());
+                        read_sum += read_length;
+
+                        info!("read sum is {}", read_sum);
+
+                        // if requested_length full break and return
+                        // necessary for interrupt ep with no EOF like usb 1.1
+                        if read_sum >= requested_length {
+                            info!("read what we needed, rest until EOF is not yet read");
+                            break;
+                        }
+                    }
+                    Some(read_sum)
+                } else {
+                    warn!("skipping hardware request");
+                    None
+                };
+
+                // collect data to return
+                let requested_bytes: Vec<u8>;
+                if let Some(length) = read_length {
+                    // hardware read happened
+                    if length < requested_length {
+                        // got short packet
+                        requested_bytes = buffer.drain(..length).collect();
+                    } else {
+                        // received at least full requested length
+                        requested_bytes = buffer.drain(..requested_length).collect();
+                    }
+                } else {
+                    // from buffer only
+                    requested_bytes = buffer.drain(..requested_length).collect();
+                }
+
+                debug!("the responded bytes len: {:?}", requested_bytes.len());
+                debug!("remaining buffer length: {}", buffer.len());
+
+                // ...and return it
+                response_submitter.send(requested_bytes)?;
+            } else {
+                warn!("received a none from the request_receiver, this worker is dead");
+                // kill task itself
+                return anyhow::Ok(());
+            }
+            trace!("one loop done");
+        }
+    } else {
+        unreachable!("");
     }
 }

--- a/src/device/xhci/nusb.rs
+++ b/src/device/xhci/nusb.rs
@@ -1,6 +1,4 @@
-use std::{
-    fmt::Debug, future::Future, io::ErrorKind, pin::Pin, sync::Arc, thread::sleep, time::Duration,
-};
+use std::{fmt::Debug, future::Future, pin::Pin, sync::Arc, thread::sleep, time::Duration};
 
 use anyhow::{anyhow, Error};
 use nusb::{
@@ -12,7 +10,7 @@ use nusb::{
 };
 use tokio::{io::AsyncReadExt, runtime, select, sync::mpsc};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::device::xhci::{
     hotplug_endpoint_handle::BaseEndpointHandle,
@@ -598,15 +596,44 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt>(
             let read_length = if requested_length > buffer.len() {
                 trace!("attempting a read");
 
+                let mut read_sum = 0;
                 loop {
                     // read
+                    let mut hardware_used_buffer: Vec<u8> = vec![0; size];
+
+                    let read_length = match pkt_reader.read(&mut hardware_used_buffer).await {
+                        Ok(length) => length,
+                        Err(e) => panic!("read failed: {e:?}"),
+                    };
+
+                    // move from hardware_used_buffer to buffer that will return bytes
+                    //   get slice of hardware_used_buffer according to read_length
+                    //   now we dont care about hardware_used_buffer any more
+                    //   append the slice to our own buffer
+                    //     check if this is possible: we might read more than currently requested -> is possible since max packet is 1024 and min is 512 so it could read 512 bytes too early
+
+                    buffer.append(&mut hardware_used_buffer.split_off(read_length));
+
+                    read_sum += read_length;
 
                     // if EOF, clear end and break and send
-                    // if requested_length on interrupt on usb 1.1 break and return
+                    // necessary for short packet handling
+                    if read_length == 0 && pkt_reader.is_end() {
+                        info!("reached EOF, consuming end to continue on next request");
+                        let _ = pkt_reader.consume_end();
+                        break;
+                    }
 
-                    break;
+                    // if requested_length full break and return
+                    // necessary for interrupt ep with no EOF like usb 1.1
+                    if read_length == 0 && read_sum >= requested_length {
+                        info!("read what we needed, rest until EOF is not yet read");
+                        break;
+                    }
                 }
+                Some(read_sum)
 
+                /*
                 match pkt_reader.read_to_end(&mut buffer).await {
                     Ok(read_length) => {
                         trace!("we have a return value from the reader {}", read_length);
@@ -619,6 +646,7 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt>(
                     }
                     Err(e) => panic!("in endpoint reader error: {e}"),
                 }
+                */
             } else {
                 trace!("skipping hardware request");
                 None
@@ -646,7 +674,7 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt>(
             // ...and return it
             response_submitter.send(requested_bytes)?;
         } else {
-            warn!("received a none from the request_receiver");
+            warn!("received a none from the request_receiver, this worker is dead");
             // kill task itself
             return anyhow::Ok(());
         }

--- a/src/device/xhci/nusb.rs
+++ b/src/device/xhci/nusb.rs
@@ -78,7 +78,7 @@ impl NusbDeviceWrapper {
             .get_interface_number_containing_endpoint(endpoint_address)
             .ok_or_else(|| anyhow!("Endpoint with id {endpoint_id} is not part of an interface"))?;
         // TODO retry this because of race condition after sending a stop signal to a worker
-        for n in 1..1000 {
+        for n in 1..10000 {
             if let Ok(endpoint) = self.interfaces[interface_num].endpoint(endpoint_address) {
                 return Ok(endpoint);
             }
@@ -476,7 +476,7 @@ pub struct NormalInEndpointHandle {
     // signal worker to stop
     cancel: CancellationToken,
     request_submitter: mpsc::UnboundedSender<usize>,
-    response_receiver: mpsc::UnboundedReceiver<Vec<u8>>,
+    response_receiver: mpsc::UnboundedReceiver<InTrbProcessingResult>,
 }
 
 impl Drop for NormalInEndpointHandle {
@@ -507,9 +507,7 @@ impl RealInEndpointHandle for NormalInEndpointHandle {
             let result = (self.response_receiver.recv().await)
                 // background worker is dead and has dropped the response sender
                 // maybe we want to error here instead
-                .map_or(InTrbProcessingResult::TransactionError, |res| {
-                    InTrbProcessingResult::Success(res)
-                });
+                .map_or(InTrbProcessingResult::TransactionError, |res| res);
 
             Ok(result)
         })
@@ -525,7 +523,11 @@ impl BaseEndpointHandle for NormalInEndpointHandle {
     }
 
     fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
-        Box::pin(async { todo!("clear halt") })
+        Box::pin(async {
+            info!("not doing anything to clear the halt with the higher level api");
+            //todo!("clear halt")
+            Ok(())
+        })
     }
 }
 
@@ -556,7 +558,7 @@ impl NormalInEndpointHandle {
 async fn cancellable_normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
     endpoint: nusb::Endpoint<EpType, In>,
     request_receiver: mpsc::UnboundedReceiver<usize>,
-    response_submitter: mpsc::UnboundedSender<Vec<u8>>,
+    response_submitter: mpsc::UnboundedSender<InTrbProcessingResult>,
     cancel: CancellationToken,
 ) {
     select! {
@@ -569,7 +571,7 @@ async fn cancellable_normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static
 async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
     endpoint: nusb::Endpoint<EpType, In>,
     mut request_receiver: mpsc::UnboundedReceiver<usize>,
-    response_submitter: mpsc::UnboundedSender<Vec<u8>>, // TODO into a processing result instead of a vec u8?
+    response_submitter: mpsc::UnboundedSender<InTrbProcessingResult>,
 ) -> anyhow::Result<()> {
     use nusb::transfer::{Bulk, Interrupt};
     use std::any::TypeId;
@@ -618,7 +620,11 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
                             // TODO does a max length for a td exist? -> maybe the 16MB being the edtla limit
                             panic!("normal in buffer OOM: {e}");
                         }
-                        Err(e) => panic!("in endpoint reader error: {e}"),
+                        Err(e) => {
+                            info!("in endpoint reader error: {e}");
+                            response_submitter.send(InTrbProcessingResult::Stall)?;
+                            continue;
+                        }
                     }
                 } else {
                     debug!("skipping hardware request");
@@ -651,7 +657,7 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
                 debug!("remaining buffer length: {}", buffer.len());
 
                 // ...and return it
-                response_submitter.send(requested_bytes)?;
+                response_submitter.send(InTrbProcessingResult::Success(requested_bytes))?;
             } else {
                 warn!("received a none from the request_receiver, this worker is dead");
                 // kill task itself
@@ -751,7 +757,7 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
                 debug!("remaining buffer length: {}", buffer.len());
 
                 // ...and return it
-                response_submitter.send(requested_bytes)?;
+                response_submitter.send(InTrbProcessingResult::Success(requested_bytes))?;
             } else {
                 warn!("received a none from the request_receiver, this worker is dead");
                 // kill task itself

--- a/src/device/xhci/nusb.rs
+++ b/src/device/xhci/nusb.rs
@@ -1,4 +1,6 @@
-use std::{fmt::Debug, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    fmt::Debug, future::Future, io::ErrorKind, pin::Pin, sync::Arc, thread::sleep, time::Duration,
+};
 
 use anyhow::{anyhow, Error};
 use nusb::{
@@ -8,9 +10,9 @@ use nusb::{
     },
     Endpoint, Interface, MaybeFuture,
 };
-use tokio::{runtime, select, sync::mpsc};
+use tokio::{io::AsyncReadExt, runtime, select, sync::mpsc};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use crate::device::xhci::{
     hotplug_endpoint_handle::BaseEndpointHandle,
@@ -75,9 +77,16 @@ impl NusbDeviceWrapper {
         let interface_num = self
             .get_interface_number_containing_endpoint(endpoint_address)
             .ok_or_else(|| anyhow!("Endpoint with id {endpoint_id} is not part of an interface"))?;
-        let endpoint = self.interfaces[interface_num].endpoint(endpoint_address)?;
+        // TODO retry this because of race condition after sending a stop signal to a worker
+        for n in 1..1000 {
+            if let Ok(endpoint) = self.interfaces[interface_num].endpoint(endpoint_address) {
+                return Ok(endpoint);
+            }
+            warn!("endpoint currently not available; this was try nr {n}");
 
-        Ok(endpoint)
+            sleep(Duration::new(0, 100));
+        }
+        panic!("unable to open endpoint");
     }
 }
 
@@ -109,9 +118,9 @@ impl NusbRealDevice {
 
 impl RealDevice for NusbRealDevice {
     type RCEH = ControlEndpointHandle;
-    type RBIEH = NormalEndpointHandle<Bulk, In>;
+    type RBIEH = NormalInEndpointHandle;
     type RBOEH = NormalEndpointHandle<Bulk, Out>;
-    type RIIEH = NormalEndpointHandle<Interrupt, In>;
+    type RIIEH = NormalInEndpointHandle;
     type RIOEH = NormalEndpointHandle<Interrupt, Out>;
 
     fn speed(&self) -> Option<super::real_device::Speed> {
@@ -123,7 +132,8 @@ impl RealDevice for NusbRealDevice {
     }
 
     fn bulk_in_endpoint_handle(&self, endpoint_id: u8) -> Self::RBIEH {
-        NormalEndpointHandle::new(endpoint_id, self.device_wrapper.clone())
+        let endpoint: Endpoint<Bulk, In> = self.device_wrapper.open_endpoint(endpoint_id).expect("Failed to open endpoint on nusb device. We could handle this error and always return transaction errors. Panic is fine for now.");
+        NormalInEndpointHandle::new(endpoint, &self.async_runtime)
     }
 
     fn bulk_out_endpoint_handle(&self, endpoint_id: u8) -> Self::RBOEH {
@@ -131,7 +141,8 @@ impl RealDevice for NusbRealDevice {
     }
 
     fn interrupt_in_endpoint_handle(&self, endpoint_id: u8) -> Self::RIIEH {
-        NormalEndpointHandle::new(endpoint_id, self.device_wrapper.clone())
+        let endpoint: Endpoint<Interrupt, In> = self.device_wrapper.open_endpoint(endpoint_id).expect("Failed to open endpoint on nusb device. We could handle this error and always return transaction errors. Panic is fine for now.");
+        NormalInEndpointHandle::new(endpoint, &self.async_runtime)
     }
 
     fn interrupt_out_endpoint_handle(&self, endpoint_id: u8) -> Self::RIOEH {
@@ -452,5 +463,181 @@ impl From<nusb::Speed> for Speed {
             nusb::Speed::SuperPlus => Self::SuperPlus,
             _ => todo!("new USB speed was added to non-exhaustive enum"),
         }
+    }
+}
+
+pub struct NormalInEndpointHandle {
+    // signal worker to stop
+    cancel: CancellationToken,
+    request_submitter: mpsc::UnboundedSender<usize>,
+    response_receiver: mpsc::UnboundedReceiver<Vec<u8>>,
+}
+
+impl Drop for NormalInEndpointHandle {
+    fn drop(&mut self) {
+        trace!("called Drop for NormalInEndpointHandle");
+        self.cancel.cancel();
+    }
+}
+
+impl Debug for NormalInEndpointHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("lol v2").finish()
+    }
+}
+
+impl RealInEndpointHandle for NormalInEndpointHandle {
+    type TrbCompletionFuture<'a> =
+        Pin<Box<dyn Future<Output = anyhow::Result<InTrbProcessingResult>> + Send + 'a>>;
+
+    fn submit(&mut self, len: usize) -> anyhow::Result<()> {
+        self.request_submitter.send(len)?;
+
+        Ok(())
+    }
+
+    fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_> {
+        Box::pin(async {
+            let result = (self.response_receiver.recv().await)
+                // background worker is dead and has dropped the response sender
+                // maybe we want to error here instead
+                .map_or(InTrbProcessingResult::TransactionError, |res| {
+                    InTrbProcessingResult::Success(res)
+                });
+
+            Ok(result)
+        })
+    }
+}
+
+impl BaseEndpointHandle for NormalInEndpointHandle {
+    type CompletionFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+    fn cancel(&mut self) -> Self::CompletionFuture<'_> {
+        // nothing we can do
+        Box::pin(async { Ok(()) })
+    }
+
+    fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
+        // nusb handles clearing halts on control endpoints by itself
+        Box::pin(async { Ok(()) })
+    }
+}
+
+impl NormalInEndpointHandle {
+    fn new<EpType: BulkOrInterrupt + 'static>(
+        endpoint: nusb::Endpoint<EpType, In>,
+        async_runtime: &runtime::Handle,
+    ) -> Self {
+        let (request_submitter, request_receiver) = mpsc::unbounded_channel();
+        let (response_submitter, response_receiver) = mpsc::unbounded_channel();
+        let cancel = CancellationToken::new();
+
+        async_runtime.spawn(cancellable_normal_in_endpoint_worker::<EpType>(
+            endpoint,
+            request_receiver,
+            response_submitter,
+            cancel.clone(),
+        ));
+
+        Self {
+            cancel,
+            request_submitter,
+            response_receiver,
+        }
+    }
+}
+
+async fn cancellable_normal_in_endpoint_worker<EpType: BulkOrInterrupt>(
+    endpoint: nusb::Endpoint<EpType, In>,
+    request_receiver: mpsc::UnboundedReceiver<usize>,
+    response_submitter: mpsc::UnboundedSender<Vec<u8>>,
+    cancel: CancellationToken,
+) {
+    select! {
+        _ = normal_in_endpoint_worker(endpoint, request_receiver, response_submitter) => {},
+        _ = cancel.cancelled() => {trace!("used the cancel token for an endpoint worker");},
+    }
+}
+
+// this function can only return with an error, but ! cannot be used in Result
+async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt>(
+    endpoint: nusb::Endpoint<EpType, In>,
+    mut request_receiver: mpsc::UnboundedReceiver<usize>,
+    response_submitter: mpsc::UnboundedSender<Vec<u8>>,
+) -> anyhow::Result<()> {
+    // seconds * N
+    const NUSB_TIMEOUT: u64 = 1000 * 20;
+
+    let mut reader = endpoint
+        // 1KB * 10
+        .reader(512 * 2 * 10) // maybe 16MB since that should be the max buffering the edtla can do
+        .with_num_transfers(1)
+        .with_read_timeout(Duration::from_millis(NUSB_TIMEOUT));
+    let mut pkt_reader = reader.until_short_packet();
+
+    let mut buffer = Vec::new();
+
+    let mut debug_counter = 0;
+
+    loop {
+        debug_counter += 1;
+        trace!(
+            "normal_in_endpoint_worker loop; counter at {}",
+            debug_counter
+        );
+
+        if let Some(requested_length) = request_receiver.recv().await {
+            debug!("original requested length: {requested_length}");
+            debug!("current buffer length: {}", buffer.len());
+
+            // do reading until end aka short or null package
+            let read_length = if requested_length > buffer.len() {
+                trace!("attempting a read");
+
+                match pkt_reader.read_to_end(&mut buffer).await {
+                    Ok(read_length) => {
+                        trace!("we have a return value from the reader {}", read_length);
+                        let _ = pkt_reader.consume_end();
+                        Some(read_length)
+                    }
+                    Err(e) if e.kind() == ErrorKind::OutOfMemory => {
+                        // TODO does a max length for a td exist? -> maybe the 16MB being the edtla limit
+                        panic!("normal in buffer OOM: {e}");
+                    }
+                    Err(e) => panic!("in endpoint reader error: {e}"),
+                }
+            } else {
+                trace!("skipping hardware request");
+                None
+            };
+
+            // collect data to return
+            let requested_bytes: Vec<u8>;
+            if let Some(length) = read_length {
+                // hardware read happened
+                if length < requested_length {
+                    // got short packet
+                    requested_bytes = buffer.drain(..length).collect();
+                } else {
+                    // received at least full requested length
+                    requested_bytes = buffer.drain(..requested_length).collect();
+                }
+            } else {
+                // from buffer only
+                requested_bytes = buffer.drain(..requested_length).collect();
+            }
+
+            debug!("the responded bytes len: {:?}", requested_bytes.len());
+            debug!("remaining buffer length: {}", buffer.len());
+
+            // ...and return it
+            response_submitter.send(requested_bytes)?;
+        } else {
+            warn!("received a none from the request_receiver");
+            // kill task itself
+            return anyhow::Ok(());
+        }
+        trace!("one loop done");
     }
 }

--- a/src/device/xhci/nusb.rs
+++ b/src/device/xhci/nusb.rs
@@ -247,7 +247,7 @@ async fn control_endpoint_worker(
             let processing_result = match is_out_request {
                 true => {
                     let data = request.data.unwrap_or(Vec::new());
-                    error!("nusb file: doing controlout");
+                    trace!("nusb file: doing controlout");
 
                     let control = ControlOut {
                         control_type,
@@ -257,14 +257,14 @@ async fn control_endpoint_worker(
                         index: request.index,
                         data: &data,
                     };
-                    error!("{:?}", control);
+                    trace!("{:?}", control);
                     match device
                         .control_out(control, Duration::from_millis(2000))
                         .await
                     {
                         Ok(_) => ControlRequestProcessingResult::SuccessfulControlOut,
                         Err(err) => {
-                            error!("mapping {:?}", err);
+                            trace!("mapping {:?}", err);
                             map_error(err)
                         }
                     }
@@ -581,7 +581,7 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
     let size;
 
     if TypeId::of::<EpType>() == TypeId::of::<Bulk>() {
-        info!("creating normal in worker for bulk");
+        trace!("creating normal in worker for bulk");
         size = 512 * 2 * 5;
         reader = endpoint
             .reader(size)
@@ -602,12 +602,12 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
             );
 
             if let Some(requested_length) = request_receiver.recv().await {
-                info!("original requested length: {requested_length}");
-                info!("current buffer length: {}", buffer.len());
+                trace!("original requested length: {requested_length}");
+                trace!("current buffer length: {}", buffer.len());
 
                 // do reading until end aka short or null package
                 let read_length = if requested_length > buffer.len() && !pkt_reader.is_end() {
-                    info!("attempting a read");
+                    trace!("attempting a read");
 
                     match pkt_reader.read_to_end(&mut buffer).await {
                         Ok(read_length) => {
@@ -621,7 +621,7 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
                         Err(e) => panic!("in endpoint reader error: {e}"),
                     }
                 } else {
-                    warn!("skipping hardware request");
+                    debug!("skipping hardware request");
                     None
                 };
 
@@ -660,7 +660,7 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
             trace!("one loop done");
         }
     } else if TypeId::of::<EpType>() == TypeId::of::<Interrupt>() {
-        info!("creating normal in worker for interrupt");
+        trace!("creating normal in worker for interrupt");
         size = endpoint.max_packet_size();
         reader = endpoint
             .reader(size)
@@ -680,16 +680,16 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
             );
 
             if let Some(requested_length) = request_receiver.recv().await {
-                info!("original requested length: {requested_length}");
-                info!("current buffer length: {}", buffer.len());
+                trace!("original requested length: {requested_length}");
+                trace!("current buffer length: {}", buffer.len());
 
                 // do reading until end aka short or null package
                 let read_length = if requested_length > buffer.len() {
-                    info!("attempting a read");
+                    trace!("attempting a read");
 
                     let mut read_sum = 0;
                     loop {
-                        info!("reading loop");
+                        trace!("reading loop");
 
                         // read
                         let mut hardware_used_buffer: Vec<u8> = vec![0; size];
@@ -704,30 +704,30 @@ async fn normal_in_endpoint_worker<EpType: BulkOrInterrupt + 'static>(
                             }
                         };
 
-                        info!("read {read_length} characters: {hardware_used_buffer:?}");
+                        trace!("read {read_length} characters: {hardware_used_buffer:?}");
 
                         if pkt_reader.is_end() {
-                            info!("reached EOF, consuming end to continue on next request");
+                            trace!("reached EOF, consuming end to continue on next request");
                             let _ = pkt_reader.consume_end();
                             break;
                         }
 
-                        info!("buffer.append");
+                        trace!("buffer.append");
                         buffer.append(&mut hardware_used_buffer.drain(0..(read_length)).collect());
                         read_sum += read_length;
 
-                        info!("read sum is {}", read_sum);
+                        trace!("read sum is {}", read_sum);
 
                         // if requested_length full break and return
                         // necessary for interrupt ep with no EOF like usb 1.1
                         if read_sum >= requested_length {
-                            info!("read what we needed, rest until EOF is not yet read");
+                            trace!("read what we needed, rest until EOF is not yet read");
                             break;
                         }
                     }
                     Some(read_sum)
                 } else {
-                    warn!("skipping hardware request");
+                    debug!("skipping hardware request");
                     None
                 };
 


### PR DESCRIPTION
See also #246 

This Draft aims to prototype using the higher level API the nusb crate provides. This is only done for bulk and interrupt In Endpoints.

In it's current state error handling is _very_ limited. This results in panics on device disconnect/stall/... .