### PR TITLE
chore(deps): lock file maintenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -157,7 +157,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -223,27 +223,27 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -304,9 +304,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "mach2"
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -669,7 +669,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -712,9 +712,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"
@@ -739,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -778,7 +778,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -815,7 +815,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1036,31 +1036,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1111,18 +1111,18 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1785693380,
-        "narHash": "sha256-drCgheG8xP1Swm4pdmlPjVNtSfxWmM/MCvrMl9YARnE=",
+        "lastModified": 1788785440,
+        "narHash": "sha256-hapO/7kRJheZE9DsDqHzuGXySfhJisaDSj0OMhOP4lk=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "d91a8fc9492378f23cba86b81770c6d16de6ebba",
+        "rev": "faedffd5118c1835e13cca3babb6059afb1eb8d0",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1785631643,
-        "narHash": "sha256-H++/2dMt+5+tErKU+t5z6c4Xedvj9w+UPQYrpygwIPw=",
+        "lastModified": 1788465171,
+        "narHash": "sha256-Y1/TTVXjYXGF068IThQH9fPSZ0SIE74PABlUxnWTUH0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b8d87f76ea4e4b6f30f2e6eaf3fbb60ff7d87167",
+        "rev": "eb35abda9f232cc6610b1d1e3200d15c49b7ac54",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1785750890,
-        "narHash": "sha256-hax+Dgq9/KtG0NPXEcyNIfKIJhzCfQVVIf6Ynu8bCRM=",
+        "lastModified": 1788782697,
+        "narHash": "sha256-vwpEIlx5cfHs4OlmFaA6bd0UgWlil6eiebI6sVh8ci4=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "1635a532f6778304adfac2044c82992ece8a99d8",
+        "rev": "36a0cdd15b062a8e6b529cf6e1a15fd4a26210b3",
         "type": "github"
       },
       "original": {
@@ -91,11 +91,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784288435,
-        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
+        "lastModified": 1788267358,
+        "narHash": "sha256-nt+lUqYVpc9Y6JeMd2WmXzCDojasdadKo0mWcluvY2Y=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
+        "rev": "27555e2624241fb116b49095df4caaee85a25691",
         "type": "github"
       },
       "original": {
@@ -106,11 +106,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785747939,
-        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
+        "lastModified": 1788608636,
+        "narHash": "sha256-RqeFOwW329f4i1f5QlJgQYwgEZvxIHJsUYlzIBxsKsY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
+        "rev": "0af3d1402dec3fc7e93635e511d1f7428c89cebf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -160,7 +160,7 @@
         packages = {
           default = usbvfiod;
         }
-        // lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
+        // lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isDarwin) {
           usbvfiod-llvm-coverage-html = craneLibLLvmTools.cargoLlvmCov (
             commonArgs
             // {

--- a/nix/checks/attach-detach.nix
+++ b/nix/checks/attach-detach.nix
@@ -8,15 +8,15 @@ let
     for i in range(1,20):
       print(f"ATTACH DETACH LOOP {i}")
       # List and print all attached devices.
-      out = machine.wait_until_succeeds("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=60)
+      out = machine.wait_until_succeeds("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=ONE_MINUTE)
       search("No attached devices", out)
 
       # Attach a device.
-      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --attach /dev/bus/usb/usbdevice", timeout=60)
+      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --attach /dev/bus/usb/usbdevice", timeout=ONE_MINUTE)
       print(out)
 
       # List attached devices.
-      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=60)
+      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=ONE_MINUTE)
       print(out)
 
       # Get the bus and device numbers.
@@ -25,14 +25,14 @@ let
 
       # Wait for the guest to find the usb device.
       if (i % 2 == 0):
-        cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+        cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=TWO_MINUTES)
 
       # Wait for the guest to find the blockdevice.
       if (i % 4 == 0):
-        cloud_hypervisor.wait_until_succeeds("lsblk /dev/sd*", timeout=120)
+        cloud_hypervisor.wait_until_succeeds("lsblk /dev/sd*", timeout=TWO_MINUTES)
 
       # Detach the device.
-      out = machine.succeed(f"${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --detach {bus_nr} {device_nr}", timeout=60)
+      out = machine.succeed(f"${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --detach {bus_nr} {device_nr}", timeout=ONE_MINUTE)
       print(out)
   '';
 in

--- a/nix/checks/blockdevice.nix
+++ b/nix/checks/blockdevice.nix
@@ -4,47 +4,47 @@
 let
   testScript = ''
     # Confirm USB controller pops up in boot logs
-    out = cloud_hypervisor.succeed("journalctl -b", timeout=60)
+    out = cloud_hypervisor.succeed("journalctl -b", timeout=ONE_MINUTE)
     search("usb usb1: Product: xHCI Host Controller", out)
     search("hub 1-0:1\\.0: [0-9]+ ports? detected", out)
 
     # Confirm some diagnostic information
-    out = cloud_hypervisor.succeed("cat /proc/interrupts", timeout=60)
+    out = cloud_hypervisor.succeed("cat /proc/interrupts", timeout=ONE_MINUTE)
     search(" +[1-9][0-9]* +PCI-MSIX.*xhci_hcd", out)
 
     # Wait until the usb drive we expect is recognized.
-    out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+    out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=TWO_MINUTES)
     search("ID ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId} QEMU QEMU USB HARDDRIVE", out)
