### PR TITLE
Add fsck to blockdevice tests

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -632,7 +632,9 @@ let
     cloud_hypervisor.wait_until_succeeds("lsblk /dev/sda1", timeout=60)
 
     # Make a filesystem
-    cloud_hypervisor.succeed("mkfs.ext4 /dev/sda1", timeout=60)
+    out = cloud_hypervisor.succeed("mkfs.ext4 -v /dev/sda1", timeout=60)
+    print(out)
+    cloud_hypervisor.succeed("fsck -t ext4 -V -r /dev/sda1 -- -y", timeout=60)
     cloud_hypervisor.wait_until_succeeds("mount /dev/sda1 /mnt", timeout=60)
 
     # Create a file and compute a checksum


### PR DESCRIPTION
We have observed the blockdevice tests to be flaky due to failing `mount` calls. At first USB 1.1 later USB 2 and one time on my local machine even USB 3. The error message from `mount` was not really helpful enough to identify the source of this flakiness.

As a first attempt to limit the list of causes, we decided to add a filesystem check before calling mount.

The flags `-r` and `-V` and printing all output seemed like a nice to have.