### PR TITLE
Refactor nix tests to remove boilerplate systemd config snippets

### DIFF
--- a/nix/checks/attach-detach.nix
+++ b/nix/checks/attach-detach.nix
@@ -1,53 +1,40 @@
 {
-  lib,
-  cloud-hypervisor,
   usbvfiod,
   testutils,
 }:
 let
-  systemd-config = args: {
-    systemd.services = {
-      usbvfiod = {
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          User = "usbaccess";
-          Group = "usbaccess";
-          Restart = "on-failure";
-          RestartSec = "2s";
-          ExecStart = ''
-            ${lib.getExe usbvfiod} ${
-              if args.debug then "-v" else ""
-            } --socket-path ${testutils.usbvfiodSocket} --hotplug-socket-path ${testutils.usbvfiodSocketHotplug} ${lib.concatStringsSep " " (builtins.map testutils.mkDeviceFlag args.virtualDevices)}
-          '';
-        };
-        environment = {
-          RUST_BACKTRACE = "full";
-        };
-      };
+  testScript = ''
+    # Run the attach-detach loop a few times.
+    for i in range(1,20):
+      print(f"ATTACH DETACH LOOP {i}")
+      # List and print all attached devices.
+      out = machine.wait_until_succeeds("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=60)
+      search("No attached devices", out)
 
-      cloud-hypervisor =
-        let
-          netboot = testutils.mkNetboot args.debug;
-        in
-        {
-          wantedBy = [ "multi-user.target" ];
-          requires = [ "usbvfiod.service" ];
-          after = [ "usbvfiod.service" ];
-          serviceConfig = {
-            Restart = "on-failure";
-            RestartSec = "2s";
-            ExecStart = ''
-              ${lib.getExe cloud-hypervisor} --memory size=2G,shared=on --console file=${testutils.guestLogFile} --serial off \
-                --kernel ${netboot.kernel} \
-                --cmdline ${lib.escapeShellArg netboot.cmdline} \
-                --initramfs ${netboot.initrd} \
-                --user-device socket=${testutils.usbvfiodSocket} \
-                --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
-            '';
-          };
-        };
-    };
-  };
+      # Attach a device.
+      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --attach /dev/bus/usb/usbdevice", timeout=60)
+      print(out)
+
+      # List attached devices.
+      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=60)
+      print(out)
+
+      # Get the bus and device numbers.
+      (bus_nr, device_nr) = re.search(r'(\d{3}):(\d{3})',out).groups()
+      print(f"Bus number: {bus_nr}, Device number: {device_nr}")
+
+      # Wait for the guest to find the usb device.
+      if (i % 2 == 0):
+        cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+
+      # Wait for the guest to find the blockdevice.
+      if (i % 4 == 0):
+        cloud_hypervisor.wait_until_succeeds("lsblk /dev/sd*", timeout=120)
+
+      # Detach the device.
+      out = machine.succeed(f"${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --detach {bus_nr} {device_nr}", timeout=60)
+      print(out)
+  '';
 in
 builtins.listToAttrs (
   builtins.map (usbVersion: {
@@ -62,38 +49,7 @@ builtins.listToAttrs (
           attachedOnStartup = "host";
         }
       ];
-      testScript = ''
-        # Run the attach-detach loop a few times.
-        for i in range(1,20):
-          print(f"ATTACH DETACH LOOP {i}")
-          # List and print all attached devices.
-          out = machine.wait_until_succeeds("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=60)
-          search("No attached devices", out)
-
-          # Attach a device.
-          out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --attach /dev/bus/usb/usbdevice", timeout=60)
-          print(out)
-
-          # List attached devices.
-          out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=60)
-          print(out)
-
-          # Get the bus and device numbers.
-          (bus_nr, device_nr) = re.search(r'(\d{3}):(\d{3})',out).groups()
-          print(f"Bus number: {bus_nr}, Device number: {device_nr}")
-
-          # Wait for the guest to find the usb device.
-          if (i % 2 == 0):
-            cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
-
-          # Wait for the guest to find the blockdevice.
-          if (i % 4 == 0):
-            cloud_hypervisor.wait_until_succeeds("lsblk /dev/sd*", timeout=120)
-
-          # Detach the device.
-          out = machine.succeed(f"${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --detach {bus_nr} {device_nr}", timeout=60)
-          print(out)
-      '';
-    } systemd-config;
+      inherit testScript;
+    };
   }) (builtins.attrNames testutils.usbVersions)
 )