-    out = cloud_hypervisor.succeed("sfdisk -l", timeout=60)
+    out = cloud_hypervisor.succeed("sfdisk -l", timeout=ONE_MINUTE)
     search("Disk /dev/sda:", out)
 
     # Test partitioning
-    cloud_hypervisor.succeed("echo ',,L' | sfdisk --label=gpt /dev/sda", timeout=60)
+    cloud_hypervisor.succeed("echo ',,L' | sfdisk --label=gpt /dev/sda", timeout=ONE_MINUTE)
 
     # The Script is sometimes too fast for the nested guest to detect the new partition.
-    cloud_hypervisor.wait_until_succeeds("lsblk /dev/sda1", timeout=60)
+    cloud_hypervisor.wait_until_succeeds("lsblk /dev/sda1", timeout=ONE_MINUTE)
 
     # Make a filesystem
-    out = cloud_hypervisor.succeed("mkfs.ext4 -v /dev/sda1", timeout=60)
+    out = cloud_hypervisor.succeed("mkfs.ext4 -v /dev/sda1", timeout=ONE_MINUTE)
     print(out)
-    cloud_hypervisor.succeed("fsck -t ext4 -V -r /dev/sda1 -- -y", timeout=60)
-    cloud_hypervisor.wait_until_succeeds("mount /dev/sda1 /mnt", timeout=60)
+    cloud_hypervisor.succeed("fsck -t ext4 -V -r /dev/sda1 -- -y", timeout=ONE_MINUTE)
+    cloud_hypervisor.wait_until_succeeds("mount /dev/sda1 /mnt", timeout=ONE_MINUTE)
 
     # Create a file and compute a checksum
-    cloud_hypervisor.succeed("dd if=/dev/urandom of=/tmp/file count=32 bs=1M", timeout=60)
-    out = cloud_hypervisor.succeed("sha256sum /tmp/file", timeout=60)
+    cloud_hypervisor.succeed("dd if=/dev/urandom of=/tmp/file count=32 bs=1M", timeout=ONE_MINUTE)
+    out = cloud_hypervisor.succeed("sha256sum /tmp/file", timeout=ONE_MINUTE)
     hash_tmp = out.split()
     print(f"hash_tmp: {hash_tmp}")
 
     # Copy the file on the blockdevice
-    cloud_hypervisor.succeed("cp /tmp/file /mnt/file", timeout=60)
-    cloud_hypervisor.succeed("sync", timeout=60)
-    cloud_hypervisor.succeed("echo 3 > /proc/sys/vm/drop_caches", timeout=60)
-    cloud_hypervisor.succeed("umount /mnt", timeout=60)
-    cloud_hypervisor.succeed("mount /dev/sda1 /mnt", timeout=60)
+    cloud_hypervisor.succeed("cp /tmp/file /mnt/file", timeout=ONE_MINUTE)
+    cloud_hypervisor.succeed("sync", timeout=ONE_MINUTE)
+    cloud_hypervisor.succeed("echo 3 > /proc/sys/vm/drop_caches", timeout=ONE_MINUTE)
+    cloud_hypervisor.succeed("umount /mnt", timeout=ONE_MINUTE)
+    cloud_hypervisor.succeed("mount /dev/sda1 /mnt", timeout=ONE_MINUTE)
 
     # Check if the file checksum changed
