### PR TITLE
Detach already attached devices and remove AlreadyAttached response

### DIFF
--- a/src/device/xhci/port.rs
+++ b/src/device/xhci/port.rs
@@ -6,7 +6,7 @@ use tokio::{
     sync::{mpsc, oneshot},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 use usbvfiod::hotplug_protocol::response::Response;
 
 use crate::{
@@ -162,8 +162,10 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
 
     fn attach(&mut self, device: CRD) -> anyhow::Result<Response> {
         if self.attached_devices().contains(&device.identifier()) {
-            warn!("Failed to attach device: A device with the same identifier is already attached");
-            return Ok(Response::AlreadyAttached);
+            info!(
+                "A device with the same identifier is already attached and will be detached first"
+            );
+            self.detach(device.identifier())?;
         }
 
         let speed = match device.realdevice_ref().speed() {

--- a/src/hotplug_protocol/response.rs
+++ b/src/hotplug_protocol/response.rs
@@ -12,7 +12,6 @@ pub enum Response {
     NoFreePort,
     CouldNotDetermineSpeed,
     FailedToOpenFd,
-    AlreadyAttached,
     NoSuchDevice,
     Invalid,
 }
@@ -90,8 +89,7 @@ impl TryFrom<u8> for Response {
             2 => Self::NoFreePort,
             3 => Self::CouldNotDetermineSpeed,
             4 => Self::FailedToOpenFd,
-            5 => Self::AlreadyAttached,
-            6 => Self::NoSuchDevice,
+            5 => Self::NoSuchDevice,
             _ => Self::Invalid,
         })
     }


### PR DESCRIPTION
When an already attached device is reattached through the hotplug socket, the remote binary already performed a reset and likely broke the attached device in the process. Instead of refusing the attach, perform a detach of the conflicting device in the controller.

Remove the now unused `AlreadyAttached` response from the protocol definition. There is no sane place where it could be useful. Callers should inspect the list of attached devices first, to avoid breaking devices that are in-use by a guest.

BREAKING: modifies the public protocol response codes.