### PR TITLE
Print logs if nested wait_until_succeeds() hits a timeout (or other exception)

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -170,6 +170,7 @@ let
             with vm_host.nested(f"must succeed in cloud-hypervisor: {command}"):
                 (status, out) = vm_host.execute("ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@192.168.100.2 '" + command + "'", timeout=timeout)
                 if status != 0:
+                    print('\nnested.succeed() FAILED')
 
                     (guest_status, guest_out) = vm_host.execute("cat ${guestLogFile}")
                     print(f'\n<<<<<GUEST LOGS>>>>>\n\n{guest_out}\n\n<<<<<END GUEST LOGS>>>>>\n')
@@ -191,7 +192,16 @@ let
           return status == 0
 
         with vm_host.nested(f"waiting for success in cloud-hypervisor: {command}"):
-          retry(check_success, timeout)
+          try:
+            retry(check_success, timeout)
+          except Exception as e:
+            print('\nnested.wait_until_succeeds() FAILED')
+
+            print(f'\n<<<<<LATEST COMMAND OUTPUT>>>>>\n\n{output}\n\n<<<<<END LATEST COMMAND OUTPUT>>>>>\n')
+
+            (guest_status, guest_out) = vm_host.execute("cat ${guestLogFile}")
+            print(f'\n<<<<<GUEST LOGS>>>>>\n\n{guest_out}\n\n<<<<<END GUEST LOGS>>>>>\n')
+            raise Exception(f"cloud-hypervisor command failed/timed out: {command}") from e
           return(output)
 
     def search(pattern: str, string: str):


### PR DESCRIPTION
Whenever the CI hits a timeout we currently do not get the guest logs (nested cloud hypervisor journal).
With this, after the retry raises either a timeout or any other exception the latest stored command output and the guest journal logs will be added to the build logs of the test.

A timeout example I used for testing this:
```
singleBlockDeviceTestScript=''
    cloud_hypervisor.wait_until_succeeds("echo hello && sleep 20", timeout=10)
    ...
    <original test script for the basic blockdevice test>
    ...
'';
```