### PR TITLE
Fix missed context updates and flaky controller reset integration test

### DIFF
--- a/nix/checks/controller-reset.nix
+++ b/nix/checks/controller-reset.nix
@@ -12,6 +12,12 @@ let
     for i in range(1, 4):
       print(f"CONTROLLER RESET LOOP {i}")
 
+      # Remove the scsi device to avoid I/O errors when unloading the xhci_pci driver.
+      cloud_hypervisor.succeed("echo 1 > /sys/block/sda/device/delete", timeout=60)
+
+      # Wait for all device events to finish.
+      cloud_hypervisor.succeed("udevadm settle", timeout=60)
+
       # Reload the guest xhci_pci driver to trigger a host controller reset.
       cloud_hypervisor.succeed("modprobe -r xhci_pci", timeout=120)
       cloud_hypervisor.succeed("modprobe xhci_pci", timeout=120)

--- a/src/device/xhci/endpoint.rs
+++ b/src/device/xhci/endpoint.rs
@@ -220,6 +220,7 @@ impl<EH: HotplugEndpointHandle> EndpointWorker<EH> {
                     // writing state is unnecessary but also not wrong.
                     self.context.set_state(endpoint_state::STOPPED);
                     self.transfer_ring.set_dequeue_pointer(ptr, cs);
+                    self.context.set_dequeue_pointer_and_cycle_state(ptr, cs);
                     self.state = WorkerState::Stopped;
                     completion.send_anyhow(CompletionCode::Success)?;
                 }

--- a/src/device/xhci/slot_manager.rs
+++ b/src/device/xhci/slot_manager.rs
@@ -492,7 +492,10 @@ impl Slot {
                 self.state = SlotState::Addressed(base_address);
                 base_address
             }
-            _ => return Ok(CompletionCode::ContextStateError),
+            state => {
+                warn!("AddressDevice in state {state:?} is treated as ContextStateError");
+                return Ok(CompletionCode::ContextStateError);
+            }
         };
         self.dma_copy_slot_context(input_context_pointer, base_address);
         self.write_slot_state();
@@ -545,7 +548,11 @@ impl Slot {
         // configure endpoint with DC=1 transitions from Addressed/Configured to Addressed
         let base_address = match self.state {
             SlotState::Enabled | SlotState::Default(_) => {
-                return Ok(CompletionCode::ContextStateError)
+                warn!(
+                    "ConfigureEndpoint in state {:?} is treated as ContextStateError",
+                    self.state
+                );
+                return Ok(CompletionCode::ContextStateError);
             }
             SlotState::Addressed(base_address) => base_address,
             SlotState::Configured(base_address) => base_address,
@@ -664,6 +671,10 @@ impl Slot {
     async fn handle_reset_device(&mut self) -> anyhow::Result<CompletionCode> {
         let base_address = match self.state {
             SlotState::Enabled | SlotState::Default(_) => {
+                warn!(
+                    "ResetDevice in state {:?} is treated as ContextStateError",
+                    self.state
+                );
                 return Ok(CompletionCode::ContextStateError);
             }
             SlotState::Addressed(base_address) => base_address,


### PR DESCRIPTION
With some open PR's that attempted to merge we ran into issues that the usb device sometimes did not work after a second or later reset (#297  #300). One of the reset tests seemed to fail almost reliable, but it switched back and forth from the tests for usb versions 1.1 and 2.0 not working.

Removing the scsi device before reloading the kernel module seems to resolve the issue.

I tested both mentioned open PR's rebased on this change locally without any issue.