-    out = cloud_hypervisor.succeed("sha256sum /mnt/file", timeout=60)
+    out = cloud_hypervisor.succeed("sha256sum /mnt/file", timeout=ONE_MINUTE)
     hash_mnt = out.split()
     print(f"hash_mnt: {hash_mnt}")
     if (hash_tmp[0] != hash_mnt[0]):

--- a/nix/checks/controller-reset.nix
+++ b/nix/checks/controller-reset.nix
@@ -4,34 +4,34 @@
 let
   testScript = ''
     # Wait until the USB drive is recognized.
-    out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+    out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=TWO_MINUTES)
     search("ID ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId} QEMU QEMU USB HARDDRIVE", out)
-    cloud_hypervisor.wait_until_succeeds("lsblk /dev/sda", timeout=120)
+    cloud_hypervisor.wait_until_succeeds("lsblk /dev/sda", timeout=TWO_MINUTES)
 
     # Run the controller reset loop a few times.
     for i in range(1, 4):
       print(f"CONTROLLER RESET LOOP {i}")
 
       # Remove the scsi device to avoid I/O errors when unloading the xhci_pci driver.
-      cloud_hypervisor.succeed("echo 1 > /sys/block/sda/device/delete", timeout=60)
+      cloud_hypervisor.succeed("echo 1 > /sys/block/sda/device/delete", timeout=ONE_MINUTE)
 
       # Wait for all device events to finish.
-      cloud_hypervisor.succeed("udevadm settle", timeout=60)
+      cloud_hypervisor.succeed("udevadm settle", timeout=ONE_MINUTE)
 
       # Reload the guest xhci_pci driver to trigger a host controller reset.
-      cloud_hypervisor.succeed("modprobe -r xhci_pci", timeout=120)
-      cloud_hypervisor.succeed("modprobe xhci_pci", timeout=120)
+      cloud_hypervisor.succeed("modprobe -r xhci_pci", timeout=TWO_MINUTES)
+      cloud_hypervisor.succeed("modprobe xhci_pci", timeout=TWO_MINUTES)
 
       # Confirm raw block I/O still works after the controller reset.
-      out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+      out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=TWO_MINUTES)
       search("ID ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId} QEMU QEMU USB HARDDRIVE", out)
-      cloud_hypervisor.wait_until_succeeds("lsblk /dev/sda", timeout=120)
-      cloud_hypervisor.succeed(f"printf after-reset-{i} > /tmp/after-reset-{i}.txt", timeout=60)
-      cloud_hypervisor.succeed(f"dd if=/tmp/after-reset-{i}.txt of=/dev/sda bs=512 seek=2048 count=1 conv=sync,fsync status=none", timeout=60)
-      cloud_hypervisor.succeed("sync", timeout=60)
-      cloud_hypervisor.succeed("echo 3 > /proc/sys/vm/drop_caches", timeout=60)
-      cloud_hypervisor.succeed(f"dd if=/dev/sda of=/tmp/read-after-reset-{i}.txt bs=512 skip=2048 count=1 status=none", timeout=60)
-      cloud_hypervisor.succeed(f"grep -ao after-reset-{i} /tmp/read-after-reset-{i}.txt", timeout=60)
+      cloud_hypervisor.wait_until_succeeds("lsblk /dev/sda", timeout=TWO_MINUTES)
+      cloud_hypervisor.succeed(f"printf after-reset-{i} > /tmp/after-reset-{i}.txt", timeout=ONE_MINUTE)
+      cloud_hypervisor.succeed(f"dd if=/tmp/after-reset-{i}.txt of=/dev/sda bs=512 seek=2048 count=1 conv=sync,fsync status=none", timeout=ONE_MINUTE)
+      cloud_hypervisor.succeed("sync", timeout=ONE_MINUTE)
+      cloud_hypervisor.succeed("echo 3 > /proc/sys/vm/drop_caches", timeout=ONE_MINUTE)
+      cloud_hypervisor.succeed(f"dd if=/dev/sda of=/tmp/read-after-reset-{i}.txt bs=512 skip=2048 count=1 status=none", timeout=ONE_MINUTE)
+      cloud_hypervisor.succeed(f"grep -ao after-reset-{i} /tmp/read-after-reset-{i}.txt", timeout=ONE_MINUTE)
   '';
 in
 builtins.listToAttrs (

--- a/nix/checks/filedescriptor.nix
+++ b/nix/checks/filedescriptor.nix
@@ -12,23 +12,23 @@ testutils.mkUsbTest {
     }
   ];
   testScript = ''
