### PR TITLE
cargo: bump crate version for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "usbvfiod"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Cyberus Technology GmbH"]
 description = "A vfio-user server for USB pass-through."
 name = "usbvfiod"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cyberus-technology/usbvfiod"


### PR DESCRIPTION
We enabled trusted publishing for the repo. Bump the version so we can try making a new release with the trusted process.