### PR TITLE
Add missing transition for configure endpoint command

### DIFF
--- a/src/device/xhci/slot_manager.rs
+++ b/src/device/xhci/slot_manager.rs
@@ -540,16 +540,14 @@ impl Slot {
         input_context_pointer: u64,
         deconfigure: bool,
     ) -> anyhow::Result<CompletionCode> {
+        // xhci specification: Figure 4-2: Slot State Diagram
         // configure endpoint with DC=0 transitions from Addressed/Configured to Configured
-        // configure endpoint with DC=1 transitions from Configured to Addressed
+        // configure endpoint with DC=1 transitions from Addressed/Configured to Addressed
         let base_address = match self.state {
             SlotState::Enabled | SlotState::Default(_) => {
                 return Ok(CompletionCode::ContextStateError)
             }
-            SlotState::Addressed(base_address) => match deconfigure {
-                true => return Ok(CompletionCode::ContextStateError),
-                false => base_address,
-            },
+            SlotState::Addressed(base_address) => base_address,
             SlotState::Configured(base_address) => base_address,
         };
 


### PR DESCRIPTION
The transition from addressed state into addressed state is legal according to the endpoint state diagram, but is currently implemented as `ContextStateError`.  

~~Also include a refactor that aligns more with the state machine pattern used in other places.~~