### PR TITLE
Add a missing slot context update

### DIFF
--- a/src/device/xhci/slot_manager.rs
+++ b/src/device/xhci/slot_manager.rs
@@ -687,6 +687,7 @@ impl Slot {
         }
 
         self.state = SlotState::Default(base_address);
+        self.write_slot_state();
 
         Ok(CompletionCode::Success)
     }


### PR DESCRIPTION
The xhci specification chapter 4.6.11 Reset Device:

> - If the Device Slot is in the Addressed or Configured state:
>   - [...]
>   - Set the Slot State field of Slot Context to the Default state

When doing a block device formatting test on Windows, this resolved a `ContextStateError`.