### PR TITLE
Add cli option to disable ansi color code usage

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,6 +54,10 @@ pub struct Cli {
     /// The file will be created when the first packet is logged.
     #[arg(long, value_name = "PATH")]
     pub pcap_path: Option<PathBuf>,
+
+    /// Do not use ANSI color codes in the output.
+    #[arg(long)]
+    pub no_color: bool,
 }
 
 /// The location of the server socket for the vfio-user client connection.

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ fn main() -> Result<()> {
             1 => Level::DEBUG,
             _ => Level::TRACE,
         })
+        .with_ansi(!args.no_color)
         .finish();
 
     tracing::subscriber::set_global_default(subscriber)


### PR DESCRIPTION
When redirecting output into a file with `&>` the color codes are noise making logs less nice readable.

To avoid going down an auto detect rabbit hole this is a simple option to deactivate color codes.