### PR TITLE
Switch llvm coverage report output to html format

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -161,10 +161,11 @@
           default = usbvfiod;
         }
         // lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
-          usbvfiod-llvm-coverage = craneLibLLvmTools.cargoLlvmCov (
+          usbvfiod-llvm-coverage-html = craneLibLLvmTools.cargoLlvmCov (
             commonArgs
             // {
               inherit cargoArtifacts;
+              cargoLlvmCovExtraArgs = "--html --output-dir $out";
             }
           );
         };


### PR DESCRIPTION
We are not using the lcov output of this derivation (https://crane.dev/API.html#cranelibcargollvmcov).

With the html format we have a human readable format for local use.