### PR TITLE
Clean up the hotplug socket on exit after client disconnect

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
     };
 
     // listen on socket for hot-attach fds
-    if let Some(hotplug_socket_path) = args.hotplug_socket_path {
+    if let Some(hotplug_socket_path) = args.hotplug_socket_path.clone() {
         let hotplug_control = backend.hotplug_control();
         let socket = UnixListener::bind(hotplug_socket_path.as_path()).unwrap();
         thread::Builder::new()
@@ -78,5 +78,12 @@ fn main() -> Result<()> {
     server
         .run(&mut backend)
         .context("Failed to start vfio-user server")?;
+
+    if let Some(hotplug_socket_path) = args.hotplug_socket_path {
+        if hotplug_socket_path.exists() {
+            let _ = std::fs::remove_file(&hotplug_socket_path);
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
This change will affect the happy case where only the hotplug socket remains while the vfio-user socket is removed. The vfio-user socket is cleaned on Drop when the vfio-user server will shutdown due to the client disconnecting.

The not-so-clean case when no client disconnected prior to service exit, both sockets will remain just like before.