### PR TITLE
Allow clear_halt to fail

### DIFF
--- a/src/device/xhci/nusb.rs
+++ b/src/device/xhci/nusb.rs
@@ -428,7 +428,9 @@ impl<EpType: BulkOrInterrupt, Dir: EndpointDirection> BaseEndpointHandle
 
     fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
         Box::pin(async {
-            self.endpoint().clear_halt().await?;
+            if let Err(error) = self.endpoint().clear_halt().await {
+                warn!("clear_halt failed on non-control endpoint: {error}");
+            }
             Ok(())
         })
     }


### PR DESCRIPTION
When an endpoint stalled or had a transaction error and entered Halted state, the driver must recover the endpoint with a ResetEndpoint command. To handle this command, we have to perform a transition on the endpoint state machine but also instruct nusb to reset the endpoint of the hardware controller with the `Endpoint::clear_halt` method (except on control endpoints, where nusb internally takes care of reseting after stalls).

This path is not well tested. I believe the integration tests do not contain any stalls on non-control endpoints. The forceful-removal test causes transaction errors when the device is gone, but, as far as we observed in CI runs, the endpoint-hotplug layer has dropped the nusb endpoint before a clear_halt request occurs.

However, we encountered the following situation when a keyboard disappeared:
```
DEBUG nusb::platform::linux_usbfs::device: Handling events for device 0
DEBUG nusb::platform::linux_usbfs::device: URB 0x7b820c0026c0 for ep 81 completed, status=-71 actual_length=0
DEBUG nusb::platform::linux_usbfs::device: Handling events for device 0
DEBUG nusb::platform::linux_usbfs::device: URB 0x7b820c003b40 for ep 82 completed, status=-71 actual_length=0
DEBUG usbvfiod::device::xhci::interrupter: Sent event: Transfer(TransferEventTrbData { trb_pointer: 83202048, trb_transfer_length: 0, completion_code: UsbTransactionError, event_data: false, endpoint_id: 3, slot_id: 1 })
DEBUG usbvfiod::device::xhci::interrupter: Sent event: Transfer(TransferEventTrbData { trb_pointer: 83177472, trb_transfer_length: 0, completion_code: UsbTransactionError, event_data: false, endpoint_id: 5, slot_id: 1 })
DEBUG usbvfiod::device::xhci::command_ring: Doorbell for the controller
DEBUG usbvfiod::device::xhci::command_ring: Processing command CommandTrb { address: 1000305152, variant: ResetEndpoint(ResetEndpointCommandTrbData { slot_id: 1, endpoint_id: 3 }) }
DEBUG nusb::platform::linux_usbfs::device: Clear halt, endpoint 81
DEBUG usbvfiod::device::xhci::command_ring: Doorbell for the controller
WARN usbvfiod::device::xhci::endpoint: endpoint stopped unexpectedly failed to clear halt (errno 71)
```
The two "polling" interrupt IN endpoints both discovered the device disconnect (`status=-71`). The endpoint workers inform other endpoints and a central component through a cancellation token about the disappearance, ultimately causing the drop of all handles to the real device. We finish the interrupted transfers by reporting transaction errors. There is a race between "the controller receives the transaction error and sends a ResetEndpoint command" and "endpoint-hotplug layer drops the real endpoint". If the latter happens first, the hotplug layer will do nothing when ResetEndpoint command/clear halt happens. When the former is faster, we call `clear_halt` on the nusb endpoint handle of the disconnect device; the call fails and we treat the fail as an unrecoverable error.

We could encounter the same problem also without the race condition: During normal operation, the endpoint was in Halted state. The driver sends ResetEndpoint command and just in that moment the device disconnects.

This PR changes the error handling for the clear_halt: We only log a warning and continue normally instead.