### PR TITLE
github-pages: switch markdown processor

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,5 @@
+# Github Pages / Jekyll configuration
+
+# We use some Github Flavored Markdown features in the documentation.
+markdown: GFM
+


### PR DESCRIPTION
> [!NOTE]
> sections like this do not render on the deployed pages currently

> [!TIP]
> see https://cyberus-technology.github.io/usbvfiod/docs/users/basic.html

Add a Jekyll configuration to select the markdown processor. GFM is used throughout GitHub, so this should fix it.

This is documented here: https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/setting-a-markdown-processor-for-your-github-pages-site-using-jekyll