--- a/nix/checks/blockdevice.nix
+++ b/nix/checks/blockdevice.nix
@@ -1,55 +1,8 @@
 {
-  lib,
-  cloud-hypervisor,
-  usbvfiod,
   testutils,
 }:
 let
-  systemd-config = args: {
-    systemd.services = {
-      usbvfiod = {
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          User = "usbaccess";
-          Group = "usbaccess";
-          Restart = "on-failure";
-          RestartSec = "2s";
-          ExecStart = ''
-            ${lib.getExe usbvfiod} ${
-              if args.debug then "-v" else ""
-            } --socket-path ${testutils.usbvfiodSocket} --hotplug-socket-path ${testutils.usbvfiodSocketHotplug} ${lib.concatStringsSep " " (builtins.map testutils.mkDeviceFlag args.virtualDevices)}
-          '';
-        };
-        environment = {
-          RUST_BACKTRACE = "full";
-        };
-      };
-
-      cloud-hypervisor =
-        let
-          netboot = testutils.mkNetboot args.debug;
-        in
-        {
-          wantedBy = [ "multi-user.target" ];
-          requires = [ "usbvfiod.service" ];
-          after = [ "usbvfiod.service" ];
-          serviceConfig = {
-            Restart = "on-failure";
-            RestartSec = "2s";
-            ExecStart = ''
-              ${lib.getExe cloud-hypervisor} --memory size=2G,shared=on --console file=${testutils.guestLogFile} --serial off \
-                --kernel ${netboot.kernel} \
-                --cmdline ${lib.escapeShellArg netboot.cmdline} \
-                --initramfs ${netboot.initrd} \
-                --user-device socket=${testutils.usbvfiodSocket} \
-                --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
-            '';
-          };
-        };
-    };
-  };
-
-  singleBlockDeviceTestScript = ''
+  testScript = ''
     # Confirm USB controller pops up in boot logs
     out = cloud_hypervisor.succeed("journalctl -b", timeout=60)
     search("usb usb1: Product: xHCI Host Controller", out)
@@ -109,7 +62,7 @@ builtins.listToAttrs (
           inherit usbVersion;
         }
       ];
-      testScript = singleBlockDeviceTestScript;
-    } systemd-config;
+      inherit testScript;
+    };
   }) (builtins.attrNames testutils.usbVersions)
 )

--- a/nix/checks/controller-reset.nix
+++ b/nix/checks/controller-reset.nix
@@ -1,54 +1,7 @@
 {
-  lib,
-  cloud-hypervisor,
-  usbvfiod,
   testutils,
 }:
 let
-  systemd-config = args: {
-    systemd.services = {
-      usbvfiod = {
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          User = "usbaccess";
-          Group = "usbaccess";
-          Restart = "on-failure";
-          RestartSec = "2s";
-          ExecStart = ''
-            ${lib.getExe usbvfiod} ${
-              if args.debug then "-v" else ""
-            } --socket-path ${testutils.usbvfiodSocket} --hotplug-socket-path ${testutils.usbvfiodSocketHotplug} ${lib.concatStringsSep " " (builtins.map testutils.mkDeviceFlag args.virtualDevices)}
-          '';
-        };
-        environment = {
-          RUST_BACKTRACE = "full";
-        };
-      };
-
-      cloud-hypervisor =
-        let
-          netboot = testutils.mkNetboot args.debug;
-        in
-        {
-          wantedBy = [ "multi-user.target" ];
-          requires = [ "usbvfiod.service" ];
-          after = [ "usbvfiod.service" ];
-          serviceConfig = {
-            Restart = "on-failure";
-            RestartSec = "2s";
-            ExecStart = ''
-              ${lib.getExe cloud-hypervisor} --memory size=2G,shared=on --console file=${testutils.guestLogFile} --serial off \
-                --kernel ${netboot.kernel} \
-                --cmdline ${lib.escapeShellArg netboot.cmdline} \
-                --initramfs ${netboot.initrd} \
-                --user-device socket=${testutils.usbvfiodSocket} \
-                --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
-            '';
-          };
-        };
-    };
-  };
-
   testScript = ''
     # Wait until the USB drive is recognized.
     out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
