### PR TITLE
Fix handling for WorkerMessage::Stop for the CommandRing worker

### DIFF
--- a/src/device/xhci/command_ring.rs
+++ b/src/device/xhci/command_ring.rs
@@ -383,7 +383,12 @@ impl CommandWorker {
                 )
             }
             CommandTrbVariant::ForceHeader => todo!(),
-            CommandTrbVariant::NoOp => todo!(),
+            CommandTrbVariant::NoOp => EventTrb::new_command_completion_event_trb(
+                trb.address,
+                0,
+                CompletionCode::Success,
+                0,
+            ),
             CommandTrbVariant::Unrecognized(_, trb_parse_error) => {
                 warn!("Failed to parse command TRB {trb_parse_error:?}");
                 EventTrb::new_command_completion_event_trb(

--- a/src/device/xhci/command_ring.rs
+++ b/src/device/xhci/command_ring.rs
@@ -413,3 +413,307 @@ impl CommandWorker {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tokio::{runtime::Handle, sync::mpsc::UnboundedReceiver};
+
+    use crate::{
+        device::{
+            bus::{testutils::TestBusDevice, BusDevice},
+            pci::constants::xhci::{
+                operational::crcr::{self},
+                rings::trb_types,
+            },
+            xhci::{
+                interrupter::tests::testutils::MockInterrupter,
+                registers::UsbcmdRegister,
+                slot_manager::{test::testutils::MockSlotManager, SlotMessage},
+                trb::testutils::RawTrbBuilder,
+            },
+        },
+        dynamic_bus::DynamicBus,
+    };
+
+    use super::*;
+
+    // We can never set a 64 bit Dequeu Pointers lowest 6 bits:
+    // "This field defines high order bits of the initial value of the 64-bit Command Ring Dequeue Pointer."
+    const FIRST_ADDRESS: u64 = 0x10 << 6;
+    const SECOND_ADDRESS: u64 = FIRST_ADDRESS + 0x10;
+    const THIRD_ADDRESS: u64 = SECOND_ADDRESS + 0x10;
+    const FOURTH_ADDRESS: u64 = THIRD_ADDRESS + 0x10;
+
+    const SLOT_ID: u8 = 0;
+
+    /// the ring is not running
+    /// dequeue_pointer points to FIRST_ADDRESS
+    fn init_test() -> (
+        CommandRing,
+        MockInterrupter,
+        UnboundedReceiver<SlotMessage>,
+        Arc<DynamicBus>,
+        UsbcmdRegister,
+    ) {
+        let dma_bus = Arc::new(DynamicBus::new());
+        let dma_backing = vec![99; 16384];
+        dma_bus
+            .add(0x0, Arc::new(TestBusDevice::new(&dma_backing[..])))
+            .unwrap();
+        let async_runtime = Handle::current();
+
+        let (event_sender, interrupter) = MockInterrupter::new();
+
+        let (slot_manager, receiver) = MockSlotManager::new();
+
+        let usbcmd = UsbcmdRegister::new();
+
+        let command_ring = CommandRing::new(
+            dma_bus.clone(),
+            &async_runtime,
+            event_sender,
+            slot_manager.create_slot_worker_handle(),
+            usbcmd.value_reference(),
+        );
+
+        assert!(interrupter.is_empty());
+        assert!(!command_ring.running.load(Ordering::Relaxed));
+
+        // write a dequeue pointer value so the first command trb is next in line
+        command_ring.control(FIRST_ADDRESS).unwrap();
+
+        (command_ring, interrupter, receiver, dma_bus, usbcmd)
+    }
+
+    #[tokio::test]
+    async fn process_many_command_trb_with_one_doorbell() {
+        let (command_ring, mut interrupter, mut receiver, dma_bus, usbcmd) = init_test();
+
+        // place command trb on a ring segment
+        let command_1 = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_type(trb_types::NO_OP_COMMAND)
+            .build();
+        let command_2 = RawTrbBuilder::new(SECOND_ADDRESS)
+            .with_type(trb_types::ENABLE_SLOT_COMMAND)
+            .build();
+        let command_3 = RawTrbBuilder::new(THIRD_ADDRESS)
+            .with_type(trb_types::DISABLE_SLOT_COMMAND)
+            .with_byte(15, SLOT_ID)
+            .build();
+        let command_4 = RawTrbBuilder::new(FOURTH_ADDRESS)
+            .with_data_field(0x1 << 4)
+            .with_type(trb_types::ADDRESS_DEVICE_COMMAND)
+            .with_byte(15, SLOT_ID)
+            .build();
+
+        let commands = vec![command_1, command_2, command_3, command_4];
+
+        for command in &commands {
+            dma_bus.write_bulk(command.address, &command.buffer);
+        }
+
+        // start the ring through usbcmd and doorbell
+        usbcmd.write(usbcmd::RS);
+        command_ring.doorbell().unwrap();
+
+        // expected outcome of the command chain
+
+        // command_1
+        let event = interrupter.await_event().await.unwrap();
+        let expected_event = EventTrb::new_command_completion_event_trb(
+            FIRST_ADDRESS,
+            0,
+            CompletionCode::Success,
+            SLOT_ID,
+        );
+        assert_eq!(event, expected_event);
+
+        // command ring running can be checked here without race condition since
+        // await above acted as "wait until succeeded"
+        assert_eq!(command_ring.status(), crcr::CRR);
+
+        // command_2
+        assert!(!receiver.is_empty());
+        match receiver.recv().await.unwrap() {
+            SlotMessage::EnableSlot(sender) => {
+                sender.send(Ok(SLOT_ID)).unwrap();
+            }
+            unexpected => {
+                panic!("unexpected SlotMessage {unexpected:?}");
+            }
+        }
+        let event = interrupter.await_event().await.unwrap();
+        let expected_event = EventTrb::new_command_completion_event_trb(
+            SECOND_ADDRESS,
+            0,
+            CompletionCode::Success,
+            SLOT_ID,
+        );
+        assert_eq!(event, expected_event);
+
+        // command_3
+        assert!(!receiver.is_empty());
+        match receiver.recv().await.unwrap() {
+            SlotMessage::DisableSlot(id, sender) => {
+                assert_eq!(id, SLOT_ID);
+                sender.send(CompletionCode::Success).unwrap();
+            }
+            unexpected => {
+                panic!("unexpected SlotMessage {unexpected:?}");
+            }
+        }
+        let event = interrupter.await_event().await.unwrap();
+        let expected_event = EventTrb::new_command_completion_event_trb(
+            THIRD_ADDRESS,
+            0,
+            CompletionCode::Success,
+            SLOT_ID,
+        );
+        assert_eq!(event, expected_event);
+
+        // command_4
+        assert!(!receiver.is_empty());
+        match receiver.recv().await.unwrap() {
+            SlotMessage::AddressDevice(data, sender) => {
+                assert_eq!(data.input_context_pointer, 0x1 << 4);
+                assert!(!data.block_set_address_request);
+                assert_eq!(data.slot_id, SLOT_ID);
+                sender.send(CompletionCode::Success).unwrap();
+            }
+            unexpected => {
+                panic!("unexpected SlotMessage {unexpected:?}");
+            }
+        }
+        let event = interrupter.await_event().await.unwrap();
+        let expected_event = EventTrb::new_command_completion_event_trb(
+            FOURTH_ADDRESS,
+            0,
+            CompletionCode::Success,
+            SLOT_ID,
+        );
+        assert_eq!(event, expected_event);
+
+        assert!(interrupter.is_empty());
+        assert!(receiver.is_empty());
+    }
+
+    #[tokio::test]
+    async fn write_to_command_stop_bit_and_restart_with_initial_dequeue_pointer_value() {
+        let (command_ring, mut interrupter, _receiver, dma_bus, usbcmd) = init_test();
+
+        let command = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_type(trb_types::NO_OP_COMMAND)
+            .build();
+
+        dma_bus.write_bulk(command.address, &command.buffer);
+
+        // start the ring through usbcmd and doorbell
+        usbcmd.write(usbcmd::RS);
+        command_ring.doorbell().unwrap();
+
+        // verify running state by waiting for the first command completion event
+        let event = interrupter.await_event().await.unwrap();
+        let expected_event = EventTrb::new_command_completion_event_trb(
+            FIRST_ADDRESS,
+            0,
+            CompletionCode::Success,
+            SLOT_ID,
+        );
+        assert_eq!(event, expected_event);
+
+        assert_eq!(command_ring.status(), crcr::CRR);
+
+        // we likely can expect idle state (without sleep(1) here) and transition to stopped
+        command_ring.control(crcr::CS).unwrap();
+        let event = interrupter.await_event().await.unwrap();
+        let expected_event = EventTrb::new_command_completion_event_trb(
+            SECOND_ADDRESS,
+            0,
+            CompletionCode::CommandRingStopped,
+            SLOT_ID,
+        );
+        assert_eq!(event, expected_event);
+
+        // check it is stopped
+        assert_eq!(command_ring.status() & crcr::CRR, 0);
+
+        // write a dequeue pointer value so the first command trb is next in line
+        command_ring.control(FIRST_ADDRESS).unwrap();
+
+        // restart
+        command_ring.doorbell().unwrap();
+
+        // verify running state by waiting for the first command completion event
+        let event = interrupter.await_event().await.unwrap();
+        let expected_event = EventTrb::new_command_completion_event_trb(
+            FIRST_ADDRESS,
+            0,
+            CompletionCode::Success,
+            SLOT_ID,
+        );
+        assert_eq!(event, expected_event);
+
+        assert_eq!(command_ring.status(), crcr::CRR);
+        assert!(interrupter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn write_to_command_abort_bit() {
+        let (command_ring, mut interrupter, _receiver, dma_bus, usbcmd) = init_test();
+
+        let command = RawTrbBuilder::new(FIRST_ADDRESS)
+            .with_type(trb_types::NO_OP_COMMAND)
+            .build();
+
+        dma_bus.write_bulk(command.address, &command.buffer);
+        dma_bus.write_bulk(SECOND_ADDRESS, &command.buffer);
+        dma_bus.write_bulk(THIRD_ADDRESS, &command.buffer);
+        dma_bus.write_bulk(FOURTH_ADDRESS, &command.buffer);
+
+        // start the ring through usbcmd and doorbell
+        usbcmd.write(usbcmd::RS);
+        command_ring.doorbell().unwrap();
+
+        // verify running state by waiting for the first command completion event
+        let event = interrupter.await_event().await.unwrap();
+        let expected_event = EventTrb::new_command_completion_event_trb(
+            FIRST_ADDRESS,
+            0,
+            CompletionCode::Success,
+            SLOT_ID,
+        );
+        assert_eq!(event, expected_event);
+
+        assert_eq!(command_ring.status(), crcr::CRR);
+
+        // abort ring operations
+        //
+        // As time of writing I have not found a surefire way to stop in between
+        // the No Op Command TRB's. So we can not be sure if we are still processing
+        // or are already done and switched to idle.
+        command_ring.control(crcr::CA).unwrap();
+        loop {
+            let event = interrupter.await_event().await.unwrap();
+            debug!("{:?}", event);
+            match event {
+                EventTrb::CommandCompletion(event_trb) => match event_trb.get_completion_code() {
+                    CompletionCode::Success => {
+                        assert_eq!(command_ring.status() & crcr::CRR, crcr::CRR);
+                    }
+                    CompletionCode::CommandRingStopped => {
+                        assert_eq!(command_ring.status() & crcr::CRR, 0);
+                        break;
+                    }
+                    unexpected => {
+                        panic!("unexpected completion code in event trb: {unexpected:?}");
+                    }
+                },
+                unexpected => {
+                    panic!("unexpected event trb: {unexpected:?}");
+                }
+            }
+        }
+
+        assert!(interrupter.is_empty());
+    }
+}

--- a/src/device/xhci/command_ring.rs
+++ b/src/device/xhci/command_ring.rs
@@ -188,7 +188,7 @@ impl CommandWorker {
 
     // function only returns on error, but cannot use ! in Result
     async fn run_loop(&mut self) -> anyhow::Result<()> {
-        loop {
+        'run_loop: loop {
             match &self.state {
                 WorkerState::Stopped => match self.next_msg().await? {
                     WorkerMessage::Reset(completion) => {
@@ -243,7 +243,7 @@ impl CommandWorker {
                             }
                             WorkerMessage::Stop => {
                                 self.state = WorkerState::Stopping;
-                                break;
+                                continue 'run_loop;
                             }
                             msg => warn!("Unexpected message: msg={msg:?}, state={:?}", self.state),
                         }
@@ -273,6 +273,14 @@ impl CommandWorker {
                 }
                 WorkerState::Stopping => {
                     self.commandring_running.store(false, Ordering::Relaxed);
+                    let (dequeue_pointer, _) = self.ring.get_dequeue_pointer();
+                    let event = EventTrb::new_command_completion_event_trb(
+                        dequeue_pointer,
+                        0,
+                        CompletionCode::CommandRingStopped,
+                        0,
+                    );
+                    self.event_sender.send(event)?;
                     self.state = WorkerState::Stopped;
                 }
             }

--- a/src/device/xhci/interrupter.rs
+++ b/src/device/xhci/interrupter.rs
@@ -232,3 +232,66 @@ impl EventWorker {
         self.event_ring.reset();
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    pub mod testutils {
+        use std::time::Duration;
+
+        use tokio::time::timeout;
+
+        use super::*;
+
+        const ASYNC_TIMEOUT_SECS: u64 = 30;
+
+        pub struct MockInterrupter {
+            timeout_sec: Duration,
+            msg_recv: mpsc::UnboundedReceiver<InterrupterMessage>,
+        }
+
+        impl MockInterrupter {
+            pub fn new() -> (EventSender, Self) {
+                let (sender, recv) = mpsc::unbounded_channel();
+                let event_sender = EventSender { sender };
+                let dummy = Self {
+                    timeout_sec: Duration::from_secs(ASYNC_TIMEOUT_SECS),
+                    msg_recv: recv,
+                };
+
+                (event_sender, dummy)
+            }
+
+            pub fn is_empty(&self) -> bool {
+                self.msg_recv.is_empty()
+            }
+
+            /// receiving anything else than a EventTrb will return None
+            pub async fn await_event(&mut self) -> Option<EventTrb> {
+                match timeout(self.timeout_sec, self.msg_recv.recv()).await {
+                    Ok(Some(InterrupterMessage::SendEvent(event_trb))) => Some(event_trb),
+                    _ => None,
+                }
+            }
+        }
+
+        mod tests {
+            use super::*;
+
+            #[tokio::test]
+            async fn send_event_through_dummy_interrupter() {
+                let (event_sender, mut interrupter) = MockInterrupter::new();
+
+                let event = EventTrb::new_port_status_change_event_trb(1);
+                matches!(event_sender.send(event), Ok(()));
+
+                assert!(!interrupter.is_empty());
+                assert_eq!(
+                    interrupter.await_event().await,
+                    Some(EventTrb::new_port_status_change_event_trb(1))
+                );
+            }
+        }
+    }
+}

--- a/src/device/xhci/linked_ring.rs
+++ b/src/device/xhci/linked_ring.rs
@@ -109,6 +109,7 @@ impl LinkedRing {
         self.cycle_state = cycle_state;
     }
 
+    /// returns (dequeue_pointer, cycle_state)
     pub const fn get_dequeue_pointer(&self) -> (u64, bool) {
         (self.dequeue_pointer, self.cycle_state)
     }

--- a/src/device/xhci/slot_manager.rs
+++ b/src/device/xhci/slot_manager.rs
@@ -867,3 +867,33 @@ impl SlotWorkerHandle {
         Ok(completion_code)
     }
 }
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    pub mod testutils {
+        use tokio::sync::mpsc::UnboundedReceiver;
+
+        use super::*;
+
+        #[derive(Debug)]
+        pub struct MockSlotManager {
+            msg_send: mpsc::UnboundedSender<SlotMessage>,
+        }
+
+        impl MockSlotManager {
+            pub fn new() -> (Self, UnboundedReceiver<SlotMessage>) {
+                let (msg_send, msg_recv) = mpsc::unbounded_channel();
+
+                (Self { msg_send }, msg_recv)
+            }
+
+            pub fn create_slot_worker_handle(&self) -> SlotWorkerHandle {
+                SlotWorkerHandle {
+                    msg_send: self.msg_send.clone(),
+                }
+            }
+        }
+    }
+}

--- a/src/device/xhci/trb.rs
+++ b/src/device/xhci/trb.rs
@@ -126,6 +126,11 @@ impl CommandCompletionEventTrbData {
 
         trb
     }
+
+    #[cfg(test)]
+    pub const fn get_completion_code(&self) -> CompletionCode {
+        self.completion_code
+    }
 }
 
 /// Stores the relevant data for a Port Status Change Event.
@@ -378,11 +383,12 @@ impl CommandTrbVariant {
     /// While this function can parse all available Command TRB types, it does
     /// not parse all of them in full detail. If the function returns only the
     /// enum variant without an associated struct, the parsing for the
-    /// particular command is not yet implemented. EnableSlotCommand is an
-    /// exception, because the TRB does not contain any additional information.
+    /// particular command is not yet implemented. NoOpCommand and EnableSlotCommand
+    /// are exceptions, because the TRB does not contain any additional information.
     pub fn parse(bytes: RawTrbBuffer) -> Self {
         let trb_type = bytes[13] >> 2;
         match trb_type {
+            trb_types::NO_OP_COMMAND => Self::NoOp,
             // EnableSlotCommand does not contain information apart from the
             // type; thus, no further parsing is necessary and we can just
             // return the enum variant.
@@ -421,7 +427,6 @@ impl CommandTrbVariant {
                 ),
             ),
             trb_types::FORCE_HEADER_COMMAND => Self::ForceHeader,
-            trb_types::NO_OP_COMMAND => Self::NoOp,
             trb_type => Self::Unrecognized(bytes, TrbParseError::UnknownTrbType(trb_type)),
         }
     }

--- a/src/device/xhci/trb.rs
+++ b/src/device/xhci/trb.rs
@@ -352,6 +352,7 @@ pub struct CommandTrb {
 /// See XHCI specification Section 6.4.3 for detailed command TRB type descriptions.
 #[derive(Debug, PartialEq, Eq)]
 pub enum CommandTrbVariant {
+    NoOp,
     EnableSlot,
     DisableSlot(DisableSlotCommandTrbData),
     AddressDevice(AddressDeviceCommandTrbData),
@@ -362,7 +363,6 @@ pub enum CommandTrbVariant {
     SetTrDequeuePointer(SetTrDequeuePointerCommandTrbData),
     ResetDevice(ResetDeviceCommandTrbData),
     ForceHeader,
-    NoOp,
     Unrecognized(RawTrbBuffer, TrbParseError),
 }
 

--- a/src/device/xhci/trb.rs
+++ b/src/device/xhci/trb.rs
@@ -11,7 +11,7 @@ use super::super::pci::constants::xhci::rings::trb_types::{self, *};
 /// of a Transfer Request Block.
 pub type RawTrbBuffer = [u8; 16];
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct RawTrb {
     pub address: u64,
     pub buffer: RawTrbBuffer,
@@ -1093,6 +1093,217 @@ pub enum TrbParseError {
     UnknownTrbType(u8),
     #[error("Detected a non-zero value in a RsvdZ field")]
     RsvdZViolation,
+}
+
+#[cfg(test)]
+pub mod testutils {
+    use super::*;
+
+    /// This Builder simplifies creating RawTrb and prevents some easy mistakes when
+    /// manually writing the correct value at the corresponding index of the buffers.
+    pub struct RawTrbBuilder {
+        pub address: u64,
+        pub buffer: RawTrbBuffer,
+    }
+    impl RawTrbBuilder {
+        const CH: u8 = 0x10;
+        const IOC: u8 = 0x20;
+        const IDT: u8 = 0x40;
+        const DIR: u8 = 0x1;
+
+        pub fn new(address: u64) -> Self {
+            Self {
+                address,
+                buffer: [0; 16],
+            }
+        }
+
+        /// setup stage trb exclusive field: bmRequestType
+        pub fn with_setup_type(mut self, value: u8) -> Self {
+            self.buffer[0] = value;
+            self
+        }
+
+        /// setup stage trb exclusive field: wLength
+        pub fn with_setup_length(mut self, value: u16) -> Self {
+            let value_bytes: [u8; 2] = value.to_le_bytes();
+            self.buffer[6..(2 + 6)].copy_from_slice(&value_bytes);
+            self
+        }
+
+        /// first 8 bytes of the trb
+        pub fn with_data_field(mut self, value: u64) -> Self {
+            let value_bytes: [u8; 8] = value.to_le_bytes();
+            self.buffer[..8].copy_from_slice(&value_bytes);
+            self
+        }
+
+        /// byte index 8 & 9 & 1 Bit of 10th: TRB Transfer Length
+        pub fn with_length(mut self, length: u32) -> Self {
+            let length_bytes: [u8; 4] = length.to_le_bytes();
+            self.buffer[8..(2 + 8)].copy_from_slice(&length_bytes[0..2]);
+            self.buffer[10] = length_bytes[2] & 0b1;
+            self
+        }
+
+        /// chain bit
+        pub fn with_ch(mut self) -> Self {
+            self.buffer[12] |= Self::CH;
+            self
+        }
+
+        /// interrupt on completion bit
+        pub fn with_ioc(mut self) -> Self {
+            self.buffer[12] |= Self::IOC;
+            self
+        }
+
+        /// immediate data bit
+        pub fn with_idt(mut self) -> Self {
+            self.buffer[12] |= Self::IDT;
+            self
+        }
+
+        /// trb type field
+        pub fn with_type(mut self, trb_type: u8) -> Self {
+            self.buffer[13] |= trb_type << 2;
+            self
+        }
+
+        /// direction bit
+        ///
+        /// for data stage and status stage trb
+        ///
+        /// if DIR { IN } else { OUT }
+        pub fn with_dir(mut self) -> Self {
+            self.buffer[14] |= Self::DIR;
+            self
+        }
+
+        /// absolute write to an arbitrary byte index
+        pub fn with_byte(mut self, index: usize, value: u8) -> Self {
+            assert!(index < self.buffer.len());
+            self.buffer[index] = value;
+            self
+        }
+
+        pub fn build(self) -> RawTrb {
+            RawTrb {
+                address: self.address,
+                buffer: self.buffer,
+            }
+        }
+    }
+
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn build_normal_trb_as_raw_trb() {
+            let normal = RawTrbBuilder::new(0x10)
+                .with_data_field(0x1122334455667788)
+                .with_length(2048)
+                .with_ioc()
+                .with_ch()
+                .with_type(0x1)
+                .build();
+            let expect = RawTrb {
+                address: 0x10,
+                buffer: [
+                    0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0, 0x8, 0, 0, 0x30, 0x4, 0, 0,
+                ],
+            };
+            assert_eq!(normal, expect);
+        }
+
+        #[test]
+        fn build_normal_trb_as_raw_trb_with_max_length() {
+            let normal = RawTrbBuilder::new(0x10)
+                .with_data_field(0x1122334455667788)
+                // this is the fields maximum value not the as per specification allowed maximum value of 0x1_0000
+                .with_length(0x1_ffff)
+                .with_ioc()
+                .with_ch()
+                .with_type(0x1)
+                .build();
+            let expect = RawTrb {
+                address: 0x10,
+                buffer: [
+                    0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0xff, 0xff, 0x1, 0, 0x30, 0x4,
+                    0, 0,
+                ],
+            };
+            assert_eq!(normal, expect);
+        }
+
+        #[test]
+        fn build_control_in_setup_stage_as_raw_trb() {
+            let setup_stage = RawTrbBuilder::new(0x10)
+                .with_setup_type(0x80)
+                .with_setup_length(512)
+                .with_length(1024)
+                .with_idt()
+                .with_ioc()
+                .with_type(0x2)
+                .with_byte(14, 0x3) // TRT: IN Data Stage
+                .build();
+            let expect = RawTrb {
+                address: 0x10,
+                buffer: [0x80, 0, 0, 0, 0, 0, 0, 0x2, 0, 0x4, 0, 0, 0x60, 0x8, 0x3, 0],
+            };
+            assert_eq!(setup_stage, expect);
+        }
+
+        #[test]
+        fn build_control_in_data_stage_as_raw_trb() {
+            let data_stage = RawTrbBuilder::new(0x10)
+                .with_data_field(0x112233445566)
+                .with_idt()
+                .with_ioc()
+                .with_type(0x3)
+                .with_dir()
+                .build();
+            let expect = RawTrb {
+                address: 0x10,
+                buffer: [
+                    0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0, 0, 0, 0, 0, 0, 0x60, 0xc, 0x1, 0,
+                ],
+            };
+            assert_eq!(data_stage, expect);
+        }
+
+        #[test]
+        fn build_control_in_status_stage_as_raw_trb() {
+            let status_stage = RawTrbBuilder::new(0x10)
+                .with_ioc()
+                .with_ch()
+                .with_type(0x4)
+                .with_dir()
+                .build();
+            let expect = RawTrb {
+                address: 0x10,
+                buffer: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x30, 0x10, 0x1, 0],
+            };
+            assert_eq!(status_stage, expect);
+        }
+
+        #[test]
+        fn build_event_data_as_raw_trb() {
+            let event_data = RawTrbBuilder::new(0x10)
+                .with_data_field(0xe4e117da7a)
+                .with_ioc()
+                .with_type(0x7)
+                .with_dir()
+                .build();
+            let expect = RawTrb {
+                address: 0x10,
+                buffer: [
+                    0x7a, 0xda, 0x17, 0xe1, 0xe4, 0, 0, 0, 0, 0, 0, 0, 0x20, 0x1c, 0x1, 0,
+                ],
+            };
+            assert_eq!(event_data, expect);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/device/xhci/trb.rs
+++ b/src/device/xhci/trb.rs
@@ -25,7 +25,7 @@ pub const fn zeroed_trb_buffer() -> RawTrbBuffer {
 /// Represents a TRB that the XHCI controller can place on the event ring.
 ///
 /// See XHCI specification Section 6.4.2 for detailed event TRB type descriptions.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum EventTrb {
     Transfer(TransferEventTrbData),
     CommandCompletion(CommandCompletionEventTrbData),
@@ -65,7 +65,7 @@ impl EventTrb {
 ///
 /// Do not use this struct directly, use EventTrb::new_command_completion_event_trb
 /// instead.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CommandCompletionEventTrbData {
     command_trb_pointer: u64,
     command_completion_parameter: u32,
@@ -132,7 +132,7 @@ impl CommandCompletionEventTrbData {
 ///
 /// Do not use this struct directly, use EventTrb::new_port_status_change_event_trb
 /// instead.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PortStatusChangeEventTrbData {
     port_id: u8,
 }
@@ -164,7 +164,7 @@ impl PortStatusChangeEventTrbData {
 }
 
 /// Stores the relevant data for a Transfer Event.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct TransferEventTrbData {
     trb_pointer: u64,
     trb_transfer_length: u32,
@@ -227,7 +227,7 @@ impl TransferEventTrbData {
 ///
 /// Refer to Table 6-90 in the XHCI specification for detailed descriptions of each code.
 #[allow(dead_code)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum CompletionCode {
     Invalid = 0,
     Success,


### PR DESCRIPTION
A new unit test and a fix discovered when adding the test.