### PR TITLE
Testutils to mock a RealDevice

### DIFF
--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -970,7 +970,6 @@ pub mod tests {
             data_length: u16,
             direction: bool,
         }
-        #[expect(dead_code)]
         impl MockRealControlEndpointReadStatic {
             pub fn new() -> Self {
                 Self {
@@ -1030,7 +1029,6 @@ pub mod tests {
         pub struct MockRealInEndpoint {
             data_length: usize,
         }
-        #[expect(dead_code)]
         impl MockRealInEndpoint {
             pub fn new() -> Self {
                 Self { data_length: 0 }
@@ -1074,7 +1072,6 @@ pub mod tests {
         // mock for bulk out real endpoint returning success while discarding the data
         #[derive(Debug)]
         pub struct MockRealOutEndpoint {}
-        #[expect(dead_code)]
         impl MockRealOutEndpoint {
             pub fn new() -> Self {
                 Self {}

--- a/src/device/xhci/endpoint_handle.rs
+++ b/src/device/xhci/endpoint_handle.rs
@@ -956,3 +956,159 @@ impl<RIEH: RealInEndpointHandle> BaseEndpointHandle for TdBasedInEndpointHandle<
         Box::pin(async { self.real_ep.clear_halt().await })
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    pub mod testutils {
+        use super::*;
+
+        // will return `vec![42; requested length]`
+        #[derive(Debug)]
+        pub struct MockRealControlEndpointReadStatic {
+            data_length: u16,
+            direction: bool,
+        }
+        #[expect(dead_code)]
+        impl MockRealControlEndpointReadStatic {
+            pub fn new() -> Self {
+                Self {
+                    data_length: 0,
+                    direction: false,
+                }
+            }
+        }
+
+        impl RealControlEndpointHandle for MockRealControlEndpointReadStatic {
+            type TrbCompletionFuture<'a> = Pin<
+                Box<
+                    dyn Future<Output = anyhow::Result<ControlRequestProcessingResult>> + Send + 'a,
+                >,
+            >;
+
+            fn submit_control_request(&mut self, request: UsbRequest) -> anyhow::Result<()> {
+                // fake request is instantly submitted but we need to remember the direction for next_complete
+                const IN: u8 = 0b10000000;
+                self.direction = (request.request_type & IN) == IN;
+                self.data_length = request.length;
+
+                Ok(())
+            }
+
+            fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_> {
+                Box::pin(async {
+                    let result = match self.direction {
+                        true => {
+                            let data = vec![42; self.data_length as usize];
+                            ControlRequestProcessingResult::SuccessfulControlIn(data)
+                        }
+                        false => ControlRequestProcessingResult::SuccessfulControlOut,
+                    };
+                    Ok(result)
+                })
+            }
+        }
+
+        impl BaseEndpointHandle for MockRealControlEndpointReadStatic {
+            type CompletionFuture<'a> =
+                Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+            fn cancel(&mut self) -> Self::CompletionFuture<'_> {
+                // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+
+            fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
+                // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+        }
+
+        // will return `vec![42; requested length]`
+        #[derive(Debug)]
+        pub struct MockRealInEndpoint {
+            data_length: usize,
+        }
+        #[expect(dead_code)]
+        impl MockRealInEndpoint {
+            pub fn new() -> Self {
+                Self { data_length: 0 }
+            }
+        }
+        impl RealInEndpointHandle for MockRealInEndpoint {
+            type TrbCompletionFuture<'a> =
+                Pin<Box<dyn Future<Output = anyhow::Result<InTrbProcessingResult>> + Send + 'a>>;
+
+            fn submit(&mut self, data: usize) -> anyhow::Result<()> {
+                self.data_length = data;
+                Ok(())
+            }
+
+            fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_> {
+                Box::pin(async {
+                    let data = vec![42; self.data_length];
+                    let result = InTrbProcessingResult {
+                        status: InTrbProcessingStatus::Success,
+                        data,
+                    };
+                    Ok(result)
+                })
+            }
+        }
+        impl BaseEndpointHandle for MockRealInEndpoint {
+            type CompletionFuture<'a> =
+                Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+            fn cancel(&mut self) -> Self::CompletionFuture<'_> {
+                // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+
+            fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
+                // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+        }
+
+        // mock for bulk out real endpoint returning success while discarding the data
+        #[derive(Debug)]
+        pub struct MockRealOutEndpoint {}
+        #[expect(dead_code)]
+        impl MockRealOutEndpoint {
+            pub fn new() -> Self {
+                Self {}
+            }
+        }
+        impl RealOutEndpointHandle for MockRealOutEndpoint {
+            type TrbCompletionFuture<'a> =
+                Pin<Box<dyn Future<Output = anyhow::Result<OutTrbProcessingResult>> + Send + 'a>>;
+
+            fn submit(&mut self, data: Vec<u8>) -> anyhow::Result<()> {
+                println!("consumed data of length: {}", data.len());
+                Ok(())
+            }
+
+            fn next_completion(&mut self) -> Self::TrbCompletionFuture<'_> {
+                Box::pin(async {
+                    let result = OutTrbProcessingResult::Success;
+                    Ok(result)
+                })
+            }
+        }
+        impl BaseEndpointHandle for MockRealOutEndpoint {
+            type CompletionFuture<'a> =
+                Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+            fn cancel(&mut self) -> Self::CompletionFuture<'_> {
+                // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+
+            fn clear_halt(&mut self) -> Self::CompletionFuture<'_> {
+                // nothing we want to do
+                Box::pin(async { Ok(()) })
+            }
+        }
+    }
+}

--- a/src/device/xhci/port.rs
+++ b/src/device/xhci/port.rs
@@ -389,3 +389,85 @@ impl<CRD: CompleteRealDevice> DeviceRetriever<CRD> {
         Ok(device)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::{runtime::Handle, time::timeout};
+
+    use crate::device::xhci::{
+        interrupter::tests::testutils::MockInterrupter,
+        real_device::{tests::testutils::MockRealDevice, CompleteRealDeviceImpl},
+    };
+
+    use super::*;
+
+    const ASYNC_TIMEOUT_SECS: u64 = 30;
+    const PORT_ID: u8 = 1;
+    const USB_BUS_NR: u8 = 1;
+    const USB_DEV_NR: u8 = 1;
+    const IDENTIFIER: (u8, u8) = (USB_BUS_NR, USB_DEV_NR);
+
+    #[tokio::test]
+    async fn port_array_hotplug_control_can_attach_list_and_detach() {
+        let async_runtime = Handle::current();
+        let (event_sender, mut interrupter) = MockInterrupter::new();
+
+        let mock_real_device = CompleteRealDeviceImpl::new(IDENTIFIER, MockRealDevice::default());
+        let port_array: PortArray<CompleteRealDeviceImpl<MockRealDevice, (u8, u8)>> =
+            PortArray::new(event_sender, async_runtime);
+
+        // attach a device
+        let hotplug_control = port_array.create_hotplug_control();
+        let response = timeout(
+            Duration::from_secs(ASYNC_TIMEOUT_SECS),
+            hotplug_control.attach(mock_real_device),
+        )
+        .await
+        .expect("local timeout on await");
+
+        assert_eq!(response, Response::SuccessfulOperation);
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_port_status_change_event_trb(PORT_ID))
+        );
+
+        // list attached devices
+        let response = timeout(
+            Duration::from_secs(ASYNC_TIMEOUT_SECS),
+            hotplug_control.list_devices(),
+        )
+        .await
+        .expect("local timeout on await");
+
+        assert_eq!(response, vec![IDENTIFIER]);
+        assert!(interrupter.is_empty());
+
+        // detach the device
+        let response = timeout(
+            Duration::from_secs(ASYNC_TIMEOUT_SECS),
+            hotplug_control.detach(IDENTIFIER),
+        )
+        .await
+        .expect("local timeout on await");
+
+        // expect a successful response for the command and an event
+        assert_eq!(response, Response::SuccessfulOperation);
+        assert_eq!(
+            interrupter.await_event().await,
+            Some(EventTrb::new_port_status_change_event_trb(PORT_ID))
+        );
+
+        // list attached devices
+        let response = timeout(
+            Duration::from_secs(ASYNC_TIMEOUT_SECS),
+            hotplug_control.list_devices(),
+        )
+        .await
+        .expect("local timeout on await");
+
+        assert_eq!(response, vec![]);
+        assert!(interrupter.is_empty());
+    }
+}

--- a/src/device/xhci/real_device.rs
+++ b/src/device/xhci/real_device.rs
@@ -126,7 +126,6 @@ pub mod tests {
             real_device,
         };
 
-        #[expect(dead_code)]
         #[derive(Default, Debug)]
         pub struct MockRealDevice {}
 

--- a/src/device/xhci/real_device.rs
+++ b/src/device/xhci/real_device.rs
@@ -62,7 +62,7 @@ impl Identifier for (u8, u8) {}
 // the best bet for identification. However, with two identical devices, the
 // approach fails to uniquely identify the devices. Complete real device allows
 // distinction of devices by storing an externally-decided, unique identifier.
-// Host bus-/device-number is an option,// but so are randomly chosen (but unique
+// Host bus-/device-number is an option, but so are randomly chosen (but unique)
 // numbers or strings.
 //
 // A CompleteRealDevice must also provide a CancellationToken that can be used
@@ -109,5 +109,57 @@ impl<RD: RealDevice, ID: Identifier> CompleteRealDevice for CompleteRealDeviceIm
 
     fn detach_token(&self) -> CancellationToken {
         self.cancel.clone()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    pub mod testutils {
+        use super::*;
+
+        use crate::device::xhci::{
+            endpoint_handle::tests::testutils::{
+                MockRealControlEndpointReadStatic, MockRealInEndpoint, MockRealOutEndpoint,
+            },
+            real_device,
+        };
+
+        #[expect(dead_code)]
+        #[derive(Default, Debug)]
+        pub struct MockRealDevice {}
+
+        impl RealDevice for MockRealDevice {
+            type RCEH = MockRealControlEndpointReadStatic;
+            type RBIEH = MockRealInEndpoint;
+            type RBOEH = MockRealOutEndpoint;
+            type RIIEH = MockRealInEndpoint;
+            type RIOEH = MockRealOutEndpoint;
+
+            fn speed(&self) -> Option<real_device::Speed> {
+                Some(Speed::Super)
+            }
+
+            fn control_endpoint_handle(&self) -> Self::RCEH {
+                MockRealControlEndpointReadStatic::new()
+            }
+
+            fn bulk_in_endpoint_handle(&self, _endpoint_id: u8) -> Self::RBIEH {
+                MockRealInEndpoint::new()
+            }
+
+            fn bulk_out_endpoint_handle(&self, _endpoint_id: u8) -> Self::RBOEH {
+                MockRealOutEndpoint::new()
+            }
+
+            fn interrupt_in_endpoint_handle(&self, _endpoint_id: u8) -> Self::RIIEH {
+                MockRealInEndpoint::new()
+            }
+
+            fn interrupt_out_endpoint_handle(&self, _endpoint_id: u8) -> Self::RIOEH {
+                MockRealOutEndpoint::new()
+            }
+        }
     }
 }


### PR DESCRIPTION
Introduce testutils and demonstrate how to test against a mock RealDevice with the example of the PortArray happy path.

Introducing these testutils here will shrink #238. 