-    out = cloud_hypervisor.succeed("lsusb", timeout=60)
+    out = cloud_hypervisor.succeed("lsusb", timeout=ONE_MINUTE)
     print(out)
     search("ID ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId} QEMU QEMU USB HARDDRIVE", out)
 
     # A nested guest reboot will break the vfio-user connection and usbvfiod will exit 0.
     # When Cloud Hypervisor re-connects to the systemd socket usbvfiod will be restarted.
-    out = cloud_hypervisor.succeed("systemctl reboot", timeout=60)
+    out = cloud_hypervisor.succeed("systemctl reboot", timeout=ONE_MINUTE)
     print(out)
 
     # confirm nested guest shutdown via usbvfiod exit message triggered by the closed vfio-user connection
-    machine.wait_until_succeeds("journalctl -b -u usbvfiod.service | grep 'Deactivated successfully.' ", timeout=60)
+    machine.wait_until_succeeds("journalctl -b -u usbvfiod.service | grep 'Deactivated successfully.' ", timeout=ONE_MINUTE)
 
-    out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=240)
+    out = cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=datetime.timedelta(minutes=4))
 
     # When using the socket path setup, we encounter failed to start logs for the cloud hypervisor service.
     # We do not expect to see this log when using the file descriptor setup.
-    out = machine.fail("journalctl -b -u cloud-hypervisor.service | grep -q 'cloud-hypervisor.service: Failed with result'", timeout=60)
+    out = machine.fail("journalctl -b -u cloud-hypervisor.service | grep -q 'cloud-hypervisor.service: Failed with result'", timeout=ONE_MINUTE)
     print(out)
   '';
 }