@@ -87,6 +40,6 @@ builtins.listToAttrs (
         }
       ];
       inherit testScript;
-    } systemd-config;
+    };
   }) (builtins.attrNames testutils.usbVersions)
 )

--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -4,12 +4,14 @@
   usbvfiod,
 }:
 let
-  testutils = import ./testutils.nix { inherit lib pkgs; };
+  testutils = import ./testutils.nix {
+    inherit lib pkgs usbvfiod;
+    inherit (pkgs) cloud-hypervisor;
+  };
   mkNixosIntegrationTest =
     file:
     pkgs.callPackage file {
-      inherit (pkgs) cloud-hypervisor;
-      inherit usbvfiod testutils;
+      inherit testutils;
     };
 in
 {
@@ -17,42 +19,14 @@ in
   forceful-removal = mkNixosIntegrationTest ./forceful-removal.nix;
 }
 // import ./controller-reset.nix {
-  inherit (pkgs)
-    cloud-hypervisor
-    ;
-  inherit
-    lib
-    usbvfiod
-    testutils
-    ;
+  inherit testutils;
 }
 // import ./blockdevice.nix {
-  inherit (pkgs)
-    cloud-hypervisor
-    ;
-  inherit
-    lib
-    usbvfiod
-    testutils
-    ;
+  inherit testutils;
 }
 // import ./attach-detach.nix {
-  inherit (pkgs)
-    cloud-hypervisor
-    ;
-  inherit
-    lib
-    usbvfiod
-    testutils
-    ;
+  inherit usbvfiod testutils;
 }
 // import ./interrupt.nix {
-  inherit (pkgs)
-    cloud-hypervisor
-    ;
-  inherit
-    lib
-    usbvfiod
-    testutils
-    ;
+  inherit testutils;
 }

--- a/nix/checks/forceful-removal.nix
+++ b/nix/checks/forceful-removal.nix
@@ -1,54 +1,7 @@
 {
-  lib,
-  cloud-hypervisor,
   usbvfiod,
   testutils,
 }:
-let
-  systemd-config = args: {
-    systemd.services = {
-      usbvfiod = {
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          User = "usbaccess";
-          Group = "usbaccess";
-          Restart = "on-failure";
-          RestartSec = "2s";
-          ExecStart = ''
-            ${lib.getExe usbvfiod} ${
-              if args.debug then "-v" else ""
-            } --socket-path ${testutils.usbvfiodSocket} --hotplug-socket-path ${testutils.usbvfiodSocketHotplug} ${lib.concatStringsSep " " (builtins.map testutils.mkDeviceFlag args.virtualDevices)}
-          '';
-        };
-        environment = {
-          RUST_BACKTRACE = "full";
-        };
-      };
-
-      cloud-hypervisor =
-        let
-          netboot = testutils.mkNetboot args.debug;
-        in
-        {
-          wantedBy = [ "multi-user.target" ];
-          requires = [ "usbvfiod.service" ];
-          after = [ "usbvfiod.service" ];
-          serviceConfig = {
-            Restart = "on-failure";
-            RestartSec = "2s";
-            ExecStart = ''
-              ${lib.getExe cloud-hypervisor} --memory size=2G,shared=on --console file=${testutils.guestLogFile} --serial off \
-                --kernel ${netboot.kernel} \
-                --cmdline ${lib.escapeShellArg netboot.cmdline} \
-                --initramfs ${netboot.initrd} \
-                --user-device socket=${testutils.usbvfiodSocket} \
-                --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
-            '';
-          };
-        };
-    };
-  };
-in
 testutils.mkUsbTest {
   name = "forceful removal";
   virtualDevices = [
@@ -126,4 +79,4 @@ testutils.mkUsbTest {
       # Wait until the xHC can confirm there is no device attached anymore.
       machine.wait_until_succeeds("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list | grep 'No attached devices'", timeout=60)
   '';
-} systemd-config
+}

--- a/nix/checks/interrupt.nix
+++ b/nix/checks/interrupt.nix
@@ -1,54 +1,6 @@
 {
-  lib,
-  cloud-hypervisor,
-  usbvfiod,
   testutils,
 }:
-let
-  systemd-config = args: {
-    systemd.services = {
-      usbvfiod = {
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          User = "usbaccess";
-          Group = "usbaccess";
-          Restart = "on-failure";
-          RestartSec = "2s";
-          ExecStart = ''
-            ${lib.getExe usbvfiod} ${
-              if args.debug then "-v" else ""
-            } --socket-path ${testutils.usbvfiodSocket} --hotplug-socket-path ${testutils.usbvfiodSocketHotplug} ${lib.concatStringsSep " " (builtins.map testutils.mkDeviceFlag args.virtualDevices)}
-          '';
-        };
-        environment = {
-          RUST_BACKTRACE = "full";
-        };
-      };
-
-      cloud-hypervisor =
-        let
-          netboot = testutils.mkNetboot args.debug;
-        in
-        {
-          wantedBy = [ "multi-user.target" ];
-          requires = [ "usbvfiod.service" ];
-          after = [ "usbvfiod.service" ];
-          serviceConfig = {
-            Restart = "on-failure";
-            RestartSec = "2s";
-            ExecStart = ''
-              ${lib.getExe cloud-hypervisor} --memory size=2G,shared=on --console file=${testutils.guestLogFile} --serial off \
-                --kernel ${netboot.kernel} \
-                --cmdline ${lib.escapeShellArg netboot.cmdline} \
-                --initramfs ${netboot.initrd} \
-                --user-device socket=${testutils.usbvfiodSocket} \
-                --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
-            '';
-          };
-        };
-    };
-  };
-in
 builtins.listToAttrs (
   builtins.map (usbVersion: {
     name = "interrupt-endpoint-usb-${builtins.replaceStrings [ "." ] [ "_" ] usbVersion}";
@@ -96,6 +48,6 @@ builtins.listToAttrs (
         # Make a clean exit since the test will wait for thread termination either way.
         t1.join()
       '';
-    } systemd-config;
+    };
   }) (builtins.attrNames testutils.usbVersions)
 )

--- a/nix/checks/multiple-blockdevices.nix
+++ b/nix/checks/multiple-blockdevices.nix
@@ -1,54 +1,6 @@
 {
-  lib,
-  cloud-hypervisor,
-  usbvfiod,
   testutils,
 }:
-let
-  systemd-config = args: {
-    systemd.services = {
-      usbvfiod = {
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          User = "usbaccess";
-          Group = "usbaccess";
-          Restart = "on-failure";
-          RestartSec = "2s";
-          ExecStart = ''
-            ${lib.getExe usbvfiod} ${
-              if args.debug then "-v" else ""
-            } --socket-path ${testutils.usbvfiodSocket} --hotplug-socket-path ${testutils.usbvfiodSocketHotplug} ${lib.concatStringsSep " " (builtins.map testutils.mkDeviceFlag args.virtualDevices)}
-          '';
-        };
-        environment = {
-          RUST_BACKTRACE = "full";
-        };
-      };
-
-      cloud-hypervisor =
-        let
-          netboot = testutils.mkNetboot args.debug;
-        in
-        {
-          wantedBy = [ "multi-user.target" ];
-          requires = [ "usbvfiod.service" ];
-          after = [ "usbvfiod.service" ];
-          serviceConfig = {
-            Restart = "on-failure";
-            RestartSec = "2s";
-            ExecStart = ''
-              ${lib.getExe cloud-hypervisor} --memory size=2G,shared=on --console file=${testutils.guestLogFile} --serial off \
-                --kernel ${netboot.kernel} \
-                --cmdline ${lib.escapeShellArg netboot.cmdline} \
-                --initramfs ${netboot.initrd} \
-                --user-device socket=${testutils.usbvfiodSocket} \
-                --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
-            '';
-          };
-        };
-    };
-  };
-in
 testutils.mkUsbTest {
   name = "multiple-blockdevices";
   debug = false;
@@ -95,4 +47,4 @@ testutils.mkUsbTest {
     search(r'sdg\s+\d+:\d+\s+0\s+${testutils.imageSize}\s+0\s+disk', out)
     search(r'sdh\s+\d+:\d+\s+0\s+${testutils.imageSize}\s+0\s+disk', out)
   '';
-} systemd-config
+}

--- a/nix/checks/testutils.nix
+++ b/nix/checks/testutils.nix
@@ -1,6 +1,8 @@
 {
   lib,
   pkgs,
+  cloud-hypervisor,
+  usbvfiod,
   ...
 }:
 let
@@ -266,6 +268,56 @@ let
     ACTION=="add|change|bind", ATTRS{serial}=="0000:00:${pciAddr}.0", SUBSYSTEM=="usb", ATTRS{product}=="${controller}", ATTR{devpath}=="${port}", MODE="0660", GROUP="usbaccess", SYMLINK+="bus/usb/${symlink}"
   '';
 
+  # configure usbvfiod with `--socket-path` or `--fd`
+  mkSystemdConfig =
+    virtualDevices: debug: useFileDescriptor:
+    if useFileDescriptor == false then
+      {
+        systemd.services = {
+          usbvfiod = {
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              User = "usbaccess";
+              Group = "usbaccess";
+              Restart = "on-failure";
+              RestartSec = "2s";
+              ExecStart = ''
+                ${lib.getExe usbvfiod} ${if debug then "-v" else ""} --socket-path ${usbvfiodSocket} --hotplug-socket-path ${usbvfiodSocketHotplug} ${lib.concatStringsSep " " (builtins.map mkDeviceFlag virtualDevices)}
+              '';
+            };
+            environment = {
+              RUST_BACKTRACE = "full";
+            };
+          };
+
+          cloud-hypervisor =
+            let
+              netboot = mkNetboot debug;
+            in
+            {
+              wantedBy = [ "multi-user.target" ];
+              requires = [ "usbvfiod.service" ];
+              after = [ "usbvfiod.service" ];
+              serviceConfig = {
+                Restart = "on-failure";
+                RestartSec = "2s";
+                ExecStart = ''
+                  ${lib.getExe cloud-hypervisor} --memory size=2G,shared=on --console file=${guestLogFile} --serial off \
+                    --kernel ${netboot.kernel} \
+                    --cmdline ${lib.escapeShellArg netboot.cmdline} \
+                    --initramfs ${netboot.initrd} \
+                    --user-device socket=${usbvfiodSocket} \
+                    --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
+                '';
+              };
+            };
+        };
+      }
+    else
+      lib.assertMsg false
+        "useFileDescriptor == true is not yet implemented for the usbvfiod service setup"
+        { };
+
   # Fill in a template for the qemu.options list for a blockdevice.
   mkQemuBlockdevice =
     driveId: driveFile: deviceBus: devicePort:
@@ -378,6 +430,7 @@ let
 
       attrs = {
         debug = true;
+        useFileDescriptor = false;
       }
       // args
       // {
