### PR TITLE
Fix device reattachment and add test

### DIFF
--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -27,6 +27,9 @@ in
 // import ./attach-detach.nix {
   inherit usbvfiod testutils;
 }
+// import ./reattach-attached.nix {
+  inherit usbvfiod testutils;
+}
 // import ./interrupt.nix {
   inherit testutils;
 }

--- a/nix/checks/reattach-attached.nix
+++ b/nix/checks/reattach-attached.nix
@@ -1,0 +1,34 @@
+{
+  usbvfiod,
+  testutils,
+}:
+{
+  reattach-attached = testutils.mkUsbTest {
+    name = "reattach-attached";
+    virtualDevices = [
+      {
+        type = "blockdevice";
+      }
+    ];
+    testScript = ''
+      # The device is attached to the controller by usbvfiod on startup.
+      cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+
+      # Reattach the same host device while the controller still has it attached.
+      # The remote already reset the USB device before sending the request, so the
+      # controller must detach the old instance and attach the new one.
+      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --attach /dev/bus/usb/testdevice", timeout=60)
+      print(out)
+      search("SuccessfulOperation", out)
+
+      # Confirm the controller explicitly detached the conflicting device before
+      # continuing with the attach.
+      out = machine.succeed("journalctl -u usbvfiod.service -b --no-pager", timeout=60)
+      print(out)
+      search("A device with the same identifier is already attached and will be detached first", out)
+      search("Detached device", out)
+
+      cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+    '';
+  };
+}