--- a/nix/checks/forceful-removal.nix
+++ b/nix/checks/forceful-removal.nix
@@ -24,7 +24,7 @@ testutils.mkUsbTest {
       print(f"ATTACH DETACH LOOP {i}")
 
       # Expect no attached devices.
-      out = machine.wait_until_succeeds("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=60)
+      out = machine.wait_until_succeeds("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=ONE_MINUTE)
       search("No attached devices", out)
 
       # plug in a blockdevice
@@ -34,17 +34,17 @@ testutils.mkUsbTest {
       }.0,drive=hotplug,port=1"))
 
       # wait for qemu host to find the blockdevice
-      machine.wait_until_succeeds("lsusb | grep 'QEMU QEMU USB HARDDRIVE'", timeout=120)
-      machine.wait_until_succeeds("lsblk /dev/sd*", timeout=120)
+      machine.wait_until_succeeds("lsusb | grep 'QEMU QEMU USB HARDDRIVE'", timeout=TWO_MINUTES)
+      machine.wait_until_succeeds("lsblk /dev/sd*", timeout=TWO_MINUTES)
 
-      machine.wait_until_succeeds("ls /dev/bus/usb/hotplug", timeout=60)
+      machine.wait_until_succeeds("ls /dev/bus/usb/hotplug", timeout=ONE_MINUTE)
 
       # Attach a device.
-      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --attach /dev/bus/usb/hotplug", timeout=60)
+      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --attach /dev/bus/usb/hotplug", timeout=ONE_MINUTE)
       print(out)
 
       # List attached devices.
-      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=60)
+      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list", timeout=ONE_MINUTE)
       print(out)
 
       # Check the list output is what we expect: one device
@@ -60,11 +60,11 @@ testutils.mkUsbTest {
 
       # Wait for the guest to find the usb device.
       if (i % 2 == 0):
-        cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+        cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=TWO_MINUTES)
 
       # Wait for the guest to find the blockdevice.
       if (i % 4 == 0):
-        cloud_hypervisor.wait_until_succeeds("lsblk /dev/sd*", timeout=120)
+        cloud_hypervisor.wait_until_succeeds("lsblk /dev/sd*", timeout=TWO_MINUTES)
 
       # Plug out a blockdevice.
       print(machine.send_monitor_command("device_del hotplug-dev"))
@@ -74,9 +74,9 @@ testutils.mkUsbTest {
 
       # Trigger the guest to access the device and get the nusb error that would otherwise come eventually.
       # If it did not already happen the xHC should then start the detach process of the device.
-      cloud_hypervisor.wait_until_succeeds("lsusb -vvv", timeout=120)
+      cloud_hypervisor.wait_until_succeeds("lsusb -vvv", timeout=TWO_MINUTES)
 
       # Wait until the xHC can confirm there is no device attached anymore.
-      machine.wait_until_succeeds("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list | grep 'No attached devices'", timeout=60)
+      machine.wait_until_succeeds("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --list | grep 'No attached devices'", timeout=ONE_MINUTE)
   '';
 }

--- a/nix/checks/interrupt.nix
+++ b/nix/checks/interrupt.nix
@@ -26,7 +26,7 @@ builtins.listToAttrs (
             print(f"input loop `{i}` done")
 
         # Check the Keyboard is in detected in the guest.
-        cloud_hypervisor.succeed("lsusb -d ${testutils.hidVendorId}:${testutils.hidProductId}", timeout=60)
+        cloud_hypervisor.succeed("lsusb -d ${testutils.hidVendorId}:${testutils.hidProductId}", timeout=ONE_MINUTE)
 
         # Generate inputs in the background.
         t1 = threading.Thread(target=create_input)
@@ -37,7 +37,7 @@ builtins.listToAttrs (
         # It is theoretically possible all events appear and are consumed by the input subsystem before we have the opportunity to listen.
         out = cloud_hypervisor.succeed("hexdump --length 144 --two-bytes-hex /dev/input/by-id/usb-QEMU_QEMU_USB_Keyboard_68284-0000\\:00\\:${
           testutils.usbVersions."${usbVersion}".addr
-        }.0-1-event-kbd", timeout=60)
+        }.0-1-event-kbd", timeout=ONE_MINUTE)
 
         # Check if the hexdump contains a ctrl event sequence
         # https://docs.kernel.org/input/input.html#event-interface

--- a/nix/checks/multiple-blockdevices.nix
+++ b/nix/checks/multiple-blockdevices.nix
@@ -27,7 +27,7 @@ testutils.mkUsbTest {
         "3"
       ];
   testScript = ''
-    out = cloud_hypervisor.succeed("lsusb --tree", timeout=60)
+    out = cloud_hypervisor.succeed("lsusb --tree", timeout=ONE_MINUTE)
     search(r'Port 001: Dev \d+, If 0, Class=Mass Storage, Driver=usb-storage, 480M', out)
     search(r'Port 002: Dev \d+, If 0, Class=Mass Storage, Driver=usb-storage, 480M', out)
     search(r'Port 003: Dev \d+, If 0, Class=Mass Storage, Driver=usb-storage, 480M', out)
@@ -37,7 +37,7 @@ testutils.mkUsbTest {
     search(r'Port 003: Dev \d+, If 0, Class=Mass Storage, Driver=usb-storage, 5000M', out)
     search(r'Port 004: Dev \d+, If 0, Class=Mass Storage, Driver=usb-storage, 5000M', out)
 
-    out = cloud_hypervisor.succeed("lsblk", timeout=60)
+    out = cloud_hypervisor.succeed("lsblk", timeout=ONE_MINUTE)
     search(r'sda\s+\d+:\d+\s+0\s+${testutils.imageSize}\s+0\s+disk', out)
     search(r'sdb\s+\d+:\d+\s+0\s+${testutils.imageSize}\s+0\s+disk', out)
     search(r'sdc\s+\d+:\d+\s+0\s+${testutils.imageSize}\s+0\s+disk', out)

--- a/nix/checks/reattach-attached.nix
+++ b/nix/checks/reattach-attached.nix
@@ -12,23 +12,23 @@
     ];
     testScript = ''
       # The device is attached to the controller by usbvfiod on startup.
-      cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+      cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=TWO_MINUTES)
 
       # Reattach the same host device while the controller still has it attached.
       # The remote already reset the USB device before sending the request, so the
       # controller must detach the old instance and attach the new one.
-      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --attach /dev/bus/usb/testdevice", timeout=60)
+      out = machine.succeed("${usbvfiod}/bin/remote --socket ${testutils.usbvfiodSocketHotplug} --attach /dev/bus/usb/testdevice", timeout=ONE_MINUTE)
       print(out)
       search("SuccessfulOperation", out)
 
       # Confirm the controller explicitly detached the conflicting device before
       # continuing with the attach.
-      out = machine.succeed("journalctl -u usbvfiod.service -b --no-pager", timeout=60)
+      out = machine.succeed("journalctl -u usbvfiod.service -b --no-pager", timeout=ONE_MINUTE)
       print(out)
       search("A device with the same identifier is already attached and will be detached first", out)
       search("Detached device", out)
 
-      cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=120)
+      cloud_hypervisor.wait_until_succeeds("lsusb -d ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId}", timeout=TWO_MINUTES)
     '';
   };
 }

