### PR TITLE
Allow termination of halted endpoints

### DIFF
--- a/src/device/xhci/endpoint.rs
+++ b/src/device/xhci/endpoint.rs
@@ -170,6 +170,9 @@ impl<EH: HotplugEndpointHandle> EndpointWorker<EH> {
                         // the Completion Code set to Context State Error.
                         completion.send_anyhow(CompletionCode::ContextStateError)?;
                     }
+                    EndpointMessage::Terminate(sender) => {
+                        self.state = WorkerState::Terminating(sender);
+                    }
                     msg => self.context_state_error(msg)?,
                 },
                 WorkerState::Error => match self.next_msg().await? {


### PR DESCRIPTION
ConfigureEndpoint commands with Drop flags or DC==1 (Deconfigure flag) terminate endpoint workers by sending a terminate message. In some endpoint states, termination is not valid/well defined (e.g., if the worker is actively processing TRBS—the driver would be responsible for stopping the endpoint first).

During local execution of the `forceful-removal` test, I encountered the case that the driver tried to deconfigure an endpoint in halted state (entered because of the transaction error we send on disconnect detection). Termination should be valid then, but we did not yet explicitly allow this state–message combination.

This PR adds the missing state transition. 