### PR TITLE
Refactor the default devshell and add a profiling utility devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -188,12 +188,9 @@
           };
         };
 
-        devShells.default = craneLib.devShell {
-          shellHook = ''
-            ${self.checks.pre-commit-check.shellHook}
-            alias sshhost=ssh\ -p\ 2000\ root@localhost\ -o\ UserKnownHostsFile=/dev/null\ -o\ StrictHostKeyChecking=no
-            alias sshguest=ssh\ -o\ ProxyCommand="ssh\ -W\ %h:%p\ -p\ 2000\ root@localhost\ -o\ UserKnownHostsFile=/dev/null\ -o\ StrictHostKeyChecking=no"\ -o\ UserKnownHostsFile=/dev/null\ -o\ StrictHostKeyChecking=no\ root@192.168.100.2
-          '';
+        devShells = import ./nix/devshell.nix {
+          inherit craneLib pkgs;
+          inherit (self.checks.pre-commit-check) shellHook;
         };
 
         herculesCI = {

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,23 @@
+{
+  craneLib,
+  pkgs,
+  shellHook,
+}:
+let
+  sshhost = pkgs.writeShellScriptBin "sshhost" ''
+    ssh -p 2000 root@localhost -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+  '';
+
+  sshguest = pkgs.writeShellScriptBin "sshguest" ''
+    ssh -p 2000 root@localhost -o ProxyCommand="ssh -W %h:%p -p 2000 root@localhost -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+  '';
+in
+{
+  default = craneLib.devShell {
+    inherit shellHook;
+    packages = [
+      sshhost
+      sshguest
+    ];
+  };
+}


### PR DESCRIPTION
While gathering profiling information it was helpful to prepare some standard commands packaged as script.

Some of that is already helpful for the default development environment.
The extended list of packages (incl. kcachegrind as a GUI application) is placed in a separate new devShell specifically meant for gathering profiling information.