--- a/nix/checks/testutils.nix
+++ b/nix/checks/testutils.nix
@@ -47,7 +47,10 @@ let
               );
             };
 
-            services.journald.console = "hvc0";
+            services.journald.settings.Journal = {
+              ForwardToConsole = true;
+              TTYPath = "/dev/hvc0";
+            };
 
             # Enable debug verbosity.
             boot.consoleLogLevel = lib.mkIf debug 8;
@@ -477,10 +480,10 @@ let
         services = {
           # The framework automatically forwards all journal output to ttyS0,
           # slowing down the test significantly if there is a lot of logs.
-          journald.extraConfig = lib.mkForce ''
-            ForwardToConsole=yes
-            TTYPath=/dev/hvc1
-          '';
+          journald.settings.Journal = {
+            ForwardToConsole = true;
+            TTYPath = lib.mkForce "/dev/hvc1";
+          };
           # Create a udev rule for every device listed that enables it.
           udev.extraRules = lib.concatStrings (
             builtins.map (

--- a/nix/checks/testutils.nix
+++ b/nix/checks/testutils.nix
@@ -155,6 +155,7 @@ let
   # This will also add a QoL 'string in string' search function.
   nestedPythonClass = ''
     import re
+    import datetime
     from test_driver.errors import RequestedAssertionFailed
 
     class Nested():
@@ -165,7 +166,7 @@ let
       def __init__(self, vm_host: BaseMachine) -> None:
         self.vm_host = vm_host
 
-      def succeed(self, *commands: str, timeout: int | None = None) -> str:
+      def succeed(self, *commands: str, timeout: datetime.timedelta = datetime.timedelta(minutes=15)) -> str:
         vm_host = self.vm_host
         output = ""
         for command in commands:
@@ -184,7 +185,7 @@ let
                 output += out
         return output
 
-      def wait_until_succeeds(self, command: str, timeout: int = 900):
+      def wait_until_succeeds(self, command: str, timeout: datetime.timedelta = datetime.timedelta(minutes=15)):
         vm_host = self.vm_host
         output = ""
 
@@ -540,6 +541,9 @@ let
       testScript = ''
         ${nestedPythonClass}
 
+        ONE_MINUTE=datetime.timedelta(minutes=1)
+        TWO_MINUTES=datetime.timedelta(minutes=2)
+
         # prepare blockdevice images if necessary
         ${lib.concatStringsSep "\n" (
           builtins.map (mkPrepareBlockdeviceImages args.name) args.virtualDevices
@@ -550,7 +554,7 @@ let
         machine.wait_for_unit("cloud-hypervisor.service")
 
         # Check sshd in systemd.services.cloud-hypervisor is usable prior to testing over ssh.
-        machine.wait_until_succeeds("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@192.168.100.2 'exit 0'", timeout=3000)
+        machine.wait_until_succeeds("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@192.168.100.2 'exit 0'", timeout=datetime.timedelta(minutes=50))
 
         cloud_hypervisor = Nested(vm_host=machine)
 
@@ -591,6 +595,8 @@ in
   /**
     Create a pkgs.testers.runNixOSTest with specific purpose of testing Usbvfiod.
     The Functions purpose is to remove duplicated lines, make comparing tests easier and write new tests with less boilerplate.
+
+    Provides QoL variables ONE_MINUTE and TWO_MINUTES to use as timeout argument and call `.succeed(commands, timeout=ONE_MINUTE)` instead of writing `.succeed(command, timeout=datetime.timedelta(minutes=1))` or declaring variables on each test.
 
     # Inputs
 
@@ -643,28 +649,28 @@ in
       ];
       testScript = ''
         # Confirm USB controller pops up in boot logs
-        out = cloud_hypervisor.succeed("journalctl -b", timeout=60)
+        out = cloud_hypervisor.succeed("journalctl -b", timeout=ONE_MINUTE)
         search("usb usb1: Product: xHCI Host Controller", out)
         search("hub 1-0:1\\.0: [0-9]+ ports? detected", out)
 
         # Confirm some diagnostic information
-        out = cloud_hypervisor.succeed("cat /proc/interrupts", timeout=60)
+        out = cloud_hypervisor.succeed("cat /proc/interrupts", timeout=ONE_MINUTE)
         search(" +[1-9][0-9]* +PCI-MSIX.*xhci_hcd", out)
-        out = cloud_hypervisor.succeed("lsusb", timeout=60)
+        out = cloud_hypervisor.succeed("lsusb", timeout=ONE_MINUTE)
         search("ID ${testutils.blockdeviceVendorId}:${testutils.blockdeviceProductId} QEMU QEMU USB HARDDRIVE", out)
-        out = cloud_hypervisor.succeed("sfdisk -l", timeout=60)
+        out = cloud_hypervisor.succeed("sfdisk -l", timeout=ONE_MINUTE)
         search("Disk /dev/sda:", out)
 
         # Test partitioning
-        cloud_hypervisor.succeed("echo ',,L' | sfdisk --label=gpt /dev/sda", timeout=60)
+        cloud_hypervisor.succeed("echo ',,L' | sfdisk --label=gpt /dev/sda", timeout=ONE_MINUTE)
 
         # Test filesystem
-        cloud_hypervisor.succeed("mkfs.ext4 /dev/sda1", timeout=60)
-        cloud_hypervisor.succeed("mount /dev/sda1 /mnt", timeout=60)
-        cloud_hypervisor.succeed("echo 123TEST123 > /mnt/file.txt", timeout=60)
-        cloud_hypervisor.succeed("umount /mnt", timeout=60)
-        cloud_hypervisor.succeed("mount /dev/sda1 /mnt", timeout=60)
-        out = cloud_hypervisor.succeed("cat /mnt/file.txt", timeout=60)
+        cloud_hypervisor.succeed("mkfs.ext4 /dev/sda1", timeout=ONE_MINUTE)
+        cloud_hypervisor.succeed("mount /dev/sda1 /mnt", timeout=ONE_MINUTE)
+        cloud_hypervisor.succeed("echo 123TEST123 > /mnt/file.txt", timeout=ONE_MINUTE)
+        cloud_hypervisor.succeed("umount /mnt", timeout=ONE_MINUTE)
+        cloud_hypervisor.succeed("mount /dev/sda1 /mnt", timeout=ONE_MINUTE)
+        out = cloud_hypervisor.succeed("cat /mnt/file.txt", timeout=ONE_MINUTE)
         search("123TEST123", out)
       '';
     };


### PR DESCRIPTION
The last full lock file maintenance was on 03.08.2026 #291.
The manual trigger in renovates Dependency Dashboard resulted in an error and retry.
This is only visible in the editing history of the renovate Dependency Dashboard.
I have not searched why this is happening.

For now, a manual update PR should do.