### PR TITLE
Update flake lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1781339692,
-        "narHash": "sha256-EzGCNJ3T5HZfDbS0lT+CQKbx85jagA4ey4vb7mRZzQw=",
+        "lastModified": 1783415702,
+        "narHash": "sha256-bt0KVQZfj5+jizbe0zI5z+e6eefDnlQ8ISSDtZ3Re9c=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "09735e12749564d6f364ecab7d723caf52ada026",
+        "rev": "5e319f89424272fa0cad22463f444ab44c93df7d",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1780532242,
-        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
+        "lastModified": 1783203018,
+        "narHash": "sha256-G6R9IT/xwFuu+CYBWDUAok6AdC4ERC4ZfPPFtEpxnZE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
+        "rev": "80db5bdc391be8a1794f6d8a2d56e3a84ebcede2",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1781430890,
-        "narHash": "sha256-Dict8ZPqm3fei8iFXh75sPBNPqCdn7a8GJytgLajbGw=",
+        "lastModified": 1782900513,
+        "narHash": "sha256-GHrsl1+ysDFgmDQtQSqWS7TiYD2Q58VlwLvnf1+crJM=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "1b9586dd32bb28519cf6eea855e2df5b4d5eca15",
+        "rev": "16810aa8f4ad89ca480b1513774e8b6f485fe368",
         "type": "github"
       },
       "original": {
@@ -86,53 +86,31 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781359544,
-        "narHash": "sha256-iUuzKQcyXvopYDDzFpMK5eQKP3WIJExYny2kJtbgUcE=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9f11f828c213641c2369a9f1fa31fe31557e3156",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -310,10 +310,10 @@ let
       filepath = "${imagePathPart}-${testname}-${device.udevRule.symlink}.img";
     in
     ''
-      import os
-      os.system("rm ${filepath}")
+      import subprocess
+      subprocess.run(["rm", "${filepath}"])
       print("Creating file image at ${filepath}")
-      os.system("dd bs=1  count=1 seek=${imageSize} if=/dev/zero of=${filepath}")
+      subprocess.run(["dd", "bs=1", "count=1", "seek=${imageSize}", "if=/dev/zero", "of=${filepath}"])
     '';
 
   # Decide if a virtual device needs a backing image file.
@@ -747,7 +747,7 @@ let
           }
         ];
         testScript = ''
-          import os
+          import subprocess
           import time
           import threading
 
@@ -755,10 +755,12 @@ let
           def create_input():
             for i in range(1, 4):
               time.sleep(1)
-              os.system("""${pkgs.socat}/bin/socat - UNIX-CONNECT:/tmp/qmp.sock >> /dev/null <<EOF
-          {"execute": "qmp_capabilities"}
-          {"execute": "send-key", "arguments": {"keys": [ { "type": "qcode", "data": "ctrl" } ]}}
-          EOF""")
+              subprocess.run(
+                ["${pkgs.socat}/bin/socat", "-", "UNIX-CONNECT:/tmp/qmp.sock"],
+                input='{"execute":"qmp_capabilities"}\n{"execute":"send-key","arguments":{"keys":[{"type":"qcode","data":"ctrl"}]}}',
+                text=True,
+                stdout=subprocess.DEVNULL
+              )
               print(f"input loop `{i}` done")
 
           # Check the Keyboard is in detected in the guest.
@@ -854,16 +856,17 @@ blockdeviceTests
       }
     ];
     testScript = ''
-      import os
-      import textwrap
+      import subprocess
 
-      os.system("dd bs=1  count=1 seek=${imageSize} if=/dev/zero of=/tmp/hotplug.img")
+      subprocess.run(["dd", "bs=1", "count=1", "seek=${imageSize}", "if=/dev/zero", "of=/tmp/hotplug.img"])
 
       # create a blockdevice
-      os.system("""${pkgs.socat}/bin/socat - UNIX-CONNECT:/tmp/qmp.sock >> /dev/null <<EOF
-      {"execute": "qmp_capabilities"}
-      {"execute": "blockdev-add", "arguments": {"driver": "file", "node-name": "hotplug", "filename": "/tmp/hotplug.img"} }
-      EOF""")
+      subprocess.run(
+        ["${pkgs.socat}/bin/socat", "-", "UNIX-CONNECT:/tmp/qmp.sock"],
+        input='{"execute":"qmp_capabilities"}\n{"execute":"blockdev-add","arguments":{"driver":"file","node-name":"hotplug","filename":"/tmp/hotplug.img"}}',
+        text=True,
+        stdout=subprocess.DEVNULL
+      )
 
       for i in range(1,20):
         print(f"ATTACH DETACH LOOP {i}")
@@ -873,11 +876,12 @@ blockdeviceTests
         search("No attached devices", out)
 
         # plug in a blockdevice
-        os.system(textwrap.dedent("""
-        ${pkgs.socat}/bin/socat - UNIX-CONNECT:/tmp/qmp.sock >> /dev/null <<EOF
-        {"execute": "qmp_capabilities"}
-        {"execute": "device_add", "arguments": {"driver": "usb-storage", "id": "hotplug", "bus": "${usbVersions."3".busName}.0", "drive": "hotplug", "port": "1"} }
-        EOF"""))
+        subprocess.run(
+          ["${pkgs.socat}/bin/socat", "-", "UNIX-CONNECT:/tmp/qmp.sock"],
+          input='{"execute":"qmp_capabilities"}\n{"execute":"device_add","arguments":{"driver":"usb-storage","id":"hotplug","bus":"${usbVersions."3".busName}.0","drive":"hotplug","port":"1"}}',
+          text=True,
+          stdout=subprocess.DEVNULL
+        )
 
         # wait for qemu host to find the blockdevice
         machine.wait_until_succeeds("lsusb | grep 'QEMU QEMU USB HARDDRIVE'", timeout=120)
@@ -913,11 +917,12 @@ blockdeviceTests
           cloud_hypervisor.wait_until_succeeds("lsblk /dev/sd*", timeout=120)
 
         # Plug out a blockdevice.
-        os.system(textwrap.dedent("""
-        ${pkgs.socat}/bin/socat - UNIX-CONNECT:/tmp/qmp.sock >> /dev/null <<EOF
-        {"execute": "qmp_capabilities"}
-        {"execute": "device_del", "arguments": { "id": "hotplug" } }
-        EOF"""))
+        subprocess.run(
+          ["${pkgs.socat}/bin/socat", "-", "UNIX-CONNECT:/tmp/qmp.sock"],
+          input='{"execute":"qmp_capabilities"}\n{"execute":"device_del","arguments": {"id":"hotplug"}}',
+          text=True,
+          stdout=subprocess.DEVNULL
+        )
 
         # Wait for the qemu host to realize the missing usb device.
         machine.wait_until_fails("lsusb | grep 'QEMU QEMU USB HARDDRIVE'")


### PR DESCRIPTION
There have been no renovate lock file update PR's lately, so this is a manual one to fill in.

This includes fixes for the deprecation of `os.system()` in favor of `subprocess.run()` used in the integration test scripts.