### PR TITLE
Controller hardware reset

### DIFF
--- a/nix/checks/controller-reset.nix
+++ b/nix/checks/controller-reset.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  cloud-hypervisor,
+  usbvfiod,
+  testutils,
+}:
+let
+  systemd-config = args: {
+    systemd.services = {
+      usbvfiod = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          User = "usbaccess";
+          Group = "usbaccess";
+          Restart = "on-failure";
+          RestartSec = "2s";
+          ExecStart = ''
+            ${lib.getExe usbvfiod} ${
+              if args.debug then "-v" else ""
+            } --socket-path ${testutils.usbvfiodSocket} --hotplug-socket-path ${testutils.usbvfiodSocketHotplug} ${lib.concatStringsSep " " (builtins.map testutils.mkDeviceFlag args.virtualDevices)}
+          '';
+        };
+        environment = {
+          RUST_BACKTRACE = "full";
+        };
+      };
+
+      cloud-hypervisor =
+        let
+          netboot = testutils.mkNetboot args.debug;
+        in
+        {
+          wantedBy = [ "multi-user.target" ];
+          requires = [ "usbvfiod.service" ];
+          after = [ "usbvfiod.service" ];
+          serviceConfig = {
+            Restart = "on-failure";
+            RestartSec = "2s";
+            ExecStart = ''
+              ${lib.getExe cloud-hypervisor} --memory size=2G,shared=on --console file=${testutils.guestLogFile} --serial off \
+                --kernel ${netboot.kernel} \
+                --cmdline ${lib.escapeShellArg netboot.cmdline} \
+                --initramfs ${netboot.initrd} \
+                --user-device socket=${testutils.usbvfiodSocket} \
+                --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
+            '';
+          };
+        };
+    };
+  };
+
+  testScript = ''
+    # Wait until the USB drive is recognized.
+    out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+    search("ID ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId} QEMU QEMU USB HARDDRIVE", out)
+    cloud_hypervisor.wait_until_succeeds("lsblk /dev/sda", timeout=120)
+
+    # Run the controller reset loop a few times.
+    for i in range(1, 4):
+      print(f"CONTROLLER RESET LOOP {i}")
+
+      # Reload the guest xhci_pci driver to trigger a host controller reset.
+      cloud_hypervisor.succeed("modprobe -r xhci_pci", timeout=120)
+      cloud_hypervisor.succeed("modprobe xhci_pci", timeout=120)
+
+      # Confirm raw block I/O still works after the controller reset.
+      out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+      search("ID ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId} QEMU QEMU USB HARDDRIVE", out)
+      cloud_hypervisor.wait_until_succeeds("lsblk /dev/sda", timeout=120)
+      cloud_hypervisor.succeed(f"printf after-reset-{i} > /tmp/after-reset-{i}.txt", timeout=60)
+      cloud_hypervisor.succeed(f"dd if=/tmp/after-reset-{i}.txt of=/dev/sda bs=512 seek=2048 count=1 conv=sync,fsync status=none", timeout=60)
+      cloud_hypervisor.succeed("sync", timeout=60)
+      cloud_hypervisor.succeed("echo 3 > /proc/sys/vm/drop_caches", timeout=60)
+      cloud_hypervisor.succeed(f"dd if=/dev/sda of=/tmp/read-after-reset-{i}.txt bs=512 skip=2048 count=1 status=none", timeout=60)
+      cloud_hypervisor.succeed(f"grep -ao after-reset-{i} /tmp/read-after-reset-{i}.txt", timeout=60)
+  '';
+in
+builtins.listToAttrs (
+  builtins.map (usbVersion: {
+    name = "controller-reset-usb-${builtins.replaceStrings [ "." ] [ "_" ] usbVersion}";
+    value = testutils.mkUsbTest {
+      name = "controller-reset-usb-${usbVersion}";
+      virtualDevices = [
+        {
+          type = "blockdevice";
+          inherit usbVersion;
+        }
+      ];
+      inherit testScript;
+    } systemd-config;
+  }) (builtins.attrNames testutils.usbVersions)
+)

--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -16,6 +16,16 @@ in
   multiple-blockdevices = mkNixosIntegrationTest ./multiple-blockdevices.nix;
   forceful-removal = mkNixosIntegrationTest ./forceful-removal.nix;
 }
+// import ./controller-reset.nix {
+  inherit (pkgs)
+    cloud-hypervisor
+    ;
+  inherit
+    lib
+    usbvfiod
+    testutils
+    ;
+}
 // import ./blockdevice.nix {
   inherit (pkgs)
     cloud-hypervisor

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -5,13 +5,14 @@
 use std::sync::{Arc, Mutex};
 
 use tokio::runtime;
