### PR TITLE
Recognize when encountering a set immediate data bit

### DIFF
--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -341,6 +341,9 @@ impl ControlRequestParser {
                 },
                 ControlRequestParserState::SetupStageConsumed => match transfer_trb {
                     TransferTrbVariant::DataStage(data_trb_data) => {
+                        if data_trb_data.immediate_data {
+                            todo!("immediate data on data stage trb")
+                        }
                         let mut data = vec![0; self.request_builder.length as usize];
                         self.dma_bus
                             .read_bulk(data_trb_data.data_pointer, &mut data);

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -427,6 +427,9 @@ impl<ROEH: RealOutEndpointHandle> EndpointHandle for OutEndpointHandle<ROEH> {
         let transfer_trb = TransferTrbVariant::parse(trb.buffer);
         match &transfer_trb {
             TransferTrbVariant::Normal(normal_data) => {
+                if normal_data.immediate_data {
+                    todo!("immediate data on normal trb")
+                }
                 let mut data = vec![0; normal_data.transfer_length as usize];
                 self.dma_bus.read_bulk(normal_data.data_pointer, &mut data);
                 pcap::out_submission(

--- a/src/device/xhci/trb.rs
+++ b/src/device/xhci/trb.rs
@@ -953,6 +953,7 @@ pub struct DataStageTrbData {
     pub transfer_length: u16,
     pub chain: bool,
     pub interrupt_on_completion: bool,
+    pub immediate_data: bool,
     pub direction: bool,
 }
 
@@ -982,6 +983,7 @@ impl TrbData for DataStageTrbData {
 
         let chain = trb_bytes[12] & 0x10 != 0;
         let interrupt_on_completion = trb_bytes[12] & 0x20 != 0;
+        let immediate_data = trb_bytes[12] & 0x40 != 0;
         let direction = trb_bytes[14] & 0x1 != 0;
 
         Ok(Self {
@@ -989,6 +991,7 @@ impl TrbData for DataStageTrbData {
             transfer_length,
             chain,
             interrupt_on_completion,
+            immediate_data,
             direction,
         })
     }
@@ -1239,6 +1242,7 @@ mod tests {
             transfer_length: 0x0010,
             chain: false,
             interrupt_on_completion: false,
+            immediate_data: false,
             direction: false,
         });
         assert_eq!(TransferTrbVariant::parse(trb_bytes), expected);

--- a/src/device/xhci/trb.rs
+++ b/src/device/xhci/trb.rs
@@ -858,6 +858,7 @@ pub struct NormalTrbData {
     pub transfer_length: u32,
     pub chain: bool,
     pub interrupt_on_completion: bool,
+    pub immediate_data: bool,
 }
 
 impl TrbData for NormalTrbData {
@@ -886,12 +887,14 @@ impl TrbData for NormalTrbData {
 
         let chain = trb_bytes[12] & 0x10 != 0;
         let interrupt_on_completion = trb_bytes[12] & 0x20 != 0;
+        let immediate_data = trb_bytes[12] & 0x40 != 0;
 
         Ok(Self {
             data_pointer,
             transfer_length,
             chain,
             interrupt_on_completion,
+            immediate_data,
         })
     }
 }
@@ -1210,6 +1213,7 @@ mod tests {
             transfer_length: 0x3412,
             chain: true,
             interrupt_on_completion: true,
+            immediate_data: false,
         });
         assert_eq!(TransferTrbVariant::parse(trb_bytes), expected);
     }


### PR DESCRIPTION
The immediate data bit is used when the 8 byte pointer field is not a pointer and instead should be used as data field directly. It is not guaranteed to use the whole 8 bytes available.

|Trb|we...|this pr does...|
|---|---|---|
|Normal Trb|should handle it|a todo!()|
|Setup Stage Trb|can ignore it because it is always set to 1|nothing|
|Data Stage Trb|should handle it|a todo!()|
|Isoch Trb|not yet have isochronous transfers|nothing|