@@ -391,7 +444,7 @@ let
 
   # See mkUsbTest (this runs without any arg checks).
   mkUsbTestChecked =
-    args: systemd:
+    args:
     pkgs.testers.runNixOSTest {
       inherit (args) name;
 
@@ -400,7 +453,7 @@ let
       nodes.machine = _: {
         imports = [
           basicMachineConfig
-          (systemd args)
+          (mkSystemdConfig args.virtualDevices args.debug args.useFileDescriptor)
         ];
 
         services = {
@@ -523,7 +576,6 @@ in
     `args`
 
     : 1\. Function argument
-    : 2\. Systemd NixOS config definition snippet
 
     # Type
 
@@ -531,6 +583,7 @@ in
     mkUsbTest :: {
       name :: String
       debug :: Bool
+      useFileDescriptor :: Bool
       virtualDevices :: [
         {
         type :: "blockdevice" || "hid-device"
@@ -542,7 +595,7 @@ in
         }
       ]
       testScript :: String
-    }  { systemd = { ... } } -> a
+    } -> a
     ```
 
     # Examples
@@ -556,6 +609,7 @@ in
     myTest = mkUsbTest {
       name = "foo";
       debug = true;
+      useFileDescriptor = false;
       virtualDevices = [
         {
           type = "blockdevice";
@@ -565,50 +619,7 @@ in
           udevRule.symlink = "teststorage";
           attachedOnStartup = "guest";
         }
-      ] {
-        systemd.services = {
-          usbvfiod = {
-            wantedBy = [ "multi-user.target" ];
-            serviceConfig = {
-              User = "usbaccess";
-              Group = "usbaccess";
-              Restart = "on-failure";
-              RestartSec = "2s";
-              ExecStart = ''
-                ${lib.getExe usbvfiod} ${
-                  if args.debug then "-v" else ""
-                } --socket-path ${testutils.usbvfiodSocket} --hotplug-socket-path ${testutils.usbvfiodSocketHotplug} ${lib.concatStringsSep " " (builtins.map testutils.mkDeviceFlag args.virtualDevices)}
-              '';
-            };
-            environment = {
-              RUST_BACKTRACE = "full";
-            };
-          };
-
-          cloud-hypervisor =
-            let
-              netboot = testutils.mkNetboot args.debug;
-            in
-            {
-              wantedBy = [ "multi-user.target" ];
-              requires = [ "usbvfiod.service" ];
-              after = [ "usbvfiod.service" ];
-              serviceConfig = {
-                Restart = "on-failure";
-                RestartSec = "2s";
-                ExecStart = ''
-                  ${lib.getExe cloud-hypervisor} --memory size=2G,shared=on --console file=${testutils.guestLogFile} --serial off \
-                    --kernel ${netboot.kernel} \
-                    --cmdline ${lib.escapeShellArg netboot.cmdline} \
-                    --initramfs ${netboot.initrd} \
-                    --user-device socket=${testutils.usbvfiodSocket} \
-                    --net "tap=tap0,mac=,ip=192.168.100.1,mask=255.255.255.0"
-                '';
-              };
-            };
-        };
-      };
-
+      ];
       testScript = ''
         # Confirm USB controller pops up in boot logs
         out = cloud_hypervisor.succeed("journalctl -b", timeout=60)
@@ -638,5 +649,5 @@ in
     };
     ```
   */
-  mkUsbTest = args: systemd: mkUsbTestChecked (sanityCheckArgs (mkDefaults args)) systemd;
+  mkUsbTest = args: mkUsbTestChecked (sanityCheckArgs (mkDefaults args));
 }


### PR DESCRIPTION
While doing #293 a refactor for the boilerplate systemd snippets used in every test came up.
This is removing those boilerplate snippets and will ad an option int the mkUsbTest args to use the alternative file descriptor and systemd sockets setup.
It is currently a todo and will fail on evaluation when used.