--- a/src/device/xhci/port.rs
+++ b/src/device/xhci/port.rs
@@ -103,7 +103,7 @@ impl<CRD: CompleteRealDevice> PortArray<CRD> {
 
 #[derive(Debug)]
 struct PortWorker<CRD: CompleteRealDevice> {
-    devices: OneIndexed<Option<Arc<CRD>>, { MAX_PORTS as usize }>,
+    devices: OneIndexed<Option<AttachedDevice<CRD>>, { MAX_PORTS as usize }>,
     portsc: Arc<OneIndexed<PortscRegister, { MAX_PORTS as usize }>>,
     event_sender: EventSender,
     // the worker does not use the sender itself but needs to pass clones of the sender to detach listeners
@@ -112,10 +112,23 @@ struct PortWorker<CRD: CompleteRealDevice> {
     async_runtime: runtime::Handle,
 }
 
+/// The detach token is created once per device instance and cloned by its users, so its identity
+/// distinguishes attached device lifecycles. Token cancellation does not change this identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceInstanceId(CancellationToken);
+
+#[derive(Debug)]
+struct AttachedDevice<CRD: CompleteRealDevice> {
+    device: Arc<CRD>,
+    // The lifecycle ID of this attached device instance.
+    instance_id: DeviceInstanceId,
+}
+
 #[derive(Debug)]
 pub enum PortMessage<CRD: CompleteRealDevice> {
     Attach(CRD, oneshot::Sender<Response>),
-    Detach(CRD::ID, oneshot::Sender<Response>),
+    // Detaches a device, optionally limited to a specific attached device lifecycle.
+    Detach(CRD::ID, Option<DeviceInstanceId>, oneshot::Sender<Response>),
     ListAttached(oneshot::Sender<Vec<CRD::ID>>),
     // port id
     GetDevice(usize, oneshot::Sender<Option<Arc<CRD>>>),
@@ -136,8 +149,8 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
                 PortMessage::Attach(device, responder) => {
                     responder.send_anyhow(self.attach(device)?)?;
                 }
-                PortMessage::Detach(identifier, responder) => {
-                    responder.send_anyhow(self.detach(identifier)?)?;
+                PortMessage::Detach(identifier, instance_id, responder) => {
+                    responder.send_anyhow(self.detach(identifier, instance_id)?)?;
                 }
                 PortMessage::ListAttached(responder) => {
                     responder.send_anyhow(self.attached_devices())?;
@@ -146,7 +159,7 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
                     let device = self
                         .devices
                         .get(port_id)
-                        .and_then(|opt| opt.as_ref().map(|dev| dev.clone()));
+                        .and_then(|opt| opt.as_ref().map(|attached| attached.device.clone()));
                     responder.send_anyhow(device)?;
                 }
             };
@@ -165,7 +178,7 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
             info!(
                 "A device with the same identifier is already attached and will be detached first"
             );
-            self.detach(device.identifier())?;
+            self.detach(device.identifier(), None)?;
         }
 
         let speed = match device.realdevice_ref().speed() {
@@ -185,13 +198,18 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
                 };
 
         let identifier = device.identifier();
+        let instance_id = DeviceInstanceId(device.detach_token());
         self.async_runtime.spawn(detach_listener(
             device.detach_token(),
             identifier,
+            instance_id.clone(),
             self.msg_sender.clone(),
         ));
 
-        self.devices[available_port_id] = Some(Arc::new(device));
+        self.devices[available_port_id] = Some(AttachedDevice {
+            device: Arc::new(device),
+            instance_id,
+        });
 
         let new_portsc = match version {
             UsbVersion::USB3 => {
@@ -227,18 +245,35 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
         self.devices
             .iter()
             .filter_map(|dev| dev.as_ref())
-            .map(|dev| dev.identifier())
+            .map(|attached| attached.device.identifier())
             .collect()
     }
 
-    fn detach(&mut self, id: CRD::ID) -> anyhow::Result<Response> {
+    /// Detach a device by identifier, optionally requiring a particular attach lifecycle.
+    ///
+    /// An absent instance ID is used by explicit detach and reattach requests, which operate on
+    /// the currently attached device with instance ID. An instance ID is used by asynchronous detach
+    /// listeners and must match the currently attached device before it is removed.
+    fn detach(
+        &mut self,
+        id: CRD::ID,
+        requested_instance_id: Option<DeviceInstanceId>,
+    ) -> anyhow::Result<Response> {
         // find out on which port the device is connected
         let port_id = match self
             .devices
             .enumerate()
-            .filter_map(|(i, port)| port.as_ref().map(|d| (i, d.identifier())))
-            .filter(|(_, dev_id)| *dev_id == id)
-            .map(|(i, _)| i)
+            .filter_map(|(i, port)| {
+                port.as_ref().and_then(|attached| {
+                    let instance_id_matches =
+                        requested_instance_id
+                            .as_ref()
+                            .is_none_or(|requested_instance_id| {
+                                requested_instance_id == &attached.instance_id
+                            });
+                    (attached.device.identifier() == id && instance_id_matches).then_some(i)
+                })
+            })
             .next()
         {
             Some(i) => {
@@ -251,6 +286,9 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
                 // - cancels the detach token
                 // - detach_listener_tasks notices the cancellation and calls this handler again
                 // - second handler of course now cannot find this devices
+                //
+                // It is also expected when a detach listener targets an instance that has been
+                // replaced by reattachment.
                 //
                 // However, this message will also be printed when detach command for unknown identifier
                 // is received.
@@ -266,6 +304,7 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
         // Safety: just determined that this port_id refers to the device we want to detach
         mem::take(&mut self.devices[port_id])
             .unwrap()
+            .device
             .detach_token()
             .cancel();
 
@@ -285,11 +324,12 @@ impl<CRD: CompleteRealDevice> PortWorker<CRD> {
 async fn detach_listener<CRD: CompleteRealDevice>(
     cancel: CancellationToken,
     identifier: CRD::ID,
+    instance_id: DeviceInstanceId,
     msg_sender: mpsc::UnboundedSender<PortMessage<CRD>>,
 ) {
     let (send, recv) = oneshot::channel();
     cancel.cancelled().await;
-    let _ = msg_sender.send(PortMessage::Detach(identifier, send));
+    let _ = msg_sender.send(PortMessage::Detach(identifier, Some(instance_id), send));
     let _ = recv.await;
 }
 
@@ -357,7 +397,7 @@ impl<CRD: CompleteRealDevice> HotplugControl<CRD> {
 
     pub async fn detach(&self, identifier: CRD::ID) -> Response {
         let (responder, response_recv) = oneshot::channel();
-        let msg = PortMessage::Detach(identifier, responder);
+        let msg = PortMessage::Detach(identifier, None, responder);
         self.msg_send.send(msg).expect("channel should never close");
         response_recv
             .await


### PR DESCRIPTION
Add an integration test for [PR#273](https://github.com/cyberus-technology/usbvfiod/pull/273).
The device should be detached before re-attaching the same instance.

I found some weird logs in the CI test:
```
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.522987Z  INFO usbvfiod::device::xhci::port: A device with the same identifier is already attached and will be detached first
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.523016Z DEBUG usbvfiod::device::xhci::port: Device to detach is connected to port 1
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.523194Z  INFO usbvfiod::device::xhci::port: Detached device (5, 2) from port 1
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.523227Z  INFO usbvfiod::device::xhci::port: Attached SuperSpeed (5 Gbps) device (5, 2) to port 1 (USB3 port)
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.523277Z DEBUG usbvfiod::device::xhci::port: Device to detach is connected to port 1
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.523457Z DEBUG nusb::platform::linux_usbfs::device: Released interface 0 on device 0: Ok(())
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.531922Z DEBUG nusb::platform::linux_usbfs::device: Reattached kernel drivers for interface 0 on device 0: Ok(())
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.531967Z DEBUG nusb::platform::linux_usbfs::device: Closing device 0
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.532078Z  INFO usbvfiod::device::xhci::port: Detached device (5, 2) from port 1
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.532146Z DEBUG usbvfiod::device::xhci::interrupter: Sent event: PortStatusChange(PortStatusChangeEventTrbData { port_id: 1 })
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.532187Z DEBUG usbvfiod::device::xhci::interrupter: Sent event: PortStatusChange(PortStatusChangeEventTrbData { port_id: 1 })
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.532226Z DEBUG usbvfiod::device::xhci::interrupter: Sent event: PortStatusChange(PortStatusChangeEventTrbData { port_id: 1 })
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.532269Z DEBUG usbvfiod::device::xhci::port: Could not find the device to detach
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.532603Z DEBUG nusb::platform::linux_usbfs::device: Released interface 0 on device 1: Err(Os { code: 22, kind: InvalidInput, message: "Invalid argument" })
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.532661Z DEBUG nusb::platform::linux_usbfs::device: Closing device 1
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.574709Z DEBUG usbvfiod::device::xhci::command_ring: Doorbell for the controller
Aug 07 13:26:22 machine usbvfiod[614]: 2026-08-07T13:26:22.574841Z DEBUG usbvfiod::device::xhci::command_ring: Processing command CommandTrb { address: 1988386928, variant: ConfigureEndpoint(ConfigureEndpointCommandTrbData { input_context_pointer: 1989033984, deconfigure: false, slot_id: 1 }) }
```
While adding the reattach integration test, I found that reattach initially follows the expected path: the controller detects the existing device, detaches it, and attaches the new instance successfully.

The explicit detach cancels the old device's detach token, which wakes its asynchronous detach listener. The listener then sends another detach request using only the device identifier. Because the new instance has the same identifier, this delayed request matches and detaches the newly attached device, causing it to disappear from the guest.

This change adds an attach-lifecycle ID to each attached device. The ID is based on the device's `CancellationToken`, which is created once per device instance and shared through clones.

Detach requests from the asynchronous listener now carry this lifecycle ID. Device lookup matches both the device identifier and lifecycle ID when one is provided, so a delayed detach from an old instance no longer matches a reattached instance. Explicit detach and the detach performed during reattach continue to match only by device identifier.