### PR TITLE
Revert "github-pages: switch markdown processor"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,0 @@
-# Github Pages / Jekyll configuration
-
-# We use some Github Flavored Markdown features in the documentation.
-markdown: GFM
-


### PR DESCRIPTION
This reverts commit 89ffe1bf351afc898b481df1dc80a16be710ddc9.

The config file does not work as intended, and also all repository files are included in the served artifacts by default. This isn't a security concern for our repo, but I disabled github-pages generation for now.