+use tracing::{error, info};
 
 use crate::device::{
     bus::{BusDeviceRef, SingleThreadedBusDevice},
     interrupt_line::InterruptLine,
     pci::{
         config_space::{ConfigSpace, ConfigSpaceBuilder},
-        constants::xhci::{offset, MAX_INTRS, RUN_BASE},
+        constants::xhci::{offset, operational::usbcmd, MAX_INTRS, RUN_BASE},
         traits::PciDevice,
     },
     xhci::{
@@ -114,7 +115,24 @@ impl<CRD: CompleteRealDevice> PciDevice for XhciController<CRD> {
 
         match req.addr {
             // xHC Operational Registers
-            offset::USBCMD => self.usbcmd.write(value),
+            offset::USBCMD => {
+                self.usbcmd.write(value);
+                if value & usbcmd::HCRST == usbcmd::HCRST {
+                    info!("Host Controller Reset requested");
+                    self.command_ring
+                        .reset()
+                        .map_err(|err| error!("failed to reset command ring: {err}"))
+                        .ok();
+                    self.interrupter
+                        .reset()
+                        .map_err(|err| error!("failed to reset event ring: {err}"))
+                        .ok();
+                    self.slot_manager
+                        .reset()
+                        .map_err(|err| error!("failed to reset slots: {err}"))
+                        .ok();
+                }
+            }
             offset::DNCTL => assert_eq!(value, 2, "debug notifications not supported"),
             offset::CRCR => self
                 .command_ring

--- a/src/device/pci/xhci.rs
+++ b/src/device/pci/xhci.rs
@@ -5,17 +5,17 @@
 use std::sync::{Arc, Mutex};
 
 use tokio::runtime;
-use tracing::{error, info};
 
 use crate::device::{
     bus::{BusDeviceRef, SingleThreadedBusDevice},
     interrupt_line::InterruptLine,
     pci::{
         config_space::{ConfigSpace, ConfigSpaceBuilder},
-        constants::xhci::{offset, operational::usbcmd, MAX_INTRS, RUN_BASE},
+        constants::xhci::{offset, MAX_INTRS, RUN_BASE},
         traits::PciDevice,
     },
     xhci::{
+        controller_reset::ResetCoordinator,
         endpoint_launcher::EndpointLauncher,
         port::{get_portli_id, get_portpmsc_id, get_portsc_id, HotplugControl, PortArray},
         real_device::CompleteRealDevice,
@@ -60,6 +60,15 @@ impl<CRD: CompleteRealDevice> XhciController<CRD> {
             interrupter.create_event_sender(),
             slot_manager.create_slot_worker_handle(),
             usbcmd.value_reference(),
+        );
+        ResetCoordinator::start(
+            usbcmd.clone(),
+            [
+                Box::new(command_ring.reset_sender()),
+                Box::new(interrupter.reset_sender()),
+                Box::new(slot_manager.reset_sender()),
+            ],
+            &async_runtime,
         );
 
         Self {
@@ -115,24 +124,7 @@ impl<CRD: CompleteRealDevice> PciDevice for XhciController<CRD> {
 
         match req.addr {
             // xHC Operational Registers
-            offset::USBCMD => {
-                self.usbcmd.write(value);
-                if value & usbcmd::HCRST == usbcmd::HCRST {
-                    info!("Host Controller Reset requested");
-                    self.command_ring
-                        .reset()
-                        .map_err(|err| error!("failed to reset command ring: {err}"))
-                        .ok();
-                    self.interrupter
-                        .reset()
-                        .map_err(|err| error!("failed to reset event ring: {err}"))
-                        .ok();
-                    self.slot_manager
-                        .reset()
-                        .map_err(|err| error!("failed to reset slots: {err}"))
-                        .ok();
-                }
-            }
+            offset::USBCMD => self.usbcmd.write(value),
             offset::DNCTL => assert_eq!(value, 2, "debug notifications not supported"),
             offset::CRCR => self
                 .command_ring

--- a/src/device/xhci/command_ring.rs
+++ b/src/device/xhci/command_ring.rs
@@ -54,6 +54,7 @@ enum WorkerMessage {
     SetDequeuePointerAndCS(u64, bool),
     Doorbell,
     Stop,
+    Reset,
 }
 
 impl CommandRing {
@@ -144,6 +145,10 @@ impl CommandRing {
         }
     }
 
+    pub fn reset(&self) -> anyhow::Result<()> {
+        self.send_to_worker(WorkerMessage::Reset)
+    }
+
     fn send_to_worker(&self, msg: WorkerMessage) -> anyhow::Result<()> {
         self.sender_to_worker.send(msg)?;
 
@@ -166,6 +171,9 @@ impl CommandWorker {
         loop {
             match &self.state {
                 WorkerState::Stopped => match self.next_msg().await? {
+                    WorkerMessage::Reset => {
+                        self.commandring_running.store(false, Ordering::Relaxed);
+                    }
                     WorkerMessage::SetDequeuePointerAndCS(dp, cs) => {
                         debug!("Updating command ring parameters: dp={dp:#x}, cs={cs}");
                         self.ring.set_dequeue_pointer(dp, cs);
@@ -183,6 +191,10 @@ impl CommandWorker {
                     msg => warn!("Unexpected message: msg={msg:?}, state={:?}", self.state),
                 },
                 WorkerState::Idle => match self.next_msg().await? {
+                    WorkerMessage::Reset => {
+                        self.commandring_running.store(false, Ordering::Relaxed);
+                        self.state = WorkerState::Stopped;
+                    }
                     WorkerMessage::Doorbell => {
                         self.state = WorkerState::LookingForNewCommand;
                     }
@@ -198,6 +210,11 @@ impl CommandWorker {
                         };
 
                         match msg {
+                            WorkerMessage::Reset => {
+                                self.commandring_running.store(false, Ordering::Relaxed);
+                                self.state = WorkerState::Stopped;
+                                break;
+                            }
                             WorkerMessage::Doorbell => {
                                 // we are already active and running, silently consume
                             }

--- a/src/device/xhci/command_ring.rs
+++ b/src/device/xhci/command_ring.rs
@@ -8,7 +8,10 @@ use std::sync::{
 use anyhow::anyhow;
 use tokio::{
     runtime,
-    sync::mpsc::{self, error::TryRecvError},
+    sync::{
+        mpsc::{self, error::TryRecvError},
+        oneshot,
+    },
 };
 use tracing::{debug, info, trace, warn};
 
@@ -16,6 +19,7 @@ use crate::device::{
     bus::BusDeviceRef,
     pci::constants::xhci::operational::{crcr, usbcmd},
     xhci::{
+        controller_reset::ResetSender,
         interrupter::EventSender,
         linked_ring::LinkedRing,
         slot_manager::SlotWorkerHandle,
@@ -27,6 +31,20 @@ use crate::device::{
 pub struct CommandRing {
     running: Arc<AtomicBool>,
     sender_to_worker: mpsc::UnboundedSender<WorkerMessage>,
+}
+
+#[derive(Debug)]
+pub struct CommandRingResetSender {
+    sender_to_worker: mpsc::UnboundedSender<WorkerMessage>,
+}
+
+impl ResetSender for CommandRingResetSender {
+    fn send_reset(&self, completion_notifier: oneshot::Sender<()>) -> anyhow::Result<()> {
+        self.sender_to_worker
+            .send(WorkerMessage::Reset(completion_notifier))?;
+
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -54,7 +72,7 @@ enum WorkerMessage {
     SetDequeuePointerAndCS(u64, bool),
     Doorbell,
     Stop,
-    Reset,
+    Reset(oneshot::Sender<()>),
 }
 
 impl CommandRing {
@@ -145,8 +163,10 @@ impl CommandRing {
         }
     }
 
-    pub fn reset(&self) -> anyhow::Result<()> {
-        self.send_to_worker(WorkerMessage::Reset)
+    pub fn reset_sender(&self) -> CommandRingResetSender {
+        CommandRingResetSender {
+            sender_to_worker: self.sender_to_worker.clone(),
+        }
     }
 
     fn send_to_worker(&self, msg: WorkerMessage) -> anyhow::Result<()> {
@@ -171,8 +191,9 @@ impl CommandWorker {
         loop {
             match &self.state {
                 WorkerState::Stopped => match self.next_msg().await? {
-                    WorkerMessage::Reset => {
+                    WorkerMessage::Reset(completion) => {
                         self.commandring_running.store(false, Ordering::Relaxed);
+                        completion.send(()).ok();
                     }
                     WorkerMessage::SetDequeuePointerAndCS(dp, cs) => {
                         debug!("Updating command ring parameters: dp={dp:#x}, cs={cs}");
@@ -191,9 +212,10 @@ impl CommandWorker {
                     msg => warn!("Unexpected message: msg={msg:?}, state={:?}", self.state),
                 },
                 WorkerState::Idle => match self.next_msg().await? {
-                    WorkerMessage::Reset => {
+                    WorkerMessage::Reset(completion) => {
                         self.commandring_running.store(false, Ordering::Relaxed);
                         self.state = WorkerState::Stopped;
+                        completion.send(()).ok();
                     }
                     WorkerMessage::Doorbell => {
                         self.state = WorkerState::LookingForNewCommand;
@@ -210,9 +232,10 @@ impl CommandWorker {
                         };
 
                         match msg {
-                            WorkerMessage::Reset => {
+                            WorkerMessage::Reset(completion) => {
                                 self.commandring_running.store(false, Ordering::Relaxed);
                                 self.state = WorkerState::Stopped;
+                                completion.send(()).ok();
                                 break;
                             }
                             WorkerMessage::Doorbell => {

--- a/src/device/xhci/controller_reset.rs
+++ b/src/device/xhci/controller_reset.rs
@@ -64,3 +64,54 @@ impl ResetCoordinator {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct TestResetSender {
+        completion_sender: mpsc::UnboundedSender<oneshot::Sender<()>>,
+    }
+
+    impl ResetSender for TestResetSender {
+        fn send_reset(&self, completion_notifier: oneshot::Sender<()>) -> anyhow::Result<()> {
+            self.completion_sender.send(completion_notifier)?;
+
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn reset_clears_hcrst_after_all_components_complete() {
+        let usbcmd = UsbcmdRegister::new();
+        usbcmd.write(usbcmd::HCRST);
+
+        let (completion_sender, mut completion_receiver) = mpsc::unbounded_channel();
+        let coordinator = ResetCoordinator {
+            usbcmd: usbcmd.clone(),
+            reset_senders: [
+                Box::new(TestResetSender {
+                    completion_sender: completion_sender.clone(),
+                }),
+                Box::new(TestResetSender {
+                    completion_sender: completion_sender.clone(),
+                }),
+                Box::new(TestResetSender { completion_sender }),
+            ],
+        };
+
+        let reset_task = tokio::spawn(async move { coordinator.reset().await });
+
+        for _ in 0..3 {
+            let completion = completion_receiver.recv().await.unwrap();
+            assert_eq!(usbcmd.read() & usbcmd::HCRST, usbcmd::HCRST);
+            completion.send(()).unwrap();
+        }
+
+        reset_task.await.unwrap().unwrap();
+        assert_eq!(usbcmd.read() & usbcmd::HCRST, 0);
+    }
+}

--- a/src/device/xhci/controller_reset.rs
+++ b/src/device/xhci/controller_reset.rs
@@ -1,0 +1,66 @@
+use tokio::{runtime, sync::oneshot};
+use tracing::error;
+
+use crate::device::{pci::constants::xhci::operational::usbcmd, xhci::registers::UsbcmdRegister};
+
+/// Sends reset requests to a component and reports when the reset finished.
+///
+/// The completion notifier must be triggered by the worker after it has applied
+/// its reset side effects.
+pub trait ResetSender: Send + Sync {
+    fn send_reset(&self, completion_notifier: oneshot::Sender<()>) -> anyhow::Result<()>;
+
+    fn reset(&self) -> anyhow::Result<oneshot::Receiver<()>> {
+        let (send, recv) = oneshot::channel();
+        self.send_reset(send)?;
+
+        Ok(recv)
+    }
+}
+
+/// Coordinates host controller reset across all resettable xHCI components.
+///
+/// The coordinator waits for `USBCMD.HCRST`, resets all registered components,
+/// and clears `HCRST` after all reset completion signals were received.
+pub struct ResetCoordinator {
+    usbcmd: UsbcmdRegister,
+    reset_senders: [Box<dyn ResetSender>; 3],
+}
+
+impl ResetCoordinator {
+    pub fn start(
+        usbcmd: UsbcmdRegister,
+        reset_senders: [Box<dyn ResetSender>; 3],
+        async_runtime: &runtime::Handle,
+    ) {
+        let coordinator = Self {
+            usbcmd,
+            reset_senders,
+        };
+
+        async_runtime.spawn(coordinator.run_loop());
+    }
+
+    async fn run_loop(self) {
+        loop {
+            self.usbcmd.hcrst_notification().await;
+
+            if self.usbcmd.read() & usbcmd::HCRST == 0 {
+                continue;
+            }
+
+            if let Err(err) = self.reset().await {
+                error!("failed to reset host controller: {err}");
+            }
+        }
+    }
+
+    async fn reset(&self) -> anyhow::Result<()> {
+        for reset_sender in &self.reset_senders {
+            reset_sender.reset()?.await?;
+        }
+        self.usbcmd.clear_hcrst();
+
+        Ok(())
+    }
+}

--- a/src/device/xhci/event_ring.rs
+++ b/src/device/xhci/event_ring.rs
@@ -68,6 +68,14 @@ impl EventRing {
         }
     }
 
+    pub const fn reset(&mut self) {
+        // The driver configures a fresh event ring after reset by writing ERSTBA.
+        self.enqueue_pointer = 0;
+        self.trb_count = 0;
+        self.erst_count = 0;
+        self.cycle_state = false;
+    }
+
     /// Configure the Event Ring.
     ///
     /// Call this function when the driver writes to the ERSTBA register (as

--- a/src/device/xhci/event_ring.rs
+++ b/src/device/xhci/event_ring.rs
@@ -410,6 +410,23 @@ mod tests {
     }
 
     #[test]
+    fn event_ring_reset_clears_local_state() {
+        let (_ram, mut ring, reg) = init_ram_and_ring_and_registers();
+
+        ring.enqueue(&dummy_trb(), reg.erstba, reg.erstsz, reg.erdp);
+        assert_ne!(ring.enqueue_pointer, 0);
+        assert_ne!(ring.trb_count, 0);
+        assert!(ring.cycle_state);
+
+        ring.reset();
+
+        assert_eq!(ring.enqueue_pointer, 0);
+        assert_eq!(ring.trb_count, 0);
+        assert_eq!(ring.erst_count, 0);
+        assert!(!ring.cycle_state);
+    }
+
+    #[test]
     #[should_panic(expected = "ERSTSZ must be set before ERSTBA")]
     fn configure_requires_erstsz_first() {
         let erste = [

--- a/src/device/xhci/interrupter.rs
+++ b/src/device/xhci/interrupter.rs
@@ -58,6 +58,7 @@ struct EventWorker {
 enum InterrupterMessage {
     SendEvent(EventTrb),
     UpdateInterruptLine(Arc<dyn InterruptLine>),
+    Reset,
 }
 
 #[derive(Debug, Clone)]
@@ -115,6 +116,19 @@ impl Interrupter {
             sender: self.msg_sender.clone(),
         }
     }
+
+    pub fn reset(&self) -> anyhow::Result<()> {
+        self.registers.interrupt_management.write(0);
+        self.registers
+            .interrupt_moderation_interval
+            .write(IMOD_DEFAULT);
+        self.registers.erst_base_address.reset();
+        self.registers.erst_size.write(0);
+        self.registers.eventring_dequeue_pointer.write(0);
+        self.msg_sender.send(InterrupterMessage::Reset)?;
+
+        Ok(())
+    }
 }
 
 impl EventWorker {
@@ -134,29 +148,41 @@ impl EventWorker {
         }
     }
 
-    // function only returns on error, but cannot use ! in Result
     async fn run_loop(&mut self) -> anyhow::Result<()> {
-        // first ERSTBA write starts the event ring.
-        // drop all events that happen before.
-        // interrupt line updates should be processed.
+        // Each ERSTBA write configures a new event ring. A host controller reset
+        // clears that configuration and sends us back to waiting for ERSTBA.
+        loop {
+            self.wait_for_event_ring_configuration().await?;
+            self.event_ring.configure(
+                self.registers.erst_base_address.erstba(),
+                self.registers.erst_size.read() as u32,
+            );
+
+            self.run_configured().await?;
+        }
+    }
+
+    // The first ERSTBA write starts the event ring. Drop events that happen
+    // before configuration, but keep processing control messages.
+    async fn wait_for_event_ring_configuration(&mut self) -> anyhow::Result<()> {
         loop {
             select! {
-                _ = self.registers.erst_base_address.write_notification() => break,
+                _ = self.registers.erst_base_address.write_notification() => return Ok(()),
                 // we cannot use self.next_msg() here because it borrows self mutable, clashing
                 // with the borrow of self.registers above
                 msg = self.msg_recv.recv() => match msg.ok_or_else(|| anyhow!("event channel closed"))? {
                     InterrupterMessage::SendEvent(_) => {}
                     InterrupterMessage::UpdateInterruptLine(interrupt_line) => self.interrupt_line = interrupt_line,
+                    InterrupterMessage::Reset => self.event_ring.reset(),
                 },
             }
         }
-        self.event_ring.configure(
-            self.registers.erst_base_address.erstba(),
-            self.registers.erst_size.read() as u32,
-        );
+    }
 
+    // Process messages while the event ring is configured. A reset clears the
+    // current configuration and returns to the outer loop to wait for ERSTBA.
+    async fn run_configured(&mut self) -> anyhow::Result<()> {
         loop {
-            // process TRB
             match self.next_msg().await? {
                 InterrupterMessage::SendEvent(event_trb) => {
                     self.event_ring.enqueue(
@@ -172,7 +198,13 @@ impl EventWorker {
                     self.interrupt_line = interrupt_line;
                     debug!("Updated interrupt line");
                 }
+                InterrupterMessage::Reset => {
+                    self.event_ring.reset();
+                    break;
+                }
             }
         }
+
+        Ok(())
     }
 }

--- a/src/device/xhci/interrupter.rs
+++ b/src/device/xhci/interrupter.rs
@@ -1,14 +1,16 @@
 use anyhow::{anyhow, Context};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::{runtime, select};
 use tracing::{debug, info};
 
 use crate::device::bus::BusDeviceRef;
 use crate::device::interrupt_line::{DummyInterruptLine, InterruptLine};
 use crate::device::pci::constants::xhci::runtime::IMOD_DEFAULT;
+use crate::device::xhci::controller_reset::ResetSender;
 use crate::device::xhci::event_ring::EventRing;
 use crate::device::xhci::registers::{ErstbaRegister, GenericRwRegister};
 use crate::device::xhci::trb::EventTrb;
+use crate::oneshot_anyhow::SendWithAnyhowError;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -16,6 +18,20 @@ pub struct Interrupter {
     pub registers: InterrupterRegisters,
     /// Transmits events to send to the worker
     msg_sender: mpsc::UnboundedSender<InterrupterMessage>,
+}
+
+#[derive(Debug)]
+pub struct InterrupterResetSender {
+    msg_sender: mpsc::UnboundedSender<InterrupterMessage>,
+}
+
+impl ResetSender for InterrupterResetSender {
+    fn send_reset(&self, completion_notifier: oneshot::Sender<()>) -> anyhow::Result<()> {
+        self.msg_sender
+            .send(InterrupterMessage::Reset(completion_notifier))?;
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -58,7 +74,7 @@ struct EventWorker {
 enum InterrupterMessage {
     SendEvent(EventTrb),
     UpdateInterruptLine(Arc<dyn InterruptLine>),
-    Reset,
+    Reset(oneshot::Sender<()>),
 }
 
 #[derive(Debug, Clone)]
@@ -117,17 +133,10 @@ impl Interrupter {
         }
     }
 
-    pub fn reset(&self) -> anyhow::Result<()> {
-        self.registers.interrupt_management.write(0);
-        self.registers
-            .interrupt_moderation_interval
-            .write(IMOD_DEFAULT);
-        self.registers.erst_base_address.reset();
-        self.registers.erst_size.write(0);
-        self.registers.eventring_dequeue_pointer.write(0);
-        self.msg_sender.send(InterrupterMessage::Reset)?;
-
-        Ok(())
+    pub fn reset_sender(&self) -> InterrupterResetSender {
+        InterrupterResetSender {
+            msg_sender: self.msg_sender.clone(),
+        }
     }
 }
 
@@ -173,7 +182,10 @@ impl EventWorker {
                 msg = self.msg_recv.recv() => match msg.ok_or_else(|| anyhow!("event channel closed"))? {
                     InterrupterMessage::SendEvent(_) => {}
                     InterrupterMessage::UpdateInterruptLine(interrupt_line) => self.interrupt_line = interrupt_line,
-                    InterrupterMessage::Reset => self.event_ring.reset(),
+                    InterrupterMessage::Reset(completion) => {
+                        self.reset();
+                        completion.send_anyhow(())?;
+                    }
                 },
             }
         }
@@ -198,13 +210,25 @@ impl EventWorker {
                     self.interrupt_line = interrupt_line;
                     debug!("Updated interrupt line");
                 }
-                InterrupterMessage::Reset => {
-                    self.event_ring.reset();
+                InterrupterMessage::Reset(completion) => {
+                    self.reset();
+                    completion.send_anyhow(())?;
                     break;
                 }
             }
         }
 
         Ok(())
+    }
+
+    fn reset(&mut self) {
+        self.registers.interrupt_management.write(0);
+        self.registers
+            .interrupt_moderation_interval
+            .write(IMOD_DEFAULT);
+        self.registers.erst_base_address.reset();
+        self.registers.erst_size.write(0);
+        self.registers.eventring_dequeue_pointer.write(0);
+        self.event_ring.reset();
     }
 }

--- a/src/device/xhci/mod.rs
+++ b/src/device/xhci/mod.rs
@@ -1,4 +1,5 @@
 pub mod command_ring;
+pub mod controller_reset;
 pub mod endpoint;
 pub mod endpoint_handle;
 pub mod endpoint_launcher;

--- a/src/device/xhci/registers.rs
+++ b/src/device/xhci/registers.rs
@@ -380,4 +380,26 @@ mod tests {
             "Not writing to allowed and already set bit 2 should clear it."
         );
     }
+
+    #[test]
+    fn usbcmd_preserves_hcrst_until_reset_completes() {
+        let reg = UsbcmdRegister::new();
+
+        reg.write(usbcmd::RS | usbcmd::HCRST);
+        assert_eq!(reg.read(), usbcmd::RS | usbcmd::HCRST);
+
+        reg.write(usbcmd::INTE);
+        assert_eq!(
+            reg.read(),
+            usbcmd::INTE | usbcmd::HCRST,
+            "HCRST should stay set until the reset coordinator clears it."
+        );
+
+        reg.clear_hcrst();
+        assert_eq!(
+            reg.read(),
+            usbcmd::INTE,
+            "clearing HCRST should preserve the other writable bits."
+        );
+    }
 }

--- a/src/device/xhci/registers.rs
+++ b/src/device/xhci/registers.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 
 use tokio::sync::Notify;
-use tracing::{trace, warn};
+use tracing::{info, trace, warn};
 
 use crate::device::{
     pci::constants::xhci::{
@@ -188,15 +188,17 @@ impl DcbaapRegister {
 }
 
 /// USB Command Register (chapter 5.4.1)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UsbcmdRegister {
     value: Arc<AtomicU32>,
+    reset_notify: Arc<Notify>,
 }
 
 impl UsbcmdRegister {
     pub fn new() -> Self {
         Self {
             value: Arc::new(AtomicU32::new(0)),
+            reset_notify: Default::default(),
         }
     }
 
@@ -206,25 +208,41 @@ impl UsbcmdRegister {
 
     /// A simple write with a very limited list of allowed bits (RsvdP is also not written).
     pub fn write(&self, value: u64) {
-        // Currently writable bits ...
-        const BITMASK_PRESERVED: u64 = usbcmd::RS | usbcmd::INTE;
-        // ... ignoring any other bits and printing a warning when anything but a reset is attempted.
-        // The MMIO write path handles the `HCRST` bit already.
-        if value & !(BITMASK_PRESERVED | usbcmd::HCRST) != 0 {
+        // Currently writable bits, ignoring any other bits and printing a warning.
+        const BITMASK_PRESERVED: u64 = usbcmd::RS | usbcmd::INTE | usbcmd::HCRST;
+        if value & !BITMASK_PRESERVED != 0 {
             warn!(
                 "received at least one bit that is ignored for USBCMD: {}",
                 value & !BITMASK_PRESERVED
             );
         }
 
-        let value = value & BITMASK_PRESERVED;
-        // SAFETY: USBCMD is defined as 32 bit and the masks used above enforce it.
+        // Preserve an ongoing reset until the reset coordinator clears HCRST.
         self.value
-            .store(value.try_into().unwrap(), Ordering::Relaxed);
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                let hcrst = current as u64 & usbcmd::HCRST;
+                let value = (value & BITMASK_PRESERVED) | hcrst;
+                // SAFETY: USBCMD is defined as 32 bit and the masks used above enforce it.
+                Some(value.try_into().unwrap())
+            })
+            .unwrap();
+        if value & usbcmd::HCRST == usbcmd::HCRST {
+            info!("Host Controller Reset requested");
+            self.reset_notify.notify_waiters();
+        }
     }
 
     pub fn value_reference(&self) -> Arc<AtomicU32> {
         self.value.clone()
+    }
+
+    pub async fn hcrst_notification(&self) {
+        self.reset_notify.notified().await;
+    }
+
+    pub fn clear_hcrst(&self) {
+        self.value
+            .fetch_and(!(usbcmd::HCRST as u32), Ordering::Relaxed);
     }
 }
 

--- a/src/device/xhci/registers.rs
+++ b/src/device/xhci/registers.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 
 use tokio::sync::Notify;
-use tracing::{info, trace, warn};
+use tracing::{trace, warn};
 
 use crate::device::{
     pci::constants::xhci::{
@@ -208,10 +208,8 @@ impl UsbcmdRegister {
     pub fn write(&self, value: u64) {
         // Currently writable bits ...
         const BITMASK_PRESERVED: u64 = usbcmd::RS | usbcmd::INTE;
-        // ... ignoring any other bits and printing a warning when attempted.
-        if value & usbcmd::HCRST == usbcmd::HCRST {
-            info!("Host Controller Reset attempted; no action");
-        }
+        // ... ignoring any other bits and printing a warning when anything but a reset is attempted.
+        // The MMIO write path handles the `HCRST` bit already.
         if value & !(BITMASK_PRESERVED | usbcmd::HCRST) != 0 {
             warn!(
                 "received at least one bit that is ignored for USBCMD: {}",

--- a/src/device/xhci/registers.rs
+++ b/src/device/xhci/registers.rs
@@ -159,6 +159,10 @@ impl ConfigureRegister {
         self.value.store(value, Ordering::Relaxed);
     }
 
+    pub fn reset(&self) {
+        self.value.store(0, Ordering::Relaxed);
+    }
+
     pub fn num_slots_enabled(&self) -> u8 {
         (self.read() & 0xff) as u8
     }
@@ -176,6 +180,10 @@ impl DcbaapRegister {
 
     pub fn write(&self, new_value: u64) {
         self.value.store(new_value & !0x1f, Ordering::Relaxed);
+    }
+
+    pub fn reset(&self) {
+        self.value.store(0, Ordering::Relaxed);
     }
 }
 
@@ -278,6 +286,10 @@ impl ErstbaRegister {
     pub fn write(&self, new_value: u64) {
         self.value.store(new_value, Ordering::Relaxed);
         self.notify.notify_waiters();
+    }
+
+    pub fn reset(&self) {
+        self.value.store(0, Ordering::Relaxed);
     }
 
     pub async fn write_notification(&self) {

--- a/src/device/xhci/slot_manager.rs
+++ b/src/device/xhci/slot_manager.rs
@@ -70,6 +70,14 @@ impl SlotManager {
             msg_send: self.msg_send.clone(),
         }
     }
+
+    pub fn reset(&self) -> anyhow::Result<()> {
+        self.config_reg.reset();
+        self.dcbaap.reset();
+        self.msg_send.send(SlotMessage::ResetAllSlots)?;
+
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -98,6 +106,7 @@ pub enum SlotMessage {
         oneshot::Sender<CompletionCode>,
     ),
     ResetDevice(u8, oneshot::Sender<CompletionCode>),
+    ResetAllSlots,
     // slot_id, endpoint_id
     StopEndpoint(u8, u8, oneshot::Sender<CompletionCode>),
     ResetEndpoint(u8, u8, oneshot::Sender<CompletionCode>),
@@ -227,6 +236,7 @@ impl SlotWorker {
                     let result = slot.handle_reset_device().await?;
                     sender.send_anyhow(result)?;
                 }
+                SlotMessage::ResetAllSlots => self.reset().await?,
                 SlotMessage::StopEndpoint(slot_id, endpoint_id, sender) => {
                     let slot = match self.slot_ref(slot_id) {
                         Some(slot) => slot,
@@ -345,6 +355,17 @@ impl SlotWorker {
         self.slots[slot_id as usize] = None;
 
         Ok(CompletionCode::Success)
+    }
+
+    async fn reset(&mut self) -> anyhow::Result<()> {
+        let mut result = Ok(());
+
+        for slot in self.slots.iter_mut().filter_map(Option::as_mut) {
+            result = result.and(slot.pre_drop().await);
+        }
+        self.slots = [const { None }; MAX_SLOTS as usize].into();
+
+        result
     }
 }
 
@@ -614,12 +635,14 @@ impl Slot {
 
     // call before dropping (disabling this slot)
     async fn pre_drop(&mut self) -> anyhow::Result<()> {
-        // disable EP0 if active
-        if !matches!(self.state, SlotState::Enabled) {
-            self.deconfigure_endpoint(1).await?;
+        let mut result = Ok(());
+
+        // disable all active endpoints
+        for endpoint_sender in self.endpoint_senders.iter_mut().filter_map(Option::take) {
+            result = result.and(endpoint_sender.terminate().await);
         }
 
-        Ok(())
+        result
     }
 
     async fn handle_reset_device(&mut self) -> anyhow::Result<CompletionCode> {

--- a/src/device/xhci/slot_manager.rs
+++ b/src/device/xhci/slot_manager.rs
@@ -10,6 +10,7 @@ use crate::{
         bus::{BusDeviceRef, Request, RequestSize},
         pci::constants::xhci::{device_slots::slot_state, MAX_SLOTS},
         xhci::{
+            controller_reset::ResetSender,
             endpoint::EndpointSender,
             endpoint_launcher::LaunchRequester,
             registers::{ConfigureRegister, DcbaapRegister},
@@ -28,6 +29,20 @@ pub struct SlotManager {
     pub config_reg: ConfigureRegister,
     pub dcbaap: DcbaapRegister,
     msg_send: mpsc::UnboundedSender<SlotMessage>,
+}
+
+#[derive(Debug)]
+pub struct SlotManagerResetSender {
+    msg_send: mpsc::UnboundedSender<SlotMessage>,
+}
+
+impl ResetSender for SlotManagerResetSender {
+    fn send_reset(&self, completion_notifier: oneshot::Sender<()>) -> anyhow::Result<()> {
+        self.msg_send
+            .send(SlotMessage::ResetAllSlots(completion_notifier))?;
+
+        Ok(())
+    }
 }
 
 impl SlotManager {
@@ -71,12 +86,10 @@ impl SlotManager {
         }
     }
 
-    pub fn reset(&self) -> anyhow::Result<()> {
-        self.config_reg.reset();
-        self.dcbaap.reset();
-        self.msg_send.send(SlotMessage::ResetAllSlots)?;
-
-        Ok(())
+    pub fn reset_sender(&self) -> SlotManagerResetSender {
+        SlotManagerResetSender {
+            msg_send: self.msg_send.clone(),
+        }
     }
 }
 
@@ -106,7 +119,7 @@ pub enum SlotMessage {
         oneshot::Sender<CompletionCode>,
     ),
     ResetDevice(u8, oneshot::Sender<CompletionCode>),
-    ResetAllSlots,
+    ResetAllSlots(oneshot::Sender<()>),
     // slot_id, endpoint_id
     StopEndpoint(u8, u8, oneshot::Sender<CompletionCode>),
     ResetEndpoint(u8, u8, oneshot::Sender<CompletionCode>),
@@ -236,7 +249,10 @@ impl SlotWorker {
                     let result = slot.handle_reset_device().await?;
                     sender.send_anyhow(result)?;
                 }
-                SlotMessage::ResetAllSlots => self.reset().await?,
+                SlotMessage::ResetAllSlots(completion) => {
+                    self.reset().await?;
+                    completion.send_anyhow(())?;
+                }
                 SlotMessage::StopEndpoint(slot_id, endpoint_id, sender) => {
                     let slot = match self.slot_ref(slot_id) {
                         Some(slot) => slot,
@@ -360,10 +376,12 @@ impl SlotWorker {
     async fn reset(&mut self) -> anyhow::Result<()> {
         let mut result = Ok(());
 
-        for slot in self.slots.iter_mut().filter_map(Option::as_mut) {
+        self.config_reg.reset();
+        self.dcbaap.reset();
+
+        for mut slot in self.slots.iter_mut().filter_map(Option::take) {
             result = result.and(slot.pre_drop().await);
         }
-        self.slots = [const { None }; MAX_SLOTS as usize].into();
 
         result
     }


### PR DESCRIPTION
When we tried to unload and reload the `xhci_pci` module in Linux, the warning `WARN usbvfiod::device::xhci::command_ring: received useless write to CRCR while running` can be triggered. 
The reason is that we didn't really implement host controller reset before. When the Linux guest unloaded and reloaded `xhci_pci`, the driver reset the host controller and then reprogrammed the command/event/slot state. Since usbvfiod still kept the old state, the command ring could still be considered running and CRCR writes during re-initialization produced warnings.

This PR fixes this error by
- Stopping the command ring
- Resetting event ring/interrupter state
- Resetting slot manager state