### PR TITLE
Implementing file descriptor usage in addition to socket path

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,8 @@ Hypervisor virtual machine. For a basic overview of the goals, see the
 
 ## For Users
 
-- [Setup and Invocation](./users/basic.md)
+- [Basic Setup and Invocation](./users/basic.md)
+- [Systemd Setup](./users/systemd.md)
 - [Security Considerations](./users/security.md)
 
 Please [get in touch](https://cyberus-technology.de/en/contact), if you need

--- a/docs/users/basic.md
+++ b/docs/users/basic.md
@@ -8,11 +8,6 @@ The server communicates via two Unix sockets:
 * a `vfio-user` socket for communication between `usbvfiod` and the VMM (Cloud Hypervisor)
 * a `hotplug` socket to attach/detach/list devices exposed by `usbvfiod` from the host (optional)
 
-> [!TODO]
-> Currently, the server creates both sockets. The `vfio-user` standard
-> requires that a server can also accept the `vfio-user` socket as a file
-> descriptor, but we have not yet implemented this functionality.
-
 ## Obtaining the Package
 
 The software is available through the [GitHub
@@ -58,7 +53,7 @@ nix run github:cyberus-technology/usbvfiod#remote -- \
 No attached devices
 ```
 
-Attach a USB device to the controller through the `hotplug` socket. The 
+Attach a USB device to the controller through the `hotplug` socket. The
 example uses a keyboard recognized at `/dev/bus/usb/009/003`.
 
 ```

--- a/docs/users/systemd.md
+++ b/docs/users/systemd.md
@@ -1,0 +1,108 @@
+# Systemd setup with socket units
+
+**Why?**
+
+An upstream service will be started automatically when someone connects to the socket. For example, Cloud Hypervisor will start and be given a socket path managed by a systemd socket unit. When the Cloud Hypervisor process connects to the socket, systemd will start the usbvfiod service unit.
+
+When the Cloud Hypervisor recreates the VM due to a reboot, the socket connection will be broken.
+Upon breaking the vfio-user connection usbvfiod will exit and clean up it's remaining sockets.
+Cloud Hypervisor's VM will fail to restart due to the missing socket. Because Cloud Hypervisor is restarted on failure systemd will only then look at its dependencies and trigger a start for usbvfiod. After usbvfiod is restarted and has recreated the socket, the Cloud Hypervisor service can leave the restart on failure loop.
+If usbvfiod exited with a non zero exit code it will be blocked by preexisting files (not previously cleaned up sockets) that will not be overwritten. Because Cloud Hypervisor in the `--socket-path` variant depends on usbvfiod, it might be blocked infinitely due to that missing cleanup.
+
+Using systemd to manage the socket and providing it over the `--fd` argument decouples `usbvfiod.service` from its socket. It is not a direct dependency for the `cloud-hypervisor.service` anymore, the socket unit is. With usbvfiod's behavior to exit if the single vfio-user client disconnects it is now the only service to restart on a guest reboot.
+
+When depending on the socket unit, the file system path for the socketis guaranteed to exists when the socket unit succeeds. A dependence on the service itself does not give any guarantee the socket has been created before dependent services start. This may lead to spurious service startup failures.
+
+## Following the integration test example
+
+This section aims to provide a summary about using systemd socket units with usbvfiod and Cloud Hypervisor.
+
+The following systemd config snippets are created with a nix integration test and should help you get up and running. They include some noise in the `Service.Environment` fields but are kept as is to avoid untested examples. Values for `Socket.Group`, `Socket.Mode`, `Socket.User`, `Service.Group`, `Service.User` are not strict for the sake of simplicity in the integration test.
+
+The example will manage both of usbvfiods available socket options with systemd: the vfio-user server and the hotplug server.
+
+### Systemd Unit: usbvfiod.socket
+
+The Socket Unit's most important field is `Socket.ListenStream`. The order (if multiple fields exist as do in this example) will be used in the environment of the service when providing the file descriptors. The fields `Socket.SocketGroup`, `Socket.SocketMode` and `Socket.SocketUser` are for permission management of the resulting Sockets.
+
+Use the same name for this socket unit and the associated service to let systemd associate them automatically (equal to explicitly declaring `Socket.Service=usbvfiod.service`). Alternatively set `Socket.Service` explicitly.
+
+```ini
+[Unit]
+Description=sockets to trigger usbvfiod service start and provide communication channels
+
+[Socket]
+Accept=no
+ListenStream=/tmp/usbvfiod.sock
+ListenStream=/tmp/hotplug.sock
+SocketGroup=usbaccess
+SocketMode=660
+SocketUser=usbaccess
+
+[Install]
+WantedBy=sockets.target
+```
+
+### Systemd Unit: usbvfiod.service
+
+Following after the three default file descriptors `stdin`, `stdout` and `stderr` systemd provides the above defined order of `Socket.ListenStream` file descriptors. They are available in the `usbvfiod.service` configuration field `Service.ExecStart`, to be used as `--fd 3` (the vfio-user socket) and `--hotplug-fd 4` (the hotplug socket).
+
+```ini
+[Unit]
+
+[Service]
+Environment="LOCALE_ARCHIVE=/nix/store/54jg0kk0cn5h7j19r0l8x36fmbfywwjj-glibc-locales-2.42-67/lib/locale/locale-archive"
+Environment="PATH=/nix/store/di26b1kkbammy0sj70nq5qzvfrh78wxl-coreutils-9.11/bin:/nix/store/fcqbwp5hx5wh3lzf0457wmf0divknz7y-findutils-4.11.0/bin:/nix/store/aak8d9mrdv9sgn0lcg7xss7wxdg9sqh3-gnugrep-3.12/bin:/nix/store/7mfsmbhsd3arnypipwm251rcd0b45riy-gnused-4.10/bin:/nix/store/r6sz8p6sd6c73fp9z8nzl04dri7lyx8n-systemd-261.1/bin:/nix/store/di26b1kkbammy0sj70nq5qzvfrh78wxl-coreutils-9.11/sbin:/nix/store/fcqbwp5hx5wh3lzf0457wmf0divknz7y-findutils-4.11.0/sbin:/nix/store/aak8d9mrdv9sgn0lcg7xss7wxdg9sqh3-gnugrep-3.12/sbin:/nix/store/7mfsmbhsd3arnypipwm251rcd0b45riy-gnused-4.10/sbin:/nix/store/r6sz8p6sd6c73fp9z8nzl04dri7lyx8n-systemd-261.1/sbin"
+Environment="RUST_BACKTRACE=full"
+Environment="TZDIR=/nix/store/2nndxyf3phkb5aggxm3c16sapa0f49kz-tzdata-2026c/share/zoneinfo"
+ExecStart=/nix/store/lcl5ngmqmqk7idgrw83ghag59sw7kz9y-usbvfiod-0.2.0/bin/usbvfiod -v --fd 3 --hotplug-fd 4 --device "/dev/bus/usb/testdevice"
+
+Group=usbaccess
+Restart=on-failure
+RestartSec=2s
+User=usbaccess
+```
+
+### Systemd Unit: cloud-hypervisor.service
+
+The `cloud-hypervisor.service` declares a dependency on `usbvfiod.socket` (via `Unit.Requires`) to ensure the path in the filesystem is created before starting Cloud Hypervisor. A dependency directly on `usbvfiod.service` is not necessary.
+
+When starting Cloud Hypervisor, the vfio-user socket path is provided in the same way as it is without a systemd socket unit (see the `Service.ExecStart` field below). In this example the `--user-device` receives the first of the two defined `Socket.ListenStream` paths, because the `usbvfiod.service` configuration above used file descriptor 3 for the vfio-user server.
+
+When the `Install.WantedBy` starts Cloud Hypervisor, it connects to the socket path provided with the `--user-device` argument. Establishing a connection to a socket unit defined path will prompt systemd to start the service unit behind the socket and pass on all communication.
+
+```ini
+[Unit]
+Requires=usbvfiod.socket
+
+[Service]
+Environment="LOCALE_ARCHIVE=/nix/store/54jg0kk0cn5h7j19r0l8x36fmbfywwjj-glibc-locales-2.42-67/lib/locale/locale-archive"
+Environment="PATH=/nix/store/di26b1kkbammy0sj70nq5qzvfrh78wxl-coreutils-9.11/bin:/nix/store/fcqbwp5hx5wh3lzf0457wmf0divknz7y-findutils-4.11.0/bin:/nix/store/aak8d9mrdv9sgn0lcg7xss7wxdg9sqh3-gnugrep-3.12/bin:/nix/store/7mfsmbhsd3arnypipwm251rcd0b45riy-gnused-4.10/bin:/nix/store/r6sz8p6sd6c73fp9z8nzl04dri7lyx8n-systemd-261.1/bin:/nix/store/di26b1kkbammy0sj70nq5qzvfrh78wxl-coreutils-9.11/sbin:/nix/store/fcqbwp5hx5wh3lzf0457wmf0divknz7y-findutils-4.11.0/sbin:/nix/store/aak8d9mrdv9sgn0lcg7xss7wxdg9sqh3-gnugrep-3.12/sbin:/nix/store/7mfsmbhsd3arnypipwm251rcd0b45riy-gnused-4.10/sbin:/nix/store/r6sz8p6sd6c73fp9z8nzl04dri7lyx8n-systemd-261.1/sbin"
+Environment="TZDIR=/nix/store/2nndxyf3phkb5aggxm3c16sapa0f49kz-tzdata-2026c/share/zoneinfo"
+ExecStart=/nix/store/kxnddbaypz5sic0dgqx60lp4k9z662yg-cloud-hypervisor-53.0/bin/cloud-hypervisor --memory size=2G,shared=on --console file=/tmp/console.log --serial off \
+  --kernel /nix/store/nmyhzfvkn5zagl7lc16w9m6d54v4696d-linux-6.18.41/bzImage \
+  --cmdline 'init=/nix/store/wgjjv8axl1rlfk277h0p4al3x1jn1w95-nixos-system-nixos-kexec-26.11.20260803.104240a/init usbcore.autosuspend=-1 console=hvc0 console=tty0 xhci_pci.dyndbg==pmfl xhci_hcd.dyndbg==pmfl nohibernate root=fstab loglevel=8 lsm=landlock,yama,bpf' \
+  --initramfs /nix/store/swc8c4c3kv1w21mlzcrw7kfpj64pq515-initrd/initrd \
+  --user-device socket=/tmp/usbvfiod.sock \
+  --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
+
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Using hotplug events to start usbvfiod
+
+In these example configurations the hotplug socket is also managed through systemd. Udev rules trigger commands for managing device attachment state using the hotplug socket. Doing this triggers systemd to start the `usbvfiod.service` independent of Cloud Hypervisor service status.
+
+In this scenario either one can start the `usbvfiod.service`: a hotplug event or a starting Cloud Hypervisor.
+
+
+Further reading:
+- https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html
+- https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html
+- https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html
+- https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html
+- https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html

--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -17,6 +17,7 @@ in
 {
   multiple-blockdevices = mkNixosIntegrationTest ./multiple-blockdevices.nix;
   forceful-removal = mkNixosIntegrationTest ./forceful-removal.nix;
+  filedescriptor = mkNixosIntegrationTest ./filedescriptor.nix;
 }
 // import ./controller-reset.nix {
   inherit testutils;

--- a/nix/checks/filedescriptor.nix
+++ b/nix/checks/filedescriptor.nix
@@ -1,0 +1,34 @@
+{
+  testutils,
+}:
+testutils.mkUsbTest {
+  debug = true;
+  name = "systemd-managed-filedescriptor";
+  useFileDescriptor = true;
+  virtualDevices = [
+    {
+      type = "blockdevice";
+      usbVersion = "3";
+    }
+  ];
+  testScript = ''
+    out = cloud_hypervisor.succeed("lsusb", timeout=60)
+    print(out)
+    search("ID ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId} QEMU QEMU USB HARDDRIVE", out)
+
+    # A nested guest reboot will break the vfio-user connection and usbvfiod will exit 0.
+    # When Cloud Hypervisor re-connects to the systemd socket usbvfiod will be restarted.
+    out = cloud_hypervisor.succeed("systemctl reboot", timeout=60)
+    print(out)
+
+    # confirm nested guest shutdown via usbvfiod exit message triggered by the closed vfio-user connection
+    machine.wait_until_succeeds("journalctl -b -u usbvfiod.service | grep 'Deactivated successfully.' ", timeout=60)
+
+    out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=240)
+
+    # When using the socket path setup, we encounter failed to start logs for the cloud hypervisor service.
+    # We do not expect to see this log when using the file descriptor setup.
+    out = machine.fail("journalctl -b -u cloud-hypervisor.service | grep -q 'cloud-hypervisor.service: Failed with result'", timeout=60)
+    print(out)
+  '';
+}

--- a/nix/checks/testutils.nix
+++ b/nix/checks/testutils.nix
@@ -110,8 +110,8 @@ let
   # Putting the socket in a world-readable location is obviously not a
   # good choice for a production setup, but for this test it works
   # well.
-  usbvfiodSocket = "/tmp/usbvfio";
-  usbvfiodSocketHotplug = "/tmp/hotplug";
+  usbvfiodSocket = "/tmp/usbvfiod.sock";
+  usbvfiodSocketHotplug = "/tmp/hotplug.sock";
 
   guestLogFile = "/tmp/console.log";
   qemuLogFile = "/tmp/qemu-vc.log";
@@ -268,55 +268,73 @@ let
     ACTION=="add|change|bind", ATTRS{serial}=="0000:00:${pciAddr}.0", SUBSYSTEM=="usb", ATTRS{product}=="${controller}", ATTR{devpath}=="${port}", MODE="0660", GROUP="usbaccess", SYMLINK+="bus/usb/${symlink}"
   '';
 
-  # configure usbvfiod with `--socket-path` or `--fd`
-  mkSystemdConfig =
-    virtualDevices: debug: useFileDescriptor:
+  # Create the partial usbvfiod argument string for either fs paths or fd ids
+  mkSocketFlag =
+    useFileDescriptor:
     if useFileDescriptor == false then
-      {
-        systemd.services = {
-          usbvfiod = {
-            wantedBy = [ "multi-user.target" ];
-            serviceConfig = {
-              User = "usbaccess";
-              Group = "usbaccess";
-              Restart = "on-failure";
-              RestartSec = "2s";
-              ExecStart = ''
-                ${lib.getExe usbvfiod} ${if debug then "-v" else ""} --socket-path ${usbvfiodSocket} --hotplug-socket-path ${usbvfiodSocketHotplug} ${lib.concatStringsSep " " (builtins.map mkDeviceFlag virtualDevices)}
-              '';
-            };
-            environment = {
-              RUST_BACKTRACE = "full";
-            };
-          };
-
-          cloud-hypervisor =
-            let
-              netboot = mkNetboot debug;
-            in
-            {
-              wantedBy = [ "multi-user.target" ];
-              requires = [ "usbvfiod.service" ];
-              after = [ "usbvfiod.service" ];
-              serviceConfig = {
-                Restart = "on-failure";
-                RestartSec = "2s";
-                ExecStart = ''
-                  ${lib.getExe cloud-hypervisor} --memory size=2G,shared=on --console file=${guestLogFile} --serial off \
-                    --kernel ${netboot.kernel} \
-                    --cmdline ${lib.escapeShellArg netboot.cmdline} \
-                    --initramfs ${netboot.initrd} \
-                    --user-device socket=${usbvfiodSocket} \
-                    --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
-                '';
-              };
-            };
-        };
-      }
+      "--socket-path ${usbvfiodSocket} --hotplug-socket-path ${usbvfiodSocketHotplug}"
     else
-      lib.assertMsg false
-        "useFileDescriptor == true is not yet implemented for the usbvfiod service setup"
-        { };
+      "--fd 3 --hotplug-fd 4";
+
+  # configure usbvfiod with `--socket-path` or `--fd`
+  mkSystemdConfig = virtualDevices: debug: useFileDescriptor: {
+    systemd.services = {
+      usbvfiod = {
+        wantedBy = lib.mkIf (!useFileDescriptor) [ "multi-user.target" ];
+        serviceConfig = {
+          User = "usbaccess";
+          Group = "usbaccess";
+          Restart = "on-failure";
+          RestartSec = "2s";
+          ExecStart = ''
+            ${lib.getExe usbvfiod} ${lib.optionalString debug "-v"} ${mkSocketFlag useFileDescriptor} ${lib.concatStringsSep " " (builtins.map mkDeviceFlag virtualDevices)}
+          '';
+        };
+        environment = {
+          RUST_BACKTRACE = "full";
+        };
+      };
+
+      cloud-hypervisor =
+        let
+          netboot = mkNetboot debug;
+        in
+        {
+          wantedBy = [ "multi-user.target" ];
+          requires = if useFileDescriptor then [ "usbvfiod.socket" ] else [ "usbvfiod.service" ];
+          after = lib.mkIf (!useFileDescriptor) [ "usbvfiod.service" ];
+          serviceConfig = {
+            Restart = "on-failure";
+            RestartSec = "2s";
+            ExecStart = ''
+              ${lib.getExe cloud-hypervisor} --memory size=2G,shared=on --console file=${guestLogFile} --serial off \
+                --kernel ${netboot.kernel} \
+                --cmdline ${lib.escapeShellArg netboot.cmdline} \
+                --initramfs ${netboot.initrd} \
+                --user-device socket=${usbvfiodSocket} \
+                --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
+            '';
+          };
+        };
+    };
+
+    systemd.sockets = lib.mkIf useFileDescriptor {
+      usbvfiod = {
+        description = "sockets to trigger usbvfiod service start and provide communication channels";
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          ListenStream = [
+            "${usbvfiodSocket}"
+            "${usbvfiodSocketHotplug}"
+          ];
+          SocketMode = 0660;
+          SocketUser = "usbaccess";
+          SocketGroup = "usbaccess";
+          Accept = "no";
+        };
+      };
+    };
+  };
 
   # Fill in a template for the qemu.options list for a blockdevice.
   mkQemuBlockdevice =

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,10 @@
 //! to the vfio-user [Backend Program
 //! Conventions](https://www.qemu.org/docs/master/interop/vfio-user.html#backend-program-conventions).
 use std::{
-    os::fd::RawFd,
+    os::{
+        fd::{FromRawFd, OwnedFd, RawFd},
+        unix::net::UnixListener,
+    },
     path::{Path, PathBuf},
 };
 
@@ -27,14 +30,14 @@ pub struct Cli {
     /// Provide the vfio-user socket as file descriptor.
     ///
     /// This option is mutually exclusive with --socket-path.
-    #[arg(long, conflicts_with = "socket_path")]
+    #[arg(long, value_name = "FDNUM", conflicts_with = "socket_path")]
     fd: Option<RawFd>,
 
     /// The path where to create a listening Unix domain socket.
     ///
     /// This is the path where Cloud Hypervisor will connect to
     /// usbvfiod. This option is mutually exclusive with --fd.
-    #[arg(long, required_unless_present = "fd")]
+    #[arg(long, value_name = "PATH", required_unless_present = "fd")]
     socket_path: Option<PathBuf>,
 
     /// Path to a USB device to be attached from VM boot. Can be
@@ -50,6 +53,9 @@ pub struct Cli {
     #[arg(long, value_name = "PATH")]
     pub hotplug_socket_path: Option<PathBuf>,
 
+    #[arg(long, value_name = "FDNUM", conflicts_with = "hotplug_socket_path")]
+    pub hotplug_fd: Option<RawFd>,
+
     /// Enable PCAP logging and write captured USB traffic to this file.
     /// The file will be created when the first packet is logged.
     #[arg(long, value_name = "PATH")]
@@ -64,7 +70,6 @@ pub struct Cli {
 #[derive(Debug)]
 pub enum ServerSocket<'a> {
     /// The socket is already open.
-    #[allow(dead_code)]
     Fd(RawFd),
 
     /// We need to create the socket at this path.
@@ -73,9 +78,35 @@ pub enum ServerSocket<'a> {
 
 impl Cli {
     pub fn server_socket(&self) -> ServerSocket<'_> {
-        self.socket_path.as_ref().map_or_else(
-            || unreachable!(),
-            |socket_path| ServerSocket::Path(socket_path),
+        // The clap configuration above ensures always only one of those two options is Some().
+        self.fd.map_or_else(
+            || {
+                let path = self.socket_path.as_ref().unwrap().as_path();
+                ServerSocket::Path(path)
+            },
+            ServerSocket::Fd,
+        )
+    }
+
+    pub fn hotplug_socket(&self) -> Option<UnixListener> {
+        // The clap configuration above ensures that maximum of one of the two hotplug options is used.
+        self.hotplug_fd.map_or_else(
+            || {
+                self.hotplug_socket_path.as_ref().map_or_else(
+                    || None,
+                    |path| {
+                        Some(
+                            UnixListener::bind(path.as_path())
+                                .expect("failed to use provided hotplug socket path"),
+                        )
+                    },
+                )
+            },
+            |hotplug_fd| {
+                // SAFETY: we have to assume the given fd is valid, there is not much else we can do
+                let owned_fd_hotplug: OwnedFd = unsafe { OwnedFd::from_raw_fd(hotplug_fd) };
+                Some(UnixListener::from(owned_fd_hotplug))
+            },
         )
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,10 @@ mod one_indexed_array;
 mod oneshot_anyhow;
 mod xhci_backend;
 
-use std::{os::unix::net::UnixListener, thread};
+use std::{
+    os::fd::{FromRawFd, OwnedFd},
+    thread,
+};
 
 use anyhow::{Context, Result};
 use async_runtime::init_runtime;
@@ -57,17 +60,20 @@ fn main() -> Result<()> {
         }
     }
 
-    let server = if let cli::ServerSocket::Path(socket_path) = args.server_socket() {
-        Server::new(socket_path, true, backend.irqs(), backend.regions())
-            .context("Failed to create vfio-user server")?
-    } else {
-        unimplemented!("Using a file descriptor as vfio-user connection is not implemented")
+    let server = match args.server_socket() {
+        cli::ServerSocket::Path(socket_path) => {
+            Server::new(socket_path, true, backend.irqs(), backend.regions())
+                .context("Failed to create vfio-user server")?
+        }
+        cli::ServerSocket::Fd(fd) => {
+            // SAFETY: we have to assume the given fd is valid, there is not much else we can do
+            let owned_fd = unsafe { OwnedFd::from_raw_fd(fd) };
+            Server::from_owned_fd(owned_fd, true, backend.irqs(), backend.regions())
+        }
     };
 
-    // listen on socket for hot-attach fds
-    if let Some(hotplug_socket_path) = args.hotplug_socket_path.clone() {
+    if let Some(socket) = args.hotplug_socket() {
         let hotplug_control = backend.hotplug_control();
-        let socket = UnixListener::bind(hotplug_socket_path.as_path()).unwrap();
         thread::Builder::new()
             .name("hot-attach-socket listener".to_string())
             .spawn(move || run_hotplug_server(socket, hotplug_control, runtime.clone()))


### PR DESCRIPTION
This enables to start usbvfiod with the given file descriptors instead of using a socket path.

With this, usbvfiod implements the file deascriptor requirement as mentioned in the vfio-user specification. Previously this was a easy to reach `unreachable!()` statement.
(ref. https://www.qemu.org/docs/master/interop/vfio-user.html#backend-program-conventions)

It enables externally managing the sockets. This is done in the new nix integration test, using a systemd socket unit to create both the vfio-server and hotplug sockets. Additionally there are some docs included to hopefully avoid having to read the systemd manual when attempting to use the systemd socket units in the same fashion as the nix integration test does.

This will stay a Draft until we get the upstream vfio-user release that includes the feature to create a vfio-server with a filedescriptor. Until then there is a temporary commit to override the crate input to the source